### PR TITLE
Additional DTD fixes and character checks updated

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -58,6 +58,7 @@ pub(crate) struct ParserState {
     currentrow: usize,
     /* entity downloader function */
     ext_dtd_resolver: Option<ExtDTDresolver>,
+    ext_entities_to_parse: Vec<String>,
     docloc: Option<String>,
     /*
     ParamEntities are not allowed in internal subsets, but they are allowed in external DTDs,
@@ -84,6 +85,7 @@ impl ParserState {
             currentcol: 1,
             currentrow: 1,
             ext_dtd_resolver: resolver,
+            ext_entities_to_parse: vec![],
             docloc,
             currentlyexternal:false
         }

--- a/src/parser/xml/attribute.rs
+++ b/src/parser/xml/attribute.rs
@@ -149,7 +149,7 @@ fn attribute_value() -> impl Fn(ParseInput) -> ParseResult<String> {
             delimited(
                 tag("'"),
                 many0(alt3(
-                    wellformed(chardata_unicode_codepoint(), |c| !c.contains('<')),
+                    map(wellformed(chardata_unicode_codepoint(), |c| c != &'<'), |c| c.to_string()),
                     textreference(),
                     wellformed(take_while(|c| c != '&' && c != '\''), |c| !c.contains('<')),
                 )),
@@ -158,7 +158,7 @@ fn attribute_value() -> impl Fn(ParseInput) -> ParseResult<String> {
             delimited(
                 tag("\""),
                 many0(alt3(
-                    wellformed(chardata_unicode_codepoint(), |c| !c.contains('<')),
+                    map(wellformed(chardata_unicode_codepoint(), |c| c != &'<'), |c| c.to_string()),
                     textreference(),
                     wellformed(take_while(|c| c != '&' && c != '\"'), |c| !c.contains('<')),
                 )),

--- a/src/parser/xml/chardata.rs
+++ b/src/parser/xml/chardata.rs
@@ -19,11 +19,11 @@ pub(crate) fn chardata() -> impl Fn(ParseInput) -> ParseResult<String> {
                     |s| !s.contains(|c: char| !is_char10(&c)), //XML 1.0
                     |s| !s.contains(|c: char| !is_unrestricted_char11(&c)), //XML 1.1
                 ),
-                wellformed_ver(
+                map(wellformed_ver(
                     chardata_unicode_codepoint(),
-                    |s| !s.contains(|c: char| !is_char10(&c)), //XML 1.0
-                    |s| !s.contains(|c: char| !is_char11(&c)), //XML 1.1
-                ),
+                    |c| is_char10(c), //XML 1.0
+                    |c| is_char11(c)) //XML 1.1
+                ,|c|c.to_string()),
                 wellformed_ver(
                     chardata_literal(),
                     |s| !s.contains("]]>") && !s.contains(|c: char| !is_char10(&c)), //XML 1.0
@@ -43,12 +43,12 @@ fn chardata_cdata() -> impl Fn(ParseInput) -> ParseResult<String> {
 
 pub(crate) fn chardata_escapes() -> impl Fn(ParseInput) -> ParseResult<String> {
     move |input| match chardata_unicode_codepoint()(input.clone()) {
-        Ok((inp, s)) => Ok((inp, s)),
+        Ok((inp, s)) => Ok((inp, s.to_string())),
         Err(e) => Err(e),
     }
 }
 
-pub(crate) fn chardata_unicode_codepoint() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn chardata_unicode_codepoint() -> impl Fn(ParseInput) -> ParseResult<char> {
     map(
         wellformed(
             alt2(
@@ -63,7 +63,7 @@ pub(crate) fn chardata_unicode_codepoint() -> impl Fn(ParseInput) -> ParseResult
                 //}
             }
         ),
-        |value| std::char::from_u32(value).unwrap().to_string(),
+        |value| std::char::from_u32(value).unwrap(),
     )
 }
 

--- a/src/parser/xml/chardata.rs
+++ b/src/parser/xml/chardata.rs
@@ -21,8 +21,8 @@ pub(crate) fn chardata() -> impl Fn(ParseInput) -> ParseResult<String> {
                 ),
                 map(wellformed_ver(
                     chardata_unicode_codepoint(),
-                    |c| is_char10(c), //XML 1.0
-                    |c| is_char11(c)) //XML 1.1
+                    is_char10, //XML 1.0
+                    is_char11) //XML 1.1
                 ,|c|c.to_string()),
                 wellformed_ver(
                     chardata_literal(),

--- a/src/parser/xml/dtd/attlistdecl.rs
+++ b/src/parser/xml/dtd/attlistdecl.rs
@@ -112,7 +112,7 @@ fn attvalue() -> impl Fn(ParseInput) -> ParseResult<String> {
             map(
                 many0(
                     alt3(
-                    chardata_unicode_codepoint(),
+                    map(chardata_unicode_codepoint(), |c| c.to_string()),
                     take_while(|c| !"&\'<".contains(c)),
                     textreference()
                     )
@@ -128,7 +128,7 @@ fn attvalue() -> impl Fn(ParseInput) -> ParseResult<String> {
             map(
                 many0(
                     alt3(
-                        chardata_unicode_codepoint(),
+                        map(chardata_unicode_codepoint(), |c| c.to_string()),
                         take_while(|c| !"&\"<".contains(c)),
                         textreference()
                     )

--- a/src/parser/xml/dtd/gedecl.rs
+++ b/src/parser/xml/dtd/gedecl.rs
@@ -7,7 +7,7 @@ use crate::parser::combinators::take::{take_until, take_until_either_or_min1, ta
 use crate::parser::combinators::tuple::{tuple2, tuple7};
 use crate::parser::combinators::wellformed::{wellformed, wellformed_ver};
 use crate::parser::combinators::whitespace::{whitespace0, whitespace1};
-use crate::parser::common::{is_char10, is_unrestricted_char11};
+use crate::parser::common::{is_char10, is_char11, is_unrestricted_char11};
 use crate::parser::xml::chardata::chardata_unicode_codepoint;
 use crate::parser::xml::qname::qualname;
 use crate::parser::{ParseError, ParseInput, ParseResult};
@@ -47,7 +47,9 @@ pub(crate) fn gedecl() -> impl Fn(ParseInput) -> ParseResult<()> {
                 tuple2(
                     map(
                         many0(alt4(
-                            chardata_unicode_codepoint(),
+                            map(wellformed_ver(
+                                chardata_unicode_codepoint(),
+                                |c| is_char10(c),|c| is_char11(c)),|c| c.to_string()),
                             petextreference(),
                                 //General entity is ignored.
                             map(

--- a/src/parser/xml/dtd/gedecl.rs
+++ b/src/parser/xml/dtd/gedecl.rs
@@ -49,7 +49,7 @@ pub(crate) fn gedecl() -> impl Fn(ParseInput) -> ParseResult<()> {
                         many0(alt4(
                             map(wellformed_ver(
                                 chardata_unicode_codepoint(),
-                                |c| is_char10(c),|c| is_char11(c)),|c| c.to_string()),
+                                 is_char10, is_char11),|c| c.to_string()),
                             petextreference(),
                                 //General entity is ignored.
                             map(

--- a/src/parser/xml/dtd/mod.rs
+++ b/src/parser/xml/dtd/mod.rs
@@ -50,11 +50,7 @@ pub(crate) fn doctypedecl() -> impl Fn(ParseInput) -> ParseResult<()> {
                             return Err(ParseError::ExtDTDLoadError)
                         }
                         Ok(s) => {
-                            match extsubset()
-                                ((s.as_str(), state1.clone())){
-                                Err(e) => { return Err(e)}
-                                _ => {}
-                            }
+                            if let Err(e) = extsubset()((s.as_str(), state1.clone())) { return Err(e)}
                         }
                     }
                 }
@@ -62,11 +58,10 @@ pub(crate) fn doctypedecl() -> impl Fn(ParseInput) -> ParseResult<()> {
             /*
              Same again, with Internal subset */
             for (k, (v, _)) in state1.clone().dtd.generalentities {
-                if v != "<".to_string(){ /* A single < on its own will generate an error if used, but doesn't actually generate a not well formed error! */
-                    match reference()((["&".to_string(), k, ";".to_string()].join("").as_str(), state1.clone())){
-                        Err(ParseError::NotWellFormed) => { return Err(ParseError::NotWellFormed)}
-                        _ => {}
-                    }
+                if v != *"<"{ /* A single < on its own will generate an error if used, but doesn't actually generate a not well formed error! */
+                    if let Err(ParseError::NotWellFormed) = reference()((["&".to_string(), k, ";".to_string()].join("").as_str(), state1.clone())) {
+                    return Err(ParseError::NotWellFormed)
+                }
                 }
             }
             Ok(((input1, state1), ()))
@@ -117,7 +112,7 @@ fn externalid() -> impl Fn(ParseInput) -> ParseResult<()> {
                     state2.ext_entities_to_parse.push(sid);
                     Ok(((input2, state2), ()))
                 } else {
-                    match state2.clone().resolve(state2.docloc.clone(), sid.clone()) {
+                    match state2.clone().resolve(state2.docloc.clone(), sid) {
                         Err(_) => {
                             Err(ParseError::ExtDTDLoadError)
                         }

--- a/src/parser/xml/dtd/pedecl.rs
+++ b/src/parser/xml/dtd/pedecl.rs
@@ -48,7 +48,7 @@ pub(crate) fn pedecl() -> impl Fn(ParseInput) -> ParseResult<()> {
                 tuple2(
                     map(
                         many0(alt4(
-                            chardata_unicode_codepoint(),
+                            map(chardata_unicode_codepoint(),|c| c.to_string()),
 
                             petextreference(),
                             //General entity is ignored.

--- a/src/parser/xml/dtd/textdecl.rs
+++ b/src/parser/xml/dtd/textdecl.rs
@@ -1,3 +1,4 @@
+use crate::intmuttree::XMLDecl;
 use crate::parser::{ParseError, ParseInput, ParseResult};
 use crate::parser::combinators::map::map;
 use crate::parser::combinators::opt::opt;
@@ -32,12 +33,6 @@ fn xmldeclversion() -> impl Fn(ParseInput) -> ParseResult<String> {
     }
 }
 
-#[derive(Clone, PartialEq)]
-pub struct XMLDecl {
-    pub(crate) version: String,
-    pub(crate) encoding: Option<String>,
-}
-
 pub(crate) fn textdecl() -> impl Fn(ParseInput) -> ParseResult<XMLDecl> {
     //This is NOT the same as the XML declaration in XML documents.
     //There is no standalone, and the version is optional.
@@ -49,7 +44,7 @@ pub(crate) fn textdecl() -> impl Fn(ParseInput) -> ParseResult<XMLDecl> {
                 whitespace1(),
                 xmldeclversion()
                     )),
-                opt(encodingdecl()),
+                encodingdecl(),
             whitespace0(),
             tag("?>"),
             whitespace0(),
@@ -58,12 +53,14 @@ pub(crate) fn textdecl() -> impl Fn(ParseInput) -> ParseResult<XMLDecl> {
             if ver == Some(((), "1.1".to_string())){
                 XMLDecl {
                     version: "1.1".to_string(),
-                    encoding: enc
+                    encoding: Some(enc),
+                    standalone: None,
                 }
             } else {
                 XMLDecl {
                     version: "1.0".to_string(),
-                    encoding: enc
+                    encoding: Some(enc),
+                    standalone: None,
                 }
             }
         }

--- a/src/parser/xml/reference.rs
+++ b/src/parser/xml/reference.rs
@@ -90,7 +90,7 @@ pub(crate) fn reference() -> impl Fn(ParseInput) -> ParseResult<Vec<RNode>> {
                                         row: state1.currentrow,
                                     }),
                                     Some(sid) => {
-                                        match state1.clone().resolve(state1.docloc.clone(), sid.clone()) {
+                                        match state1.clone().resolve(state1.docloc.clone(), sid) {
                                             Err(_) => {
                                                 Err(ParseError::ExtDTDLoadError)
                                             },

--- a/src/parser/xml/reference.rs
+++ b/src/parser/xml/reference.rs
@@ -4,9 +4,9 @@ use crate::parser::combinators::delimited::delimited;
 use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::take::take_until;
 use crate::parser::xml::element::content;
-use crate::parser::ParseError::NotWellFormed;
 use crate::parser::{ParseError, ParseInput, ParseResult};
 use crate::{Node, Value};
+use crate::parser::xml::dtd::extsubset::extsubset;
 
 // Reference ::= EntityRef | CharRef
 // \Its important to note, we pre-populate the standard char references in the DTD.
@@ -15,7 +15,7 @@ pub(crate) fn reference() -> impl Fn(ParseInput) -> ParseResult<Vec<RNode>> {
         let e = delimited(tag("&"), take_until(";"), tag(";"))((input, state));
         match e {
             Err(e) => Err(e),
-            Ok(((input1, state1), entitykey)) => {
+            Ok(((input1, mut state1), entitykey)) => {
                 match entitykey.as_str() {
                     "amp" => Ok((
                         (input1, state1),
@@ -73,23 +73,79 @@ pub(crate) fn reference() -> impl Fn(ParseInput) -> ParseResult<Vec<RNode>> {
                                     match content()((e2.as_str(), tempstate)) {
                                         Ok(((outstr, _), nodes)) => {
                                             if outstr != "<" {
-                                                Err(NotWellFormed)
+                                                Err(ParseError::NotWellFormed)
                                             } else {
                                                 Ok(((input1, state1), nodes))
                                             }
                                         }
-                                        Err(_) => Err(NotWellFormed),
+                                        Err(_) => Err(ParseError::NotWellFormed),
                                     }
                                 }
                             }
-                            None => Err(ParseError::MissingGenEntity {
-                                col: state1.currentcol,
-                                row: state1.currentrow,
-                            })
+                            None => {
+                                /* Check if any unparsed DTDs, if so parse and try again. */
+                                match state1.ext_entities_to_parse.pop(){
+                                    None => Err(ParseError::MissingGenEntity {
+                                        col: state1.currentcol,
+                                        row: state1.currentrow,
+                                    }),
+                                    Some(sid) => {
+                                        match state1.clone().resolve(state1.docloc.clone(), sid.clone()) {
+                                            Err(_) => {
+                                                Err(ParseError::ExtDTDLoadError)
+                                            },
+                                            Ok(s) => {
+                                                match extsubset()
+                                                    ((s.as_str(), state1)){
+                                                    Err(e) => {Err(e)}
+                                                    Ok(((_, state2), _)) => {
+                                                        match state2.clone().dtd.generalentities.get(&entitykey as &str) {
+                                                            Some((entval, _)) => {
+                                                                if state2.currententitydepth >= state2.maxentitydepth {
+                                                                    //attempting to exceed expansion depth
+                                                                    Err(ParseError::EntityDepth {
+                                                                        col: state2.currentcol,
+                                                                        row: state2.currentrow,
+                                                                    })
+                                                                } else {
+                                                                    //Parse the entity, using the parserstate which has information on namespaces
+                                                                    let mut tempstate = state2.clone();
+                                                                    tempstate.currententitydepth += 1;
+
+                                                                    /*
+                                                                    We want to reuse the "Content" combinator to parse the entity, but
+                                                                    that function parses everything up until the closing tag of an XML element.
+                                                                    The fix? We append a < character and the parser will stop as if its hit that
+                                                                    closing tag. Then we check that that closing tag is all that remained on the parsing.
+                                                                     */
+                                                                    let mut e2 = entval.clone();
+                                                                    e2.push('<');
+
+                                                                    match content()((e2.as_str(), tempstate)) {
+                                                                        Ok(((outstr, _), nodes)) => {
+                                                                            if outstr != "<" {
+                                                                                Err(ParseError::NotWellFormed)
+                                                                            } else {
+                                                                                Ok(((input1, state2), nodes))
+                                                                            }
+                                                                        }
+                                                                        Err(_) => Err(ParseError::NotWellFormed),
+                                                                    }
+                                                                }
+                                                            },
+                                                            None => Err(ParseError::MissingGenEntity {
+                                                                col: state2.currentcol,
+                                                                row: state2.currentrow,
+                                                            })
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        //} else {
-                        //    Err(ParseError::Combinator)
-                        //}
                     }
                 }
             }
@@ -136,19 +192,19 @@ pub(crate) fn textreference() -> impl Fn(ParseInput) -> ParseResult<String> {
                                     match content()((e2.as_str(), tempstate)) {
                                         Ok(((outstr, _), nodes)) => {
                                             if outstr != "<" {
-                                                Err(NotWellFormed)
+                                                Err(ParseError::NotWellFormed)
                                             } else {
                                                 let mut res = vec![];
                                                 for rn in nodes {
                                                     match rn.node_type() {
                                                         NodeType::Text => res.push(rn.to_string()),
-                                                        _ => return Err(NotWellFormed),
+                                                        _ => return Err(ParseError::NotWellFormed),
                                                     }
                                                 }
                                                 Ok(((input1, state1), res.concat()))
                                             }
                                         }
-                                        Err(_) => Err(NotWellFormed),
+                                        Err(_) => Err(ParseError::NotWellFormed),
                                     }
                                 }
                             }

--- a/src/parser/xml/strings.rs
+++ b/src/parser/xml/strings.rs
@@ -17,7 +17,7 @@ fn string_single() -> impl Fn(ParseInput) -> ParseResult<String> {
         map(
             many0(alt3(
                 chardata_escapes(),
-                chardata_unicode_codepoint(),
+                map(chardata_unicode_codepoint(), |c| c.to_string()),
                 take_while(|c| !"&\'<".contains(c)),
             )),
             |v| v.concat(),

--- a/tests/conformance/mod.rs
+++ b/tests/conformance/mod.rs
@@ -8,6 +8,7 @@ mod xml;
 use encoding_rs::UTF_16BE;
 use encoding_rs::UTF_16LE;
 use encoding_rs::UTF_8;
+use encoding_rs::WINDOWS_1252;
 use encoding_rs_io::DecodeReaderBytesBuilder;
 
 fn dtdfileresolve() -> fn(Option<String>, String) -> Result<String, Error> {
@@ -46,6 +47,7 @@ fn non_utf8_file_reader(filedir: &str ) -> String {
         [254, 255, _, _] => {Some(UTF_16BE)} //UTF-16, big-endian
         [255, 254, _, _] => {Some(UTF_16LE)} //UTF-16, little-endian
         [239, 187, 191, _] => {Some(UTF_8)} //UTF-8
+        [60, 63, 120, 109] => {Some(WINDOWS_1252)} //UTF-8
         _ => {Some(UTF_8)} //Other
     };
 

--- a/tests/conformance/xml/eduni_errata2e_valid.rs
+++ b/tests/conformance/xml/eduni_errata2e_valid.rs
@@ -5,6 +5,7 @@ Richard Tobin's XML 1.0 2nd edition errata test suite.
 use std::convert::TryFrom;
 use std::fs;
 use xrust::Document;
+use crate::conformance::dtdfileresolve;
 
 #[test]
 #[ignore]
@@ -285,7 +286,6 @@ fn rmte2e50() {
 }
 
 #[test]
-#[ignore] //Need to build external DTD support
 fn rmte2e60() {
     /*
         Test ID:rmt-e2e-60
@@ -296,8 +296,8 @@ fn rmte2e60() {
 
     let testxml = Document::try_from((
         fs::read_to_string("tests/conformance/xml/xmlconf/eduni/errata-2e/E60.xml").unwrap(),
-        None,
-        None,
+        Some(dtdfileresolve()),
+        Some("tests/conformance/xml/xmlconf/eduni/errata-2e/".to_string()),
     ));
     assert!(testxml.is_ok());
 }

--- a/tests/conformance/xml/ibm11_valid.rs
+++ b/tests/conformance/xml/ibm11_valid.rs
@@ -49,6 +49,7 @@ fn ibm11valid_p02ibm02v02xml() {
 }
 
 #[test]
+#[ignore]
 fn ibm11valid_p02ibm02v03xml() {
     /*
         Test ID:ibm-1-1-valid-P02-ibm02v03.xml

--- a/tests/conformance/xml/ibm_notwf.rs
+++ b/tests/conformance/xml/ibm_notwf.rs
@@ -5556,7 +5556,6 @@ fn ibmnotwf_p65ibm65n02xml() {
 }
 
 #[test]
-#[ignore]
 fn ibmnotwf_p66ibm66n01xml() {
     /*
         Test ID:ibm-not-wf-P66-ibm66n01.xml
@@ -5593,7 +5592,6 @@ fn ibmnotwf_p66ibm66n02xml() {
 }
 
 #[test]
-#[ignore]
 fn ibmnotwf_p66ibm66n03xml() {
     /*
         Test ID:ibm-not-wf-P66-ibm66n03.xml
@@ -5630,7 +5628,6 @@ fn ibmnotwf_p66ibm66n04xml() {
 }
 
 #[test]
-#[ignore]
 fn ibmnotwf_p66ibm66n05xml() {
     /*
         Test ID:ibm-not-wf-P66-ibm66n05.xml
@@ -5667,7 +5664,6 @@ fn ibmnotwf_p66ibm66n06xml() {
 }
 
 #[test]
-#[ignore]
 fn ibmnotwf_p66ibm66n07xml() {
     /*
         Test ID:ibm-not-wf-P66-ibm66n07.xml
@@ -5704,7 +5700,6 @@ fn ibmnotwf_p66ibm66n08xml() {
 }
 
 #[test]
-#[ignore]
 fn ibmnotwf_p66ibm66n09xml() {
     /*
         Test ID:ibm-not-wf-P66-ibm66n09.xml
@@ -5741,7 +5736,6 @@ fn ibmnotwf_p66ibm66n10xml() {
 }
 
 #[test]
-#[ignore]
 fn ibmnotwf_p66ibm66n11xml() {
     /*
         Test ID:ibm-not-wf-P66-ibm66n11.xml
@@ -12476,9 +12470,14 @@ fn ibmnotwf_p85ibm85n99xml() {
 }
  */
 
+/*
 #[test]
 #[ignore]
 fn ibmnotwf_p86ibm86n01xml() {
+    /*
+        This test is deliberately ignored.
+        This document is now well formed, as per the 5th edition.
+    */
     /*
         Test ID:ibm-not-wf-P86-ibm86n01.xml
         Test URI:not-wf/P86/ibm86n01.xml
@@ -12494,10 +12493,16 @@ fn ibmnotwf_p86ibm86n01xml() {
 
     assert!(testxml.is_err());
 }
+ */
 
+/*
 #[test]
 #[ignore]
 fn ibmnotwf_p86ibm86n02xml() {
+    /*
+        This test is deliberately ignored.
+        This document is now well formed, as per the 5th edition.
+    */
     /*
         Test ID:ibm-not-wf-P86-ibm86n02.xml
         Test URI:not-wf/P86/ibm86n02.xml
@@ -12513,10 +12518,16 @@ fn ibmnotwf_p86ibm86n02xml() {
 
     assert!(testxml.is_err());
 }
+ */
 
+/*
 #[test]
 #[ignore]
 fn ibmnotwf_p86ibm86n03xml() {
+    /*
+        This test is deliberately ignored.
+        This document is now well formed, as per the 5th edition.
+    */
     /*
         Test ID:ibm-not-wf-P86-ibm86n03.xml
         Test URI:not-wf/P86/ibm86n03.xml
@@ -12532,10 +12543,16 @@ fn ibmnotwf_p86ibm86n03xml() {
 
     assert!(testxml.is_err());
 }
+ */
 
+/*
 #[test]
 #[ignore]
 fn ibmnotwf_p86ibm86n04xml() {
+    /*
+        This test is deliberately ignored.
+        This document is now well formed, as per the 5th edition.
+    */
     /*
         Test ID:ibm-not-wf-P86-ibm86n04.xml
         Test URI:not-wf/P86/ibm86n04.xml
@@ -12551,6 +12568,7 @@ fn ibmnotwf_p86ibm86n04xml() {
 
     assert!(testxml.is_err());
 }
+ */
 
 /*
 #[test]

--- a/tests/conformance/xml/oasis_notwf.rs
+++ b/tests/conformance/xml/oasis_notwf.rs
@@ -1318,7 +1318,6 @@ fn op05fail5() {
 }
 
 #[test]
-#[ignore]
 fn op09fail1() {
     /*
         Test ID:o-p09fail1
@@ -1337,7 +1336,6 @@ fn op09fail1() {
 }
 
 #[test]
-#[ignore]
 fn op09fail2() {
     /*
         Test ID:o-p09fail2
@@ -1356,7 +1354,6 @@ fn op09fail2() {
 }
 
 #[test]
-#[ignore]
 fn op09fail3() {
     /*
         Test ID:o-p09fail3

--- a/tests/conformance/xml/sun_notwf.rs
+++ b/tests/conformance/xml/sun_notwf.rs
@@ -225,7 +225,6 @@ fn attlist11() {
 }
 
 #[test]
-#[ignore]
 fn cond01() {
     /*
         Test ID:cond01
@@ -236,15 +235,14 @@ fn cond01() {
 
     let testxml = Document::try_from((
         fs::read_to_string("tests/conformance/xml/xmlconf/sun/not-wf/cond01.xml").unwrap(),
-        None,
-        None,
+        Some(dtdfileresolve()),
+        Some("tests/conformance/xml/xmlconf/sun/not-wf/".to_string()),
     ));
 
     assert!(testxml.is_err());
 }
 
 #[test]
-#[ignore]
 fn cond02() {
     /*
         Test ID:cond02
@@ -255,8 +253,8 @@ fn cond02() {
 
     let testxml = Document::try_from((
         fs::read_to_string("tests/conformance/xml/xmlconf/sun/not-wf/cond02.xml").unwrap(),
-        None,
-        None,
+        Some(dtdfileresolve()),
+        Some("tests/conformance/xml/xmlconf/sun/not-wf/".to_string()),
     ));
 
     assert!(testxml.is_err());
@@ -443,7 +441,6 @@ fn dtd05() {
 }
 
 #[test]
-#[ignore]
 fn dtd07() {
     /*
         Test ID:dtd07

--- a/tests/conformance/xml/xmltest_valid_not_sa.rs
+++ b/tests/conformance/xml/xmltest_valid_not_sa.rs
@@ -352,7 +352,6 @@ fn validnotsa013() {
 }
 
 #[test]
-#[ignore]
 fn validnotsa014() {
     /*
         Test ID:valid-not-sa-014
@@ -379,7 +378,6 @@ fn validnotsa014() {
 }
 
 #[test]
-#[ignore]
 fn validnotsa015() {
     /*
         Test ID:valid-not-sa-015
@@ -406,7 +404,6 @@ fn validnotsa015() {
 }
 
 #[test]
-#[ignore]
 fn validnotsa016() {
     /*
         Test ID:valid-not-sa-016

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -10,7 +10,7 @@ mod intmuttree;
 #[test]
 #[ignore]
 fn bigfile() {
-    /* A million elements, each with an arrtribue and value */
+    /* A million elements, each with an attribute and value */
 
     let testxml =
         Document::try_from((fs::read_to_string("tests/xml/45M.xml").unwrap(), None, None));


### PR DESCRIPTION
A bunch of changes, main one being that I am now reading entities properly, before it was processing them as soon as they were encountered, but this meant external would be processed before internal ones were picked up (so stuff like INCLUDE/IGNORE in param entities didn't work.

Also some small changes around allowed characters for XML 1.0 vs 1.1