### PR TITLE
Identity XSL Stylesheet

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -61,13 +61,13 @@ Data type: xs:NOTATION|no|
 Functions|no|
 Map|no|
 Array|no|
-Document node|yes|roxmltree|\
-Element node|yes|roxmltree, json
-Attribute node|no|
+Document node|yes||\
+Element node|yes|
+Attribute node|yes|
 Namespace node|no|
-PI node|yes|roxmltree
-Comment node|yes|roxmltree
-Text node|yes|roxmltree, json
+PI node|yes|
+Comment node|yes|
+Text node|yes|
 Accessor|no|
 
 ## XPath
@@ -88,8 +88,8 @@ Path expression: steps|yes|
 Path expression: axes|partial|
 Axis: child|yes|
 Axis: self|yes|
-Axis: descendant|yes|roxmltree
-Axis: descendant-or-self|yes|roxmltree
+Axis: descendant|yes|
+Axis: descendant-or-self|yes|
 Axis: ancestor|yes|
 Axis: ancestor-or-self|yes|
 Axis: parent|yes|

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -336,7 +336,7 @@ xsl:mode|no|
 xsl:mode/@name|no|
 xsl:mode/@streamable|no|
 xsl:mode/@use-accumulators|no|
-xsl:mode/@on-no-match|no|
+xsl:mode/@on-no-match|partial|text-only-copy is the default
 xsl:mode/@on-multiple-match|no|
 xsl:mode/@warning-on-no-match|no|
 xsl:mode/@warning-on-multiple-match|no|

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -126,6 +126,7 @@ Simple map operator: !|no|
 Arrow operator: =>|no|
 Unary expression|no|
 Comments|yes|
+Union|no|
 
 ## XPath Functions
 
@@ -216,7 +217,7 @@ xsl:comment/@select|no|
 xsl:context-item|no|
 xsl:context-item/@as|no|
 xsl:context-item/@use|no|
-xsl:copy|no|
+xsl:copy|yes|
 xsl:copy/@select|no|
 xsl:copy/@copy-namespaces|no|
 xsl:copy/@inherit-namespaces|no|

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -490,7 +490,7 @@ xsl:stylesheet/@xpath-default-namespace|no|
 xsl:template|yes|
 xsl:template/@match|yes|
 xsl:template/@name|no|
-xsl:template/@priority|no|
+xsl:template/@priority|yes|
 xsl:template/@mode|no|
 xsl:template/@as|no|
 xsl:template/@visibility|no|

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -97,7 +97,7 @@ Axis: following|yes|
 Axis: following-sibling|yes|
 Axis: preceding|yes|
 Axis: preceding-sibling|yes|
-Axis: attribute|no|
+Axis: attribute|yes|
 Axis: namespace|no|
 Path expression: Node tests|yes|
 Path expression: Predicates within steps|yes|

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -500,7 +500,8 @@ fn evaluate_one(
 	        Ok(vec![Rc::clone(&ctxt.unwrap()[posn.unwrap()])])
 	      }
 	      Axis::Parent |
-	      Axis::Selfaxis => Ok(vec![]),
+	      Axis::Selfaxis |
+	      Axis::Attribute => Ok(vec![]),
 	      _ => {
 	        // Not yet implemented
 		Result::Err(Error{kind: ErrorKind::NotImplemented, message: "not yet implemented (document)".to_string()})
@@ -656,6 +657,13 @@ fn evaluate_one(
 		  .filter(|e| is_node_match(&nm.nodetest, &e))
 		  .fold(Sequence::new(), |mut f, g| {f.new_node(Rc::clone(g)); f});
 	      	Ok(predicates(dc, seq, p))
+	      }
+	      Axis::Attribute => {
+		let attrs = n.attributes().iter()
+		  .inspect(|a| println!("processing attr {}", a.to_name().get_localname()))
+		  .filter(|c| is_node_match(&nm.nodetest, &c))
+		  .fold(Sequence::new(), |mut c, a| {c.new_node(Rc::clone(a)); c});
+		Ok(predicates(dc, attrs, p))
 	      }
 	      Axis::SelfDocument => Ok(vec![]),
 	      _ => {
@@ -1102,7 +1110,8 @@ fn is_node_match(nt: &NodeTest, n: &Rc<dyn Node>) -> bool {
   match nt {
     NodeTest::Name(t) => {
       match n.node_type() {
-        NodeType::Element => {
+        NodeType::Element |
+	NodeType::Attribute => {
       	  // TODO: namespaces
       	  match &t.name {
             Some(a) => {

--- a/src/item.rs
+++ b/src/item.rs
@@ -441,6 +441,7 @@ pub trait Node: Any {
   /// Add a text node as a child.
   fn append_text_child(&self, t: Value) -> Result<(), Error>;
   // TODO: insert_before, replace_child
+  fn add_attribute_node(&self, a: &dyn Any) -> Result<(), Error>;
 
   /// Remove a node from its parent
   fn remove(&self) -> Result<(), Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ We need your help!
 pub mod xdmerror;
 pub use xdmerror::{Error, ErrorKind};
 
+pub mod qname;
+
 pub mod item;
 pub use item::{Sequence, SequenceTrait, Item, Value, Document, Node};
 

--- a/src/parsexml.rs
+++ b/src/parsexml.rs
@@ -19,6 +19,7 @@ use nom:: {
   bytes::complete::{tag, take_until},
   sequence::delimited,
 };
+use crate::qname::*;
 use crate::item::*;
 use crate::parsecommon::*;
 use crate::xdmerror::*;

--- a/src/qname.rs
+++ b/src/qname.rs
@@ -1,0 +1,111 @@
+//! # xrust::qname
+//!
+//! Support for Qualified Names.
+
+use core::hash::{Hash, Hasher};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug)]
+pub struct QualifiedName {
+  nsuri: Option<String>,
+  prefix: Option<String>,
+  localname: String,
+}
+
+// TODO: we may need methods that return a string slice, rather than a copy of the string
+impl QualifiedName {
+  pub fn new(nsuri: Option<String>, prefix: Option<String>, localname: String) -> QualifiedName {
+    QualifiedName{nsuri, prefix, localname}
+  }
+  pub fn get_nsuri(&self) -> Option<String> {
+    self.nsuri.clone()
+  }
+  pub fn get_nsuri_ref(&self) -> Option<&str> {
+    match self.nsuri {
+      Some(ref n) => {
+        Some(&n)
+      }
+      None => None,
+    }
+  }
+  pub fn get_prefix(&self) -> Option<String> {
+    self.prefix.clone()
+  }
+  pub fn get_localname(&self) -> String {
+    self.localname.clone()
+  }
+  pub fn to_string(&self) -> String {
+    let mut result = String::new();
+    self.prefix.as_ref().map_or((), |p| {
+      result.push_str(p.as_str());
+      result.push(':');
+    });
+    result.push_str(self.localname.as_str());
+    result
+  }
+}
+
+pub type QHash<T> = HashMap<QualifiedName, T>;
+
+impl PartialEq for QualifiedName {
+  // Only the namespace URI and local name have to match
+  fn eq(&self, other: &QualifiedName) -> bool {
+    self.nsuri.as_ref().map_or_else(
+      || {
+        other.nsuri.as_ref().map_or_else(
+	  || self.localname.eq(other.localname.as_str()),
+	  |_| false,
+	)
+      },
+      |ns| {
+        other.nsuri.as_ref().map_or_else(
+	  || false,
+	  |ons| {ns.eq(ons.as_str()) && self.localname.eq(other.localname.as_str())}
+	)
+      }
+    )
+  }
+}
+impl Eq for QualifiedName {}
+
+impl Hash for QualifiedName {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.nsuri.as_ref().map(|ns| ns.hash(state));
+    self.localname.hash(state);
+  }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unqualified() {
+      assert_eq!(QualifiedName::new(None, None, "foo".to_string()).to_string(), "foo")
+    }
+    #[test]
+    fn qualified() {
+      assert_eq!(QualifiedName::new(Some("http://example.org/whatsinaname/".to_string()), Some("x".to_string()), "foo".to_string()).to_string(), "x:foo")
+    }
+    #[test]
+    fn hashmap() {
+      let mut h = QHash::<String>::new();
+      h.insert(QualifiedName::new(None, None, "foo".to_string()), String::from("this is unprefixed foo"));
+      h.insert(QualifiedName::new(Some("http://example.org/whatsinaname/".to_string()), Some("x".to_string()), "foo".to_string()), "this is x:foo".to_string());
+      h.insert(QualifiedName::new(Some("http://example.org/whatsinaname/".to_string()), Some("y".to_string()), "bar".to_string()), "this is y:bar".to_string());
+
+      assert_eq!(h.len(), 3);
+      assert_eq!(
+        h.get(&QualifiedName{
+          nsuri: Some("http://example.org/whatsinaname/".to_string()),
+	  prefix: Some("x".to_string()),
+	  localname: "foo".to_string()
+        }),
+	Some(&"this is x:foo".to_string())
+      );
+      assert_eq!(h.get(&QualifiedName{
+        nsuri: None,
+	prefix: None,
+	localname: "foo".to_string()
+      }), Some(&"this is unprefixed foo".to_string()));
+    }
+}


### PR DESCRIPTION
This Pull Request achieves the objective of being able to run the identity XSL stylesheet (see Wiki). Basically, this is a stylesheet that copies it's input to the result document.

Although it is one of the simplest stylesheets, being able to run it has required the introduction of several features:

* Built-in templates
* Template priorities
* xsl:copy
* Support for attribute nodes

This release will also align certain method names with W3C DOM.

