### PR TITLE
Xmlparser refactor

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -16,6 +16,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::Formatter;
 use std::rc::Rc;
+use crate::xmldecl::XMLDecl;
 
 /// In XPath, the Sequence is the fundamental data structure.
 /// It is an ordered collection of [Item]s.
@@ -463,6 +464,10 @@ pub trait Node: Clone {
     fn shallow_copy(&self) -> Result<Self, Error>;
     /// Deep copy the node, i.e. the node itself and it's attributes and descendants. The resulting top-level node is unattached.
     fn deep_copy(&self) -> Result<Self, Error>;
-    /// Canonical XML representation of the node
+    /// Canonical XML representation of the node.
     fn get_canonical(&self) -> Result<Self, Error>;
+    /// Get the XML Declaration for the document.
+    fn xmldecl(&self) -> XMLDecl;
+    /// Set the XML Declaration for the document.
+    fn set_xmldecl(&mut self, d: XMLDecl) -> Result<(), Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub mod xdmerror;
 pub use xdmerror::{Error, ErrorKind};
 
 pub mod xmldecl;
+pub mod externals;
 pub mod output;
 mod parsepicture;
 pub mod qname;

--- a/src/parser/combinators/alt.rs
+++ b/src/parser/combinators/alt.rs
@@ -1,9 +1,10 @@
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::item::Node;
+use crate::parser::{ParseError, ParseInput};
 
-pub fn alt2<P1, P2, A>(parser1: P1, parser2: P2) -> impl Fn(ParseInput) -> ParseResult<A>
+pub fn alt2<P1, P2, A, N: Node>(parser1: P1, parser2: P2) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<A>,
-    P2: Fn(ParseInput) -> ParseResult<A>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
 {
     move |(input, state)| match parser1((input, state.clone())) {
         Ok(parse_result) => Ok(parse_result),
@@ -17,15 +18,15 @@ where
     }
 }
 
-pub fn alt3<P1, P2, P3, A>(
+pub fn alt3<P1, P2, P3, A, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
-) -> impl Fn(ParseInput) -> ParseResult<A>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<A>,
-    P2: Fn(ParseInput) -> ParseResult<A>,
-    P3: Fn(ParseInput) -> ParseResult<A>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
 {
     move |(input, state)| match parser1((input, state.clone())) {
         Ok(parse_result) => Ok(parse_result),
@@ -45,17 +46,17 @@ where
     }
 }
 
-pub fn alt4<P1, P2, P3, P4, A>(
+pub fn alt4<P1, P2, P3, P4, A, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
     parser4: P4,
-) -> impl Fn(ParseInput) -> ParseResult<A>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<A>,
-    P2: Fn(ParseInput) -> ParseResult<A>,
-    P3: Fn(ParseInput) -> ParseResult<A>,
-    P4: Fn(ParseInput) -> ParseResult<A>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
 {
     move |(input, state)| match parser1((input, state.clone())) {
         Ok(parse_result) => Ok(parse_result),
@@ -81,19 +82,19 @@ where
     }
 }
 
-pub(crate) fn alt5<P1, P2, P3, P4, P5, A>(
+pub(crate) fn alt5<P1, P2, P3, P4, P5, A, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
     parser4: P4,
     parser5: P5,
-) -> impl Fn(ParseInput) -> ParseResult<A>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<A>,
-    P2: Fn(ParseInput) -> ParseResult<A>,
-    P3: Fn(ParseInput) -> ParseResult<A>,
-    P4: Fn(ParseInput) -> ParseResult<A>,
-    P5: Fn(ParseInput) -> ParseResult<A>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
 {
     move |(input, state)| match parser1((input, state.clone())) {
         Ok(parse_result) => Ok(parse_result),
@@ -125,21 +126,21 @@ where
     }
 }
 
-pub(crate) fn alt6<P1, P2, P3, P4, P5, P6, A>(
+pub(crate) fn alt6<P1, P2, P3, P4, P5, P6, A, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
     parser4: P4,
     parser5: P5,
     parser6: P6,
-) -> impl Fn(ParseInput) -> ParseResult<A>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<A>,
-    P2: Fn(ParseInput) -> ParseResult<A>,
-    P3: Fn(ParseInput) -> ParseResult<A>,
-    P4: Fn(ParseInput) -> ParseResult<A>,
-    P5: Fn(ParseInput) -> ParseResult<A>,
-    P6: Fn(ParseInput) -> ParseResult<A>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P6: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
 {
     move |(input, state)| match parser1((input, state.clone())) {
         Ok(parse_result) => Ok(parse_result),
@@ -167,7 +168,7 @@ where
     }
 }
 
-pub(crate) fn alt7<P1, P2, P3, P4, P5, P6, P7, A>(
+pub(crate) fn alt7<P1, P2, P3, P4, P5, P6, P7, A, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
@@ -175,15 +176,15 @@ pub(crate) fn alt7<P1, P2, P3, P4, P5, P6, P7, A>(
     parser5: P5,
     parser6: P6,
     parser7: P7,
-) -> impl Fn(ParseInput) -> ParseResult<A>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<A>,
-    P2: Fn(ParseInput) -> ParseResult<A>,
-    P3: Fn(ParseInput) -> ParseResult<A>,
-    P4: Fn(ParseInput) -> ParseResult<A>,
-    P5: Fn(ParseInput) -> ParseResult<A>,
-    P6: Fn(ParseInput) -> ParseResult<A>,
-    P7: Fn(ParseInput) -> ParseResult<A>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P6: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P7: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
 {
     move |(input, state)| match parser1((input, state.clone())) {
         Ok(parse_result) => Ok(parse_result),
@@ -217,7 +218,7 @@ where
 
 /*
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn alt8<P1, P2, P3, P4, P5, P6, P7, P8, A>(
+pub(crate) fn alt8<P1, P2, P3, P4, P5, P6, P7, P8, A, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
@@ -226,16 +227,16 @@ pub(crate) fn alt8<P1, P2, P3, P4, P5, P6, P7, P8, A>(
     parser6: P6,
     parser7: P7,
     parser8: P8,
-) -> impl Fn(ParseInput) -> ParseResult<A>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<A>,
-    P2: Fn(ParseInput) -> ParseResult<A>,
-    P3: Fn(ParseInput) -> ParseResult<A>,
-    P4: Fn(ParseInput) -> ParseResult<A>,
-    P5: Fn(ParseInput) -> ParseResult<A>,
-    P6: Fn(ParseInput) -> ParseResult<A>,
-    P7: Fn(ParseInput) -> ParseResult<A>,
-    P8: Fn(ParseInput) -> ParseResult<A>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P6: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P7: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P8: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
 {
     move |(input, state)| match parser1((input, state.clone())) {
         Ok(parse_result) => Ok(parse_result),
@@ -273,7 +274,7 @@ where
  */
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn alt9<P1, P2, P3, P4, P5, P6, P7, P8, P9, A>(
+pub(crate) fn alt9<P1, P2, P3, P4, P5, P6, P7, P8, P9, A, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
@@ -283,17 +284,17 @@ pub(crate) fn alt9<P1, P2, P3, P4, P5, P6, P7, P8, P9, A>(
     parser7: P7,
     parser8: P8,
     parser9: P9,
-) -> impl Fn(ParseInput) -> ParseResult<A>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<A>,
-    P2: Fn(ParseInput) -> ParseResult<A>,
-    P3: Fn(ParseInput) -> ParseResult<A>,
-    P4: Fn(ParseInput) -> ParseResult<A>,
-    P5: Fn(ParseInput) -> ParseResult<A>,
-    P6: Fn(ParseInput) -> ParseResult<A>,
-    P7: Fn(ParseInput) -> ParseResult<A>,
-    P8: Fn(ParseInput) -> ParseResult<A>,
-    P9: Fn(ParseInput) -> ParseResult<A>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P6: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P7: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P8: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P9: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
 {
     move |(input, state)| match parser1((input, state.clone())) {
         Ok(parse_result) => Ok(parse_result),
@@ -338,7 +339,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn alt10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, A>(
+pub(crate) fn alt10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, A, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
@@ -349,18 +350,18 @@ pub(crate) fn alt10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, A>(
     parser8: P8,
     parser9: P9,
     parser10: P10,
-) -> impl Fn(ParseInput) -> ParseResult<A>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<A>,
-    P2: Fn(ParseInput) -> ParseResult<A>,
-    P3: Fn(ParseInput) -> ParseResult<A>,
-    P4: Fn(ParseInput) -> ParseResult<A>,
-    P5: Fn(ParseInput) -> ParseResult<A>,
-    P6: Fn(ParseInput) -> ParseResult<A>,
-    P7: Fn(ParseInput) -> ParseResult<A>,
-    P8: Fn(ParseInput) -> ParseResult<A>,
-    P9: Fn(ParseInput) -> ParseResult<A>,
-    P10: Fn(ParseInput) -> ParseResult<A>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P6: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P7: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P8: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P9: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P10: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
 {
     move |(input, state)| match parser1((input, state.clone())) {
         Ok(parse_result) => Ok(parse_result),
@@ -412,7 +413,7 @@ where
 
 /*
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn alt11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, A>(
+pub(crate) fn alt11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, A, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
@@ -424,19 +425,19 @@ pub(crate) fn alt11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, A>(
     parser9: P9,
     parser10: P10,
     parser11: P11
-) -> impl Fn(ParseInput) -> ParseResult<A>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
     where
-        P1: Fn(ParseInput) -> ParseResult<A>,
-        P2: Fn(ParseInput) -> ParseResult<A>,
-        P3: Fn(ParseInput) -> ParseResult<A>,
-        P4: Fn(ParseInput) -> ParseResult<A>,
-        P5: Fn(ParseInput) -> ParseResult<A>,
-        P6: Fn(ParseInput) -> ParseResult<A>,
-        P7: Fn(ParseInput) -> ParseResult<A>,
-        P8: Fn(ParseInput) -> ParseResult<A>,
-        P9: Fn(ParseInput) -> ParseResult<A>,
-        P10: Fn(ParseInput) -> ParseResult<A>,
-        P11: Fn(ParseInput) -> ParseResult<A>,
+        P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+        P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+        P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+        P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+        P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+        P6: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+        P7: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+        P8: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+        P9: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+        P10: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+        P11: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
 {
     move |(input, state)| match parser1((input, state.clone())) {
         Ok(parse_result) => Ok(parse_result),

--- a/src/parser/combinators/debug.rs
+++ b/src/parser/combinators/debug.rs
@@ -1,11 +1,12 @@
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::item::Node;
+use crate::parser::{ParseError, ParseInput};
 //use std::fmt::Debug;
 
 /// Emits a message to stderr from within the parser combinator. This can be useful for debugging.
 #[allow(dead_code)]
-pub fn inspect<'a, P1, A>(msg: &'a str, parser: P1) -> impl Fn(ParseInput) -> ParseResult<A> + '_
+pub fn inspect<'a, P1, A, N: Node>(msg: &'a str, parser: P1) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError> + '_
 where
-    P1: Fn(ParseInput) -> ParseResult<A> + 'a,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError> + 'a,
 {
     move |(input, state)| {
         eprintln!("inspect pre: {} - input: \"{}\"", msg, input);

--- a/src/parser/combinators/delimited.rs
+++ b/src/parser/combinators/delimited.rs
@@ -1,14 +1,15 @@
-use crate::parser::{ParseInput, ParseResult};
+use crate::item::Node;
+use crate::parser::{ParseError, ParseInput};
 
-pub(crate) fn delimited<P1, P2, P3, R1, R2, R3>(
+pub(crate) fn delimited<P1, P2, P3, R1, R2, R3, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
-) -> impl Fn(ParseInput) -> ParseResult<R2>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, R2), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
-    P2: Fn(ParseInput) -> ParseResult<R2>,
-    P3: Fn(ParseInput) -> ParseResult<R3>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R2), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R3), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, _)) => match parser2(input1) {
@@ -27,15 +28,16 @@ mod tests {
     use crate::parser::combinators::delimited::delimited;
     use crate::parser::combinators::tag::tag;
     use crate::parser::ParserState;
+    use crate::trees::nullo::Nullo;
 
     #[test]
     fn parser_delimited_test1() {
         let testdoc = "<doc>";
-        let teststate = ParserState::new(None, None);
+        let teststate: ParserState<Nullo> = ParserState::new(None, None, None);
         let parse_doc = delimited(tag("<"), tag("doc"), tag(">"));
 
         assert_eq!(
-            Ok((("", ParserState::new(None, None)), ())),
+            Ok((("", ParserState::new(None, None, None)), ())),
             parse_doc((testdoc, teststate))
         );
     }

--- a/src/parser/combinators/expander.rs
+++ b/src/parser/combinators/expander.rs
@@ -1,4 +1,6 @@
-use crate::intmuttree::DTDDecl;
+use std::string::ParseError;
+use crate::item::Node;
+use crate::xmldecl::DTDDecl;
 use crate::parser::combinators::delimited::delimited;
 use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::take::take_until;
@@ -8,7 +10,7 @@ pub(crate) fn geexpander(inp: RNode) -> RNode{
 
 }
 
-pub(crate) fn genentityexpander() -> impl Fn(ParseInput) -> ParseResult<String> + 'static {
+pub(crate) fn genentityexpander<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> + 'static {
     move |input| {
         let e = delimited(tag("&"), take_until(";"), tag(";"))(input);
 
@@ -45,7 +47,7 @@ pub(crate) fn genentityexpander() -> impl Fn(ParseInput) -> ParseResult<String> 
     }
 }
 
-pub(crate) fn paramentityexpander() -> impl Fn(ParseInput) -> ParseResult<String> + 'static {
+pub(crate) fn paramentityexpander<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> + 'static {
     move |input| {
         let e = delimited(tag("%"), take_until(";"), tag(";"))(input);
 

--- a/src/parser/combinators/list.rs
+++ b/src/parser/combinators/list.rs
@@ -1,9 +1,10 @@
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::item::Node;
+use crate::parser::{ParseError, ParseInput};
 
-pub fn separated_list0<P1, P2, R1>(sep: P1, f: P2) -> impl Fn(ParseInput) -> ParseResult<Vec<R1>>
+pub fn separated_list0<P1, P2, R1, N: Node>(sep: P1, f: P2) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, Vec<R1>), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<()>,
-    P2: Fn(ParseInput) -> ParseResult<R1>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
 {
     move |mut input| {
         let mut res = Vec::new();
@@ -45,13 +46,13 @@ where
     }
 }
 
-pub(crate) fn separated_list1<P1, P2, R1>(
+pub(crate) fn separated_list1<P1, P2, R1, N: Node>(
     sep: P1,
     f: P2,
-) -> impl Fn(ParseInput) -> ParseResult<Vec<R1>>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, Vec<R1>), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<()>,
-    P2: Fn(ParseInput) -> ParseResult<R1>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
 {
     move |mut input| {
         let mut res = Vec::new();
@@ -100,15 +101,16 @@ mod tests {
     use crate::parser::combinators::map::map;
     use crate::parser::combinators::tag::tag;
     use crate::parser::ParserState;
+    use crate::trees::nullo::Nullo;
 
     #[test]
     fn parser_separated_list0_test1() {
         let testdoc = "b";
-        let teststate = ParserState::new(None, None);
+        let teststate: ParserState<Nullo> = ParserState::new(None, None, None);
         let parse_doc = separated_list0(tag(","), map(tag("a"), |_| "a"));
 
         assert_eq!(
-            Ok((("b", ParserState::new(None, None)), vec![])),
+            Ok((("b", ParserState::new(None, None, None)), vec![])),
             parse_doc((testdoc, teststate))
         );
     }
@@ -116,11 +118,11 @@ mod tests {
     #[test]
     fn parser_separated_list0_test2() {
         let testdoc = "a";
-        let teststate = ParserState::new(None, None);
+        let teststate: ParserState<Nullo> = ParserState::new(None, None, None);
         let parse_doc = separated_list0(tag(","), map(tag("a"), |_| "a"));
 
         assert_eq!(
-            Ok((("", ParserState::new(None, None)), vec!["a"])),
+            Ok((("", ParserState::new(None, None, None)), vec!["a"])),
             parse_doc((testdoc, teststate))
         );
     }
@@ -128,7 +130,7 @@ mod tests {
     #[test]
     fn parser_separated_list0_test3() {
         let testdoc = "a,b,c,d";
-        let teststate = ParserState::new(None, None);
+        let teststate: ParserState<Nullo> = ParserState::new(None, None, None);
         let parse_doc = separated_list1(
             tag(","),
             alt4(
@@ -140,7 +142,7 @@ mod tests {
         );
 
         assert_eq!(
-            Ok((("", ParserState::new(None, None)), vec!["1", "2", "3", "4"])),
+            Ok((("", ParserState::new(None, None, None)), vec!["1", "2", "3", "4"])),
             parse_doc((testdoc, teststate))
         );
     }
@@ -148,11 +150,11 @@ mod tests {
     #[test]
     fn parser_separated_list1_test1() {
         let testdoc = "a";
-        let teststate = ParserState::new(None, None);
+        let teststate: ParserState<Nullo> = ParserState::new(None, None, None);
         let parse_doc = separated_list1(tag(","), map(tag("a"), |_| "a"));
 
         assert_eq!(
-            Ok((("", ParserState::new(None, None)), vec!["a"])),
+            Ok((("", ParserState::new(None, None, None)), vec!["a"])),
             parse_doc((testdoc, teststate))
         );
     }
@@ -160,7 +162,7 @@ mod tests {
     #[test]
     fn parser_separated_list1_test2() {
         let testdoc = "a,b,c,d";
-        let teststate = ParserState::new(None, None);
+        let teststate: ParserState<Nullo> = ParserState::new(None, None, None);
         let parse_doc = separated_list1(
             tag(","),
             alt4(
@@ -172,7 +174,7 @@ mod tests {
         );
 
         assert_eq!(
-            Ok((("", ParserState::new(None, None)), vec!["1", "2", "3", "4"])),
+            Ok((("", ParserState::new(None, None, None)), vec!["1", "2", "3", "4"])),
             parse_doc((testdoc, teststate))
         );
     }

--- a/src/parser/combinators/many.rs
+++ b/src/parser/combinators/many.rs
@@ -1,8 +1,9 @@
-use crate::parser::{ParseInput, ParseResult};
+use crate::item::Node;
+use crate::parser::{ParseError, ParseInput};
 
-pub fn many0<P, R>(parser: P) -> impl Fn(ParseInput) -> ParseResult<Vec<R>>
+pub fn many0<P, R, N: Node>(parser: P) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, Vec<R>), ParseError>
 where
-    P: Fn(ParseInput) -> ParseResult<R>,
+    P: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R), ParseError>,
 {
     //TODO ERROR IF ANY ERROR OTHER THAN COMBINATOR RETURNED.
     move |mut input| {
@@ -17,9 +18,9 @@ where
     }
 }
 
-pub fn many1<P, R>(parser: P) -> impl Fn(ParseInput) -> ParseResult<Vec<R>>
+pub fn many1<P, R, N: Node>(parser: P) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, Vec<R>), ParseError>
 where
-    P: Fn(ParseInput) -> ParseResult<R>,
+    P: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R), ParseError>,
 {
     //TODO ERROR IF ANY ERROR OTHER THAN COMBINATOR RETURNED.
     move |mut input| {

--- a/src/parser/combinators/map.rs
+++ b/src/parser/combinators/map.rs
@@ -1,9 +1,10 @@
-use crate::parser::{ParseInput, ParseResult};
+use crate::item::Node;
+use crate::parser::{ParseError, ParseInput};
 
-pub fn map<P, F, A, B>(parser: P, map_fn: F) -> impl Fn(ParseInput) -> ParseResult<B>
-//-> impl Fn(ParseInput)-> Result<(String, usize, B), usize>
+pub fn map<P, F, A, B, N: Node>(parser: P, map_fn: F) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, B), ParseError>
+//-> impl Fn(ParseInput<N>)-> Result<(String, usize, B), usize>
 where
-    P: Fn(ParseInput) -> ParseResult<A>,
+    P: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
     F: Fn(A) -> B,
 {
     move |input| match parser(input) {

--- a/src/parser/combinators/opt.rs
+++ b/src/parser/combinators/opt.rs
@@ -1,8 +1,9 @@
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::item::Node;
+use crate::parser::{ParseError, ParseInput};
 
-pub(crate) fn opt<P1, R1>(parser1: P1) -> impl Fn(ParseInput) -> ParseResult<Option<R1>>
+pub(crate) fn opt<P1, R1, N: Node>(parser1: P1) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, Option<R1>), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
 {
     move |input| match parser1(input.clone()) {
         Ok((input1, result1)) => Ok((input1, Some(result1))),
@@ -16,14 +17,15 @@ mod tests {
     use crate::parser::combinators::opt::opt;
     use crate::parser::combinators::tag::tag;
     use crate::parser::ParserState;
+    use crate::trees::nullo::Nullo;
 
     #[test]
     fn parser_opt_test1() {
         let testdoc = "<doc>";
-        let teststate = ParserState::new(None, None);
+        let teststate: ParserState<Nullo> = ParserState::new(None, None, None);
         let parse_doc = opt(tag("<"));
         assert_eq!(
-            Ok((("doc>", ParserState::new(None, None)), Some(()))),
+            Ok((("doc>", ParserState::new(None, None, None)), Some(()))),
             parse_doc((testdoc, teststate))
         );
     }
@@ -31,10 +33,10 @@ mod tests {
     #[test]
     fn parser_opt_test2() {
         let testdoc = "<doc>";
-        let teststate = ParserState::new(None, None);
+        let teststate: ParserState<Nullo> = ParserState::new(None, None, None);
         let parse_doc = opt(tag(">"));
         assert_eq!(
-            Ok((("<doc>", ParserState::new(None, None)), None)),
+            Ok((("<doc>", ParserState::new(None, None, None)), None)),
             parse_doc((testdoc, teststate))
         );
     }

--- a/src/parser/combinators/pair.rs
+++ b/src/parser/combinators/pair.rs
@@ -1,12 +1,13 @@
-use crate::parser::{ParseInput, ParseResult};
+use crate::item::Node;
+use crate::parser::{ParseError, ParseInput};
 
-pub(crate) fn pair<P1, P2, A, B>(
+pub(crate) fn pair<P1, P2, A, B, N: Node>(
     parser1: P1,
     parser2: P2,
-) -> impl Fn(ParseInput) -> ParseResult<(A, B)>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (A, B)), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<A>,
-    P2: Fn(ParseInput) -> ParseResult<B>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, B), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, parse1_result)) => match parser2(input1) {

--- a/src/parser/combinators/tuple.rs
+++ b/src/parser/combinators/tuple.rs
@@ -1,12 +1,13 @@
-use crate::parser::{ParseInput, ParseResult};
+use crate::item::Node;
+use crate::parser::{ParseError, ParseInput};
 
-pub fn tuple2<P1, P2, R1, R2>(
+pub fn tuple2<P1, P2, R1, R2, N: Node>(
     parser1: P1,
     parser2: P2,
-) -> impl Fn(ParseInput) -> ParseResult<(R1, R2)>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (R1, R2)), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
-    P2: Fn(ParseInput) -> ParseResult<R2>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R2), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, result1)) => match parser2(input1) {
@@ -17,15 +18,15 @@ where
     }
 }
 
-pub fn tuple3<P1, P2, P3, R1, R2, R3>(
+pub fn tuple3<P1, P2, P3, R1, R2, R3, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
-) -> impl Fn(ParseInput) -> ParseResult<(R1, R2, R3)>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (R1, R2, R3)), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
-    P2: Fn(ParseInput) -> ParseResult<R2>,
-    P3: Fn(ParseInput) -> ParseResult<R3>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R2), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R3), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, result1)) => match parser2(input1) {
@@ -39,17 +40,17 @@ where
     }
 }
 
-pub fn tuple4<P1, P2, P3, P4, R1, R2, R3, R4>(
+pub fn tuple4<P1, P2, P3, P4, R1, R2, R3, R4, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
     parser4: P4,
-) -> impl Fn(ParseInput) -> ParseResult<(R1, R2, R3, R4)>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (R1, R2, R3, R4)), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
-    P2: Fn(ParseInput) -> ParseResult<R2>,
-    P3: Fn(ParseInput) -> ParseResult<R3>,
-    P4: Fn(ParseInput) -> ParseResult<R4>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R2), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R3), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R4), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, result1)) => match parser2(input1) {
@@ -66,19 +67,19 @@ where
     }
 }
 
-pub(crate) fn tuple5<P1, P2, P3, P4, P5, R1, R2, R3, R4, R5>(
+pub(crate) fn tuple5<P1, P2, P3, P4, P5, R1, R2, R3, R4, R5, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
     parser4: P4,
     parser5: P5,
-) -> impl Fn(ParseInput) -> ParseResult<(R1, R2, R3, R4, R5)>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (R1, R2, R3, R4, R5)), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
-    P2: Fn(ParseInput) -> ParseResult<R2>,
-    P3: Fn(ParseInput) -> ParseResult<R3>,
-    P4: Fn(ParseInput) -> ParseResult<R4>,
-    P5: Fn(ParseInput) -> ParseResult<R5>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R2), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R3), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R4), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R5), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, result1)) => match parser2(input1) {
@@ -100,21 +101,21 @@ where
     }
 }
 
-pub(crate) fn tuple6<P1, P2, P3, P4, P5, P6, R1, R2, R3, R4, R5, R6>(
+pub(crate) fn tuple6<P1, P2, P3, P4, P5, P6, R1, R2, R3, R4, R5, R6, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
     parser4: P4,
     parser5: P5,
     parser6: P6,
-) -> impl Fn(ParseInput) -> ParseResult<(R1, R2, R3, R4, R5, R6)>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (R1, R2, R3, R4, R5, R6)), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
-    P2: Fn(ParseInput) -> ParseResult<R2>,
-    P3: Fn(ParseInput) -> ParseResult<R3>,
-    P4: Fn(ParseInput) -> ParseResult<R4>,
-    P5: Fn(ParseInput) -> ParseResult<R5>,
-    P6: Fn(ParseInput) -> ParseResult<R6>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R2), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R3), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R4), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R5), ParseError>,
+    P6: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R6), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, result1)) => match parser2(input1) {
@@ -140,7 +141,7 @@ where
     }
 }
 
-pub(crate) fn tuple7<P1, P2, P3, P4, P5, P6, P7, R1, R2, R3, R4, R5, R6, R7>(
+pub(crate) fn tuple7<P1, P2, P3, P4, P5, P6, P7, R1, R2, R3, R4, R5, R6, R7, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
@@ -148,15 +149,15 @@ pub(crate) fn tuple7<P1, P2, P3, P4, P5, P6, P7, R1, R2, R3, R4, R5, R6, R7>(
     parser5: P5,
     parser6: P6,
     parser7: P7,
-) -> impl Fn(ParseInput) -> ParseResult<(R1, R2, R3, R4, R5, R6, R7)>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (R1, R2, R3, R4, R5, R6, R7)), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
-    P2: Fn(ParseInput) -> ParseResult<R2>,
-    P3: Fn(ParseInput) -> ParseResult<R3>,
-    P4: Fn(ParseInput) -> ParseResult<R4>,
-    P5: Fn(ParseInput) -> ParseResult<R5>,
-    P6: Fn(ParseInput) -> ParseResult<R6>,
-    P7: Fn(ParseInput) -> ParseResult<R7>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R2), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R3), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R4), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R5), ParseError>,
+    P6: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R6), ParseError>,
+    P7: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R7), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, result1)) => match parser2(input1) {
@@ -189,7 +190,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn tuple8<P1, P2, P3, P4, P5, P6, P7, P8, R1, R2, R3, R4, R5, R6, R7, R8>(
+pub(crate) fn tuple8<P1, P2, P3, P4, P5, P6, P7, P8, R1, R2, R3, R4, R5, R6, R7, R8, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
@@ -198,16 +199,16 @@ pub(crate) fn tuple8<P1, P2, P3, P4, P5, P6, P7, P8, R1, R2, R3, R4, R5, R6, R7,
     parser6: P6,
     parser7: P7,
     parser8: P8,
-) -> impl Fn(ParseInput) -> ParseResult<(R1, R2, R3, R4, R5, R6, R7, R8)>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (R1, R2, R3, R4, R5, R6, R7, R8)), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
-    P2: Fn(ParseInput) -> ParseResult<R2>,
-    P3: Fn(ParseInput) -> ParseResult<R3>,
-    P4: Fn(ParseInput) -> ParseResult<R4>,
-    P5: Fn(ParseInput) -> ParseResult<R5>,
-    P6: Fn(ParseInput) -> ParseResult<R6>,
-    P7: Fn(ParseInput) -> ParseResult<R7>,
-    P8: Fn(ParseInput) -> ParseResult<R8>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R2), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R3), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R4), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R5), ParseError>,
+    P6: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R6), ParseError>,
+    P7: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R7), ParseError>,
+    P8: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R8), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, result1)) => match parser2(input1) {
@@ -243,7 +244,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn tuple9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R1, R2, R3, R4, R5, R6, R7, R8, R9>(
+pub(crate) fn tuple9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R1, R2, R3, R4, R5, R6, R7, R8, R9, N: Node>(
     parser1: P1,
     parser2: P2,
     parser3: P3,
@@ -253,17 +254,17 @@ pub(crate) fn tuple9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R1, R2, R3, R4, R5, R6,
     parser7: P7,
     parser8: P8,
     parser9: P9,
-) -> impl Fn(ParseInput) -> ParseResult<(R1, R2, R3, R4, R5, R6, R7, R8, R9)>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (R1, R2, R3, R4, R5, R6, R7, R8, R9)), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
-    P2: Fn(ParseInput) -> ParseResult<R2>,
-    P3: Fn(ParseInput) -> ParseResult<R3>,
-    P4: Fn(ParseInput) -> ParseResult<R4>,
-    P5: Fn(ParseInput) -> ParseResult<R5>,
-    P6: Fn(ParseInput) -> ParseResult<R6>,
-    P7: Fn(ParseInput) -> ParseResult<R7>,
-    P8: Fn(ParseInput) -> ParseResult<R8>,
-    P9: Fn(ParseInput) -> ParseResult<R9>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R2), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R3), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R4), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R5), ParseError>,
+    P6: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R6), ParseError>,
+    P7: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R7), ParseError>,
+    P8: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R8), ParseError>,
+    P9: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R9), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, result1)) => match parser2(input1) {
@@ -323,6 +324,7 @@ pub(crate) fn tuple10<
     R8,
     R9,
     R10,
+    N: Node
 >(
     parser1: P1,
     parser2: P2,
@@ -334,18 +336,18 @@ pub(crate) fn tuple10<
     parser8: P8,
     parser9: P9,
     parser10: P10,
-) -> impl Fn(ParseInput) -> ParseResult<(R1, R2, R3, R4, R5, R6, R7, R8, R9, R10)>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (R1, R2, R3, R4, R5, R6, R7, R8, R9, R10)), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
-    P2: Fn(ParseInput) -> ParseResult<R2>,
-    P3: Fn(ParseInput) -> ParseResult<R3>,
-    P4: Fn(ParseInput) -> ParseResult<R4>,
-    P5: Fn(ParseInput) -> ParseResult<R5>,
-    P6: Fn(ParseInput) -> ParseResult<R6>,
-    P7: Fn(ParseInput) -> ParseResult<R7>,
-    P8: Fn(ParseInput) -> ParseResult<R8>,
-    P9: Fn(ParseInput) -> ParseResult<R9>,
-    P10: Fn(ParseInput) -> ParseResult<R10>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
+    P2: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R2), ParseError>,
+    P3: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R3), ParseError>,
+    P4: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R4), ParseError>,
+    P5: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R5), ParseError>,
+    P6: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R6), ParseError>,
+    P7: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R7), ParseError>,
+    P8: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R8), ParseError>,
+    P9: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R9), ParseError>,
+    P10: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R10), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, result1)) => match parser2(input1) {
@@ -391,14 +393,15 @@ mod tests {
     use crate::parser::combinators::tag::tag;
     use crate::parser::combinators::tuple::tuple3;
     use crate::parser::ParserState;
+    use crate::trees::nullo::Nullo;
 
     #[test]
     fn parser_tuple3_test1() {
         let testdoc = "<doc>";
-        let teststate = ParserState::new(None, None);
+        let teststate: ParserState<Nullo> = ParserState::new(None, None, None);
         let parse_doc = tuple3(tag("<"), tag("doc"), tag(">"));
         assert_eq!(
-            Ok((("", ParserState::new(None, None)), ((), (), ()))),
+            Ok((("", ParserState::new(None, None, None)), ((), (), ()))),
             parse_doc((testdoc, teststate))
         );
     }

--- a/src/parser/combinators/value.rs
+++ b/src/parser/combinators/value.rs
@@ -1,8 +1,9 @@
-use crate::parser::{ParseInput, ParseResult};
+use crate::item::Node;
+use crate::parser::{ParseInput, ParseError};
 
-pub(crate) fn value<P1, R1, V: Clone>(parser1: P1, val: V) -> impl Fn(ParseInput) -> ParseResult<V>
+pub(crate) fn value<P1, R1, V: Clone, N: Node>(parser1: P1, val: V) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, V), ParseError>
 where
-    P1: Fn(ParseInput) -> ParseResult<R1>,
+    P1: Fn(ParseInput<N>) -> Result<(ParseInput<N>, R1), ParseError>,
 {
     move |input| match parser1(input) {
         Ok((input1, _)) => Ok((input1, val.clone())),

--- a/src/parser/combinators/wellformed.rs
+++ b/src/parser/combinators/wellformed.rs
@@ -1,11 +1,12 @@
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::item::Node;
+use crate::parser::{ParseError, ParseInput};
 
-pub(crate) fn wellformed<P, F, A>(
+pub(crate) fn wellformed<P, F, A, N: Node>(
     parser: P,
     validate_fn: F,
-) -> impl Fn(ParseInput) -> ParseResult<A>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
 where
-    P: Fn(ParseInput) -> ParseResult<A>,
+    P: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
     F: Fn(&A) -> bool,
 {
     move |input| match parser(input) {
@@ -19,13 +20,13 @@ where
         Err(err) => Err(err),
     }
 }
-pub(crate) fn wellformed_ver<P, F10, F11, A>(
+pub(crate) fn wellformed_ver<P, F10, F11, A, N: Node>(
     parser: P,
     validate_fn10: F10,
     validate_fn11: F11,
-) -> impl Fn(ParseInput) -> ParseResult<A>
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>
 where
-    P: Fn(ParseInput) -> ParseResult<A>,
+    P: Fn(ParseInput<N>) -> Result<(ParseInput<N>, A), ParseError>,
     F10: Fn(&A) -> bool,
     F11: Fn(&A) -> bool,
 {

--- a/src/parser/combinators/whitespace.rs
+++ b/src/parser/combinators/whitespace.rs
@@ -1,13 +1,14 @@
 use std::cmp::Ordering;
 
+use crate::item::Node;
 use crate::parser::combinators::alt::alt4;
 use crate::parser::combinators::many::{many0, many1};
 use crate::parser::combinators::map::map;
 use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::tuple::tuple3;
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 
-pub fn whitespace0() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub fn whitespace0<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     //TODO add support for xml:space
     map(
         many0(alt4(tag(" "), tag("\t"), tag("\r"), tag("\n"))),
@@ -15,7 +16,7 @@ pub fn whitespace0() -> impl Fn(ParseInput) -> ParseResult<()> {
     )
 }
 
-pub(crate) fn whitespace1() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn whitespace1<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     //TODO add support for xml:space
     map(
         many1(alt4(tag(" "), tag("\t"), tag("\r"), tag("\n"))),
@@ -23,7 +24,7 @@ pub(crate) fn whitespace1() -> impl Fn(ParseInput) -> ParseResult<()> {
     )
 }
 
-pub(crate) fn xpwhitespace() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn xpwhitespace<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     map(
         tuple3(
             whitespace0(),
@@ -49,10 +50,10 @@ pub(crate) fn xpwhitespace() -> impl Fn(ParseInput) -> ParseResult<()> {
 /// * There is no open delimiter. In this case, consume up to and including the close delimiter. If the bracket count is 1 then return Ok, otherwise error.
 /// * There is an open delimiter. If the open occurs after the close, then consume up to and including the close delimiter. If the bracket count is 1 then return Ok, otherwise error.
 /// * The open delimiter occurs before the close. In this case, increment the bracket count and continue after the open delimiter.
-fn take_until_balanced(
+fn take_until_balanced<N: Node>(
     open: &'static str,
     close: &'static str,
-) -> impl Fn(ParseInput) -> ParseResult<()> {
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |(input, state)| {
         let mut pos = 0;
         let mut counter = 0;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4,7 +4,8 @@ A parser combinator, inspired by nom.
 This parser combinator passes a context into the function, which includes the string being parsed. This supports resolving context-based constructs such as general entities and XML Namespaces.
 */
 
-use crate::trees::intmuttree::{ExtDTDresolver, DTD};
+use crate::xmldecl::DTD;
+use crate::externals::URLResolver;
 use crate::xdmerror::{Error, ErrorKind};
 use std::collections::HashMap;
 use std::fmt;
@@ -64,7 +65,7 @@ pub struct ParserState {
     //stack: Vec<String>,
     //limit: Option<usize>,
     /* entity downloader function */
-    ext_dtd_resolver: Option<ExtDTDresolver>,
+    ext_dtd_resolver: Option<URLResolver>,
     ext_entities_to_parse: Vec<String>,
     docloc: Option<String>,
     /*
@@ -75,7 +76,7 @@ pub struct ParserState {
 }
 
 impl ParserState {
-    pub fn new(resolver: Option<ExtDTDresolver>, docloc: Option<String>) -> Self {
+    pub fn new(resolver: Option<URLResolver>, docloc: Option<String>) -> Self {
         ParserState {
             dtd: DTD::new(),
             standalone: false,

--- a/src/parser/xml/chardata.rs
+++ b/src/parser/xml/chardata.rs
@@ -1,3 +1,4 @@
+use crate::item::Node;
 use crate::parser::combinators::alt::{alt2, alt3};
 use crate::parser::combinators::delimited::delimited;
 use crate::parser::combinators::many::many1;
@@ -6,11 +7,11 @@ use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::take::{take_until, take_while};
 use crate::parser::combinators::wellformed::{wellformed, wellformed_ver};
 use crate::parser::common::{is_char10, is_char11, is_unrestricted_char11};
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use std::str::FromStr;
 
 // CharData ::= [^<&]* - (']]>')
-pub(crate) fn chardata() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn chardata<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     map(
         many1(alt3(
             wellformed_ver(
@@ -37,18 +38,18 @@ pub(crate) fn chardata() -> impl Fn(ParseInput) -> ParseResult<String> {
     )
 }
 
-fn chardata_cdata() -> impl Fn(ParseInput) -> ParseResult<String> {
+fn chardata_cdata<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     delimited(tag("<![CDATA["), take_until("]]>"), tag("]]>"))
 }
 
-pub(crate) fn chardata_escapes() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn chardata_escapes<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     move |input| match chardata_unicode_codepoint()(input.clone()) {
         Ok((inp, s)) => Ok((inp, s.to_string())),
         Err(e) => Err(e),
     }
 }
 
-pub(crate) fn chardata_unicode_codepoint() -> impl Fn(ParseInput) -> ParseResult<char> {
+pub(crate) fn chardata_unicode_codepoint<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, char), ParseError> {
     map(
         wellformed(
             alt2(
@@ -67,7 +68,7 @@ pub(crate) fn chardata_unicode_codepoint() -> impl Fn(ParseInput) -> ParseResult
     )
 }
 
-fn parse_hex() -> impl Fn(ParseInput) -> ParseResult<u32> {
+fn parse_hex<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, u32), ParseError> {
     move |input| match take_while(|c: char| c.is_ascii_hexdigit())(input) {
         Ok((input1, hex)) => match u32::from_str_radix(&hex, 16) {
             Ok(r) => Ok((input1, r)),
@@ -76,7 +77,7 @@ fn parse_hex() -> impl Fn(ParseInput) -> ParseResult<u32> {
         Err(e) => Err(e),
     }
 }
-fn parse_decimal() -> impl Fn(ParseInput) -> ParseResult<u32> {
+fn parse_decimal<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, u32), ParseError> {
     move |input| match take_while(|c: char| c.is_ascii_digit())(input) {
         Ok((input1, dec)) => match u32::from_str(&dec) {
             Ok(r) => Ok((input1, r)),
@@ -86,6 +87,6 @@ fn parse_decimal() -> impl Fn(ParseInput) -> ParseResult<u32> {
     }
 }
 
-fn chardata_literal() -> impl Fn(ParseInput) -> ParseResult<String> {
+fn chardata_literal<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     take_while(|c| c != '<' && c != '&')
 }

--- a/src/parser/xml/dtd/conditionals.rs
+++ b/src/parser/xml/dtd/conditionals.rs
@@ -1,3 +1,4 @@
+use crate::item::Node;
 use crate::parser::combinators::alt::alt3;
 use crate::parser::combinators::many::many0;
 use crate::parser::combinators::tag::tag;
@@ -7,9 +8,9 @@ use crate::parser::combinators::value::value;
 use crate::parser::combinators::whitespace::whitespace0;
 use crate::parser::xml::dtd::extsubset::extsubsetdecl;
 use crate::parser::xml::dtd::pereference::petextreference;
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 
-pub(crate) fn conditionalsect() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn conditionalsect<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |(input, state)| match tuple5(
         tag("<!["),
         whitespace0(),
@@ -31,21 +32,21 @@ pub(crate) fn conditionalsect() -> impl Fn(ParseInput) -> ParseResult<()> {
     }
 }
 
-pub(crate) fn includesect() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn includesect<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |(input, state)| match tuple2(extsubsetdecl(), tag("]]>"))((input, state)) {
         Ok(((input2, state2), (_, _))) => Ok(((input2, state2), ())),
         Err(e) => Err(e),
     }
 }
 
-pub(crate) fn ignoresect() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn ignoresect<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |(input, state)| match tuple2(ignoresectcontents(), tag("]]>"))((input, state.clone())) {
         Ok(((input2, _), (_, _))) => Ok(((input2, state), ())),
         Err(e) => Err(e),
     }
 }
 
-fn ignoresectcontents() -> impl Fn(ParseInput) -> ParseResult<()> {
+fn ignoresectcontents<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |(input, state)| match tuple2(
         many0(tuple2(
             take_until_either_or("<![", "]]>"),

--- a/src/parser/xml/dtd/elementdecl.rs
+++ b/src/parser/xml/dtd/elementdecl.rs
@@ -3,11 +3,12 @@ use crate::parser::combinators::tuple::tuple7;
 use crate::parser::combinators::whitespace::{whitespace0, whitespace1};
 use crate::parser::xml::dtd::misc::contentspec;
 use crate::parser::xml::qname::qualname;
-use crate::parser::{ParseInput, ParseResult};
-use crate::trees::intmuttree::DTDDecl;
+use crate::parser::{ParseError, ParseInput};
+use crate::xmldecl::DTDDecl;
+use crate::item::Node;
 
 //elementdecl	   ::=   	'<!ELEMENT' S Name S contentspec S? '>'
-pub(crate) fn elementdecl() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn elementdecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |input| match tuple7(
         tag("<!ELEMENT"),
         whitespace1(),

--- a/src/parser/xml/dtd/enumerated.rs
+++ b/src/parser/xml/dtd/enumerated.rs
@@ -6,15 +6,16 @@ use crate::parser::combinators::tuple::{tuple4, tuple6};
 use crate::parser::combinators::whitespace::whitespace0;
 use crate::parser::xml::dtd::misc::nmtoken;
 use crate::parser::xml::dtd::notation::notationtype;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
+use crate::item::Node;
 
 //EnumeratedType ::= NotationType | Enumeration
-pub(crate) fn enumeratedtype() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn enumeratedtype<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     alt2(notationtype(), enumeration())
 }
 
 //Enumeration ::= '(' S? Nmtoken (S? '|' S? Nmtoken)* S? ')'
-fn enumeration() -> impl Fn(ParseInput) -> ParseResult<()> {
+fn enumeration<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     map(
         tuple6(
             tag("("),

--- a/src/parser/xml/dtd/extsubset.rs
+++ b/src/parser/xml/dtd/extsubset.rs
@@ -13,9 +13,10 @@ use crate::parser::xml::dtd::pedecl::pedecl;
 use crate::parser::xml::dtd::pereference::pereference;
 use crate::parser::xml::dtd::textdecl::textdecl;
 use crate::parser::xml::misc::{comment, processing_instruction};
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
+use crate::item::Node;
 
-pub(crate) fn extsubset() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn extsubset<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |(input, mut state)| {
         if state.standalone {
             Ok(((input, state), ()))
@@ -36,7 +37,7 @@ pub(crate) fn extsubset() -> impl Fn(ParseInput) -> ParseResult<()> {
     }
 }
 
-pub(crate) fn extsubsetdecl() -> impl Fn(ParseInput) -> ParseResult<Vec<()>> {
+pub(crate) fn extsubsetdecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, Vec<()>), ParseError> {
     many0(alt10(
         conditionalsect(),
         elementdecl(),

--- a/src/parser/xml/dtd/gedecl.rs
+++ b/src/parser/xml/dtd/gedecl.rs
@@ -13,9 +13,10 @@ use crate::parser::xml::dtd::intsubset::intsubset;
 use crate::parser::xml::dtd::pereference::petextreference;
 use crate::parser::xml::dtd::textexternalid;
 use crate::parser::xml::qname::qualname;
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
+use crate::item::Node;
 
-pub(crate) fn gedecl() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn gedecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |input| match wellformed_ver(
         tuple7(
             tag("<!ENTITY"),

--- a/src/parser/xml/dtd/intsubset.rs
+++ b/src/parser/xml/dtd/intsubset.rs
@@ -10,9 +10,10 @@ use crate::parser::xml::dtd::pedecl::pedecl;
 use crate::parser::xml::dtd::pereference::pereference;
 use crate::parser::xml::misc::comment;
 use crate::parser::xml::misc::processing_instruction;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
+use crate::item::Node;
 
-pub(crate) fn intsubset() -> impl Fn(ParseInput) -> ParseResult<Vec<()>> {
+pub(crate) fn intsubset<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, Vec<()>), ParseError> {
     many0(alt9(
         elementdecl(),
         attlistdecl(),

--- a/src/parser/xml/dtd/misc.rs
+++ b/src/parser/xml/dtd/misc.rs
@@ -10,13 +10,14 @@ use crate::parser::combinators::whitespace::whitespace0;
 use crate::parser::common::is_namechar;
 use crate::parser::xml::dtd::pereference::petextreference;
 use crate::parser::xml::qname::name;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
+use crate::item::Node;
 
-pub(crate) fn nmtoken() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn nmtoken<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     map(many1(take_while(|c| is_namechar(&c))), |_x| ())
 }
 
-pub(crate) fn contentspec() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn contentspec<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     alt4(
         value(tag("EMPTY"), "EMPTY".to_string()),
         value(tag("ANY"), "ANY".to_string()),
@@ -26,7 +27,7 @@ pub(crate) fn contentspec() -> impl Fn(ParseInput) -> ParseResult<String> {
 }
 
 //Mixed	   ::=   	'(' S? '#PCDATA' (S? '|' S? Name)* S? ')*' | '(' S? '#PCDATA' S? ')'
-pub(crate) fn mixed() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn mixed<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     alt2(
         map(
             tuple6(
@@ -58,7 +59,7 @@ pub(crate) fn mixed() -> impl Fn(ParseInput) -> ParseResult<String> {
 }
 
 // children	   ::=   	(choice | seq) ('?' | '*' | '+')?
-pub(crate) fn children() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn children<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     map(
         tuple2(
             alt3(petextreference(), choice(), seq()),
@@ -69,7 +70,7 @@ pub(crate) fn children() -> impl Fn(ParseInput) -> ParseResult<String> {
 }
 
 // cp	   ::=   	(Name | choice | seq) ('?' | '*' | '+')?
-fn cp() -> impl Fn(ParseInput) -> ParseResult<String> {
+fn cp<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     move |input| {
         map(
             tuple2(
@@ -81,7 +82,7 @@ fn cp() -> impl Fn(ParseInput) -> ParseResult<String> {
     }
 }
 //choice	   ::=   	'(' S? cp ( S? '|' S? cp )+ S? ')'
-fn choice() -> impl Fn(ParseInput) -> ParseResult<String> {
+fn choice<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     move |input| {
         map(
             tuple6(
@@ -101,7 +102,7 @@ fn choice() -> impl Fn(ParseInput) -> ParseResult<String> {
 }
 
 //seq	   ::=   	'(' S? cp ( S? ',' S? cp )* S? ')'
-fn seq() -> impl Fn(ParseInput) -> ParseResult<String> {
+fn seq<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     map(
         tuple6(
             tag("("),

--- a/src/parser/xml/dtd/mod.rs
+++ b/src/parser/xml/dtd/mod.rs
@@ -11,6 +11,7 @@ mod pedecl;
 pub(crate) mod pereference;
 mod textdecl;
 
+use crate::item::Node;
 use crate::parser::combinators::alt::alt2;
 use crate::parser::combinators::delimited::delimited;
 use crate::parser::combinators::map::map;
@@ -25,9 +26,9 @@ use crate::parser::xml::dtd::intsubset::intsubset;
 use crate::parser::xml::dtd::textdecl::textdecl;
 use crate::parser::xml::qname::name;
 use crate::parser::xml::reference::reference;
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 
-pub(crate) fn doctypedecl() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn doctypedecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |input| match tuple8(
         tag("<!DOCTYPE"),
         whitespace1(),
@@ -72,7 +73,7 @@ pub(crate) fn doctypedecl() -> impl Fn(ParseInput) -> ParseResult<()> {
     }
 }
 
-fn externalid() -> impl Fn(ParseInput) -> ParseResult<()> {
+fn externalid<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |(input, state)| {
         match alt2(
             map(
@@ -127,7 +128,7 @@ fn externalid() -> impl Fn(ParseInput) -> ParseResult<()> {
     }
 }
 
-fn textexternalid() -> impl Fn(ParseInput) -> ParseResult<String> {
+fn textexternalid<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     move |(input, state)| {
         match alt2(
             map(

--- a/src/parser/xml/dtd/notation.rs
+++ b/src/parser/xml/dtd/notation.rs
@@ -9,11 +9,12 @@ use crate::parser::combinators::wellformed::wellformed;
 use crate::parser::combinators::whitespace::{whitespace0, whitespace1};
 use crate::parser::common::{is_pubid_char, is_pubid_charwithapos};
 use crate::parser::xml::qname::{name, qualname};
-use crate::parser::{ParseInput, ParseResult};
-use crate::trees::intmuttree::DTDDecl;
+use crate::parser::{ParseError, ParseInput};
+use crate::xmldecl::DTDDecl;
+use crate::item::Node;
 
 //NotationType ::= 'NOTATION' S '(' S? Name (S? '|' S? Name)* S? ')'
-pub(crate) fn notationtype() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn notationtype<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     map(
         tuple8(
             tag("NOTATION"),
@@ -29,7 +30,7 @@ pub(crate) fn notationtype() -> impl Fn(ParseInput) -> ParseResult<()> {
     )
 }
 
-pub(crate) fn notationpublicid() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn notationpublicid<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     alt3(
         map(
             tuple3(
@@ -80,7 +81,7 @@ pub(crate) fn notationpublicid() -> impl Fn(ParseInput) -> ParseResult<String> {
     )
 }
 
-pub(crate) fn ndatadecl() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn ndatadecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |input| match tuple7(
         tag("<!NOTATION"),
         whitespace1(),

--- a/src/parser/xml/dtd/pedecl.rs
+++ b/src/parser/xml/dtd/pedecl.rs
@@ -13,9 +13,10 @@ use crate::parser::xml::dtd::intsubset::intsubset;
 use crate::parser::xml::dtd::pereference::petextreference;
 use crate::parser::xml::dtd::textexternalid;
 use crate::parser::xml::qname::qualname;
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
+use crate::item::Node;
 
-pub(crate) fn pedecl() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn pedecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |input| match wellformed_ver(
         tuple9(
             tag("<!ENTITY"),

--- a/src/parser/xml/dtd/pereference.rs
+++ b/src/parser/xml/dtd/pereference.rs
@@ -2,9 +2,10 @@ use crate::parser::combinators::delimited::delimited;
 use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::take::take_until;
 use crate::parser::xml::dtd::extsubset::extsubsetdecl;
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
+use crate::item::Node;
 
-pub(crate) fn pereference() -> impl Fn(ParseInput) -> ParseResult<()> {
+pub(crate) fn pereference<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |(input, state)| {
         let e = delimited(tag("%"), take_until(";"), tag(";"))((input, state));
         match e {
@@ -52,7 +53,7 @@ pub(crate) fn pereference() -> impl Fn(ParseInput) -> ParseResult<()> {
     }
 }
 
-pub(crate) fn petextreference() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn petextreference<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     move |(input, state)| {
         let e = delimited(tag("%"), take_until(";"), tag(";"))((input, state));
         match e {

--- a/src/parser/xml/dtd/textdecl.rs
+++ b/src/parser/xml/dtd/textdecl.rs
@@ -5,10 +5,11 @@ use crate::parser::combinators::tuple::{tuple2, tuple5, tuple6};
 use crate::parser::combinators::whitespace::{whitespace0, whitespace1};
 use crate::parser::xml::strings::delimited_string;
 use crate::parser::xml::xmldecl::encodingdecl;
-use crate::parser::{ParseError, ParseInput, ParseResult};
-use crate::trees::intmuttree::XMLDecl;
+use crate::parser::{ParseError, ParseInput};
+use crate::xmldecl::XMLDecl;
+use crate::item::Node;
 
-fn xmldeclversion() -> impl Fn(ParseInput) -> ParseResult<String> {
+fn xmldeclversion<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     move |(input, state)| match tuple5(
         tag("version"),
         whitespace0(),
@@ -33,7 +34,7 @@ fn xmldeclversion() -> impl Fn(ParseInput) -> ParseResult<String> {
     }
 }
 
-pub(crate) fn textdecl() -> impl Fn(ParseInput) -> ParseResult<XMLDecl> {
+pub(crate) fn textdecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, XMLDecl), ParseError> {
     //This is NOT the same as the XML declaration in XML documents.
     //There is no standalone, and the version is optional.
     map(

--- a/src/parser/xml/element.rs
+++ b/src/parser/xml/element.rs
@@ -1,5 +1,5 @@
 use std::rc::Rc;
-use crate::item::NodeType;
+use crate::item::{Node, NodeType};
 use crate::parser::combinators::alt::{alt2, alt4};
 use crate::parser::combinators::many::many0;
 use crate::parser::combinators::map::map;
@@ -13,17 +13,17 @@ use crate::parser::xml::chardata::chardata;
 use crate::parser::xml::misc::{comment, processing_instruction};
 use crate::parser::xml::qname::qualname;
 use crate::parser::xml::reference::reference;
-use crate::parser::{ParseError, ParseInput, ParseResult};
-use crate::trees::intmuttree::{NodeBuilder, RNode};
-use crate::{Node, Value};
+use crate::parser::{ParseError, ParseInput};
+use crate::qname::QualifiedName;
+use crate::value::Value;
 
 // Element ::= EmptyElemTag | STag content ETag
-pub(crate) fn element() -> impl Fn(ParseInput) -> ParseResult<RNode> {
+pub(crate) fn element<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), ParseError> {
     move |input| alt2(emptyelem(), taggedelem())(input)
 }
 
 // EmptyElemTag ::= '<' Name (Attribute)* '/>'
-fn emptyelem() -> impl Fn(ParseInput) -> ParseResult<RNode> {
+fn emptyelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), ParseError> {
     move |input| {
         match tuple5(
             tag("<"),
@@ -36,7 +36,7 @@ fn emptyelem() -> impl Fn(ParseInput) -> ParseResult<RNode> {
         )(input)
         {
             Ok(((input1, mut state1), (_, n, av, _, _))) => {
-                let e = NodeBuilder::new(NodeType::Element).name(n.clone()).build();
+                let mut ens = n.get_nsuri();
                 match state1.namespace.pop() {
                     None => {
                         //No namespace to assign.
@@ -44,7 +44,7 @@ fn emptyelem() -> impl Fn(ParseInput) -> ParseResult<RNode> {
                     Some(ns) => {
                         let ns_to_check = n.get_prefix().unwrap_or_else(|| "xmlns".to_string());
                         if ns_to_check == *"xml" {
-                            e.set_nsuri("http://www.w3.org/XML/1998/namespace".to_string())
+                            ens = Some("http://www.w3.org/XML/1998/namespace".to_string())
                         } else {
                             match ns.get(&*ns_to_check) {
                                 None => {
@@ -60,15 +60,18 @@ fn emptyelem() -> impl Fn(ParseInput) -> ParseResult<RNode> {
                                     {
                                         return Err(ParseError::NotWellFormed);
                                     }
-                                    e.set_nsuri(nsuri.clone())
+                                    ens = Some(nsuri.clone())
                                 }
                             }
                         }
                     }
                 };
+                let e = state1.doc.clone().unwrap()
+                    .new_element(QualifiedName::new(ens, n.get_prefix(), n.get_localname()))
+                    .expect("unable to create element");
                 av.iter()
                     .for_each(|b| e.add_attribute(b.clone()).expect("unable to add attribute"));
-                Ok(((input1, state1), e))
+                Ok(((input1, state1.clone()), e))
             }
             Err(err) => Err(err),
         }
@@ -78,7 +81,7 @@ fn emptyelem() -> impl Fn(ParseInput) -> ParseResult<RNode> {
 // STag ::= '<' Name (Attribute)* '>'
 // ETag ::= '</' Name '>'
 // NB. Names must match
-fn taggedelem() -> impl Fn(ParseInput) -> ParseResult<RNode> {
+fn taggedelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), ParseError> {
     move |input| {
         match wellformed(
             tuple10(
@@ -101,7 +104,7 @@ fn taggedelem() -> impl Fn(ParseInput) -> ParseResult<RNode> {
         )(input)
         {
             Ok(((input1, mut state1), (_, n, av, _, _, c, _, _, _, _))) => {
-                let mut e = NodeBuilder::new(NodeType::Element).name(n.clone()).build();
+                let mut ens = n.get_nsuri();
                 match state1.namespace.pop() {
                     None => {
                         //No namespace to assign.
@@ -109,7 +112,7 @@ fn taggedelem() -> impl Fn(ParseInput) -> ParseResult<RNode> {
                     Some(ns) => {
                         let ns_to_check = n.get_prefix().unwrap_or_else(|| "xmlns".to_string());
                         if ns_to_check == *"xml" {
-                            e.set_nsuri("http://www.w3.org/XML/1998/namespace".to_string())
+                            ens = Some("http://www.w3.org/XML/1998/namespace".to_string());
                         } else {
                             match ns.get(&*ns_to_check) {
                                 None => {
@@ -117,17 +120,22 @@ fn taggedelem() -> impl Fn(ParseInput) -> ParseResult<RNode> {
                                         return Err(ParseError::MissingNameSpace);
                                     }
                                 }
-                                Some(nsuri) => e.set_nsuri(nsuri.clone()),
+                                Some(nsuri) => {
+                                    ens = Some(nsuri.clone());
+                                }
                             }
                         }
                     }
                 };
+                let mut e = state1.doc.clone().unwrap()
+                    .new_element(QualifiedName::new(ens, n.get_prefix(), n.get_localname()))
+                    .expect("unable to create element");
                 av.iter()
                     .for_each(|b| e.add_attribute(b.clone()).expect("unable to add attribute"));
                 c.iter().for_each(|d| {
                     e.push(d.clone()).expect("unable to add node");
                 });
-                Ok(((input1, state1), e))
+                Ok(((input1, state1.clone()), e))
             }
             Err(err) => Err(err),
         }
@@ -135,57 +143,58 @@ fn taggedelem() -> impl Fn(ParseInput) -> ParseResult<RNode> {
 }
 
 // content ::= CharData? ((element | Reference | CDSect | PI | Comment) CharData?)*
-pub(crate) fn content() -> impl Fn(ParseInput) -> ParseResult<Vec<RNode>> {
-    map(
-        tuple2(
-            opt(chardata()),
-            many0(tuple2(
-                alt4(
-                    map(processing_instruction(), |e| vec![e]),
-                    map(comment(), |e| vec![e]),
-                    map(element(), |e| vec![e]),
-                    reference(),
-                ),
+pub(crate) fn content<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, Vec<N>), ParseError> {
+    move |(input, state)| {
+        match tuple2(
                 opt(chardata()),
-            )),
-        ),
-        |(c, v)| {
-            let mut new: Vec<RNode> = Vec::new();
-            let mut notex: Vec<String> = Vec::new();
-            if let Some(..) = c {
-                notex.push(c.unwrap());
-            }
-            if !v.is_empty() {
-                for (w, d) in v {
-                    for x in w {
-                        match x.node_type() {
-                            NodeType::Text => notex.push(x.to_string()),
-                            _ => {
-                                if !notex.is_empty() {
-                                    new.push(
-                                        NodeBuilder::new(NodeType::Text)
-                                            .value(Rc::new(Value::String(notex.concat())))
-                                            .build(),
-                                    );
-                                    notex.clear();
+                many0(tuple2(
+                    alt4(
+                        map(processing_instruction(), |e| vec![e]),
+                        map(comment(), |e| vec![e]),
+                        map(element(), |e| vec![e]),
+                        reference(),
+                    ),
+                    opt(chardata()),
+                )),
+            )((input, state.clone())) {
+            Ok((state1, (c, v))) =>             {
+                let mut new: Vec<N> = Vec::new();
+                let mut notex: Vec<String> = Vec::new();
+                if let Some(..) = c {
+                    notex.push(c.unwrap());
+                }
+                if !v.is_empty() {
+                    for (w, d) in v {
+                        for x in w {
+                            match x.node_type() {
+                                NodeType::Text => notex.push(x.to_string()),
+                                _ => {
+                                    if !notex.is_empty() {
+                                        new.push(
+                                            state.doc.clone().unwrap().new_text(Rc::new(Value::String(notex.concat())))
+                                                .expect("unable to create text node"),
+                                        );
+                                        notex.clear();
+                                    }
+                                    new.push(x);
                                 }
-                                new.push(x);
                             }
                         }
-                    }
-                    if let Some(..) = d {
-                        notex.push(d.unwrap())
+                        if let Some(..) = d {
+                            notex.push(d.unwrap())
+                        }
                     }
                 }
-            }
-            if !notex.is_empty() {
-                new.push(
-                    NodeBuilder::new(NodeType::Text)
-                        .value(Rc::new(Value::String(notex.concat())))
-                        .build(),
-                );
-            }
-            new
-        },
-    )
+                if !notex.is_empty() {
+                    new.push(
+                        state.doc.clone().unwrap().new_text(Rc::new(Value::String(notex.concat())))
+                            .expect("unable to create text node")
+                    );
+                }
+                Ok((state1, new))
+            },
+
+            Err(e) => Err(e),
+        }
+    }
 }

--- a/src/parser/xml/mod.rs
+++ b/src/parser/xml/mod.rs
@@ -32,7 +32,7 @@ pub fn parse<N: Node>(
 ) -> Result<N, Error> {
     let state = ParserState::new(Some(doc), entityresolver, docloc);
     match document((input, state)) {
-        Ok((_, xmldoc)) => Result::Ok(xmldoc),
+        Ok((_, xmldoc)) => Ok(xmldoc),
         Err(err) => {
             match err {
                 ParseError::Combinator => Err(Error::new(

--- a/src/parser/xml/qname.rs
+++ b/src/parser/xml/qname.rs
@@ -1,3 +1,4 @@
+use crate::item::Node;
 use crate::parser::combinators::alt::alt2;
 use crate::parser::combinators::map::map;
 use crate::parser::combinators::opt::opt;
@@ -8,19 +9,19 @@ use crate::parser::combinators::tuple::{tuple2, tuple3};
 use crate::parser::combinators::wellformed::wellformed;
 use crate::parser::common::{is_namechar, is_namestartchar, is_ncnamechar, is_ncnamestartchar};
 use crate::parser::xml::dtd::pereference::petextreference;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::qname::QualifiedName;
 
 // QualifiedName
-pub(crate) fn qualname() -> impl Fn(ParseInput) -> ParseResult<QualifiedName> {
+pub(crate) fn qualname<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, QualifiedName), ParseError> {
     alt2(prefixed_name(), unprefixed_name())
 }
-fn unprefixed_name() -> impl Fn(ParseInput) -> ParseResult<QualifiedName> {
+fn unprefixed_name<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, QualifiedName), ParseError> {
     map(alt2(petextreference(), ncname()), |localpart| {
         QualifiedName::new(None, None, localpart)
     })
 }
-fn prefixed_name() -> impl Fn(ParseInput) -> ParseResult<QualifiedName> {
+fn prefixed_name<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, QualifiedName), ParseError> {
     map(
         tuple3(
             alt2(petextreference(), ncname()),
@@ -35,7 +36,7 @@ fn prefixed_name() -> impl Fn(ParseInput) -> ParseResult<QualifiedName> {
 // Name ::= NameStartChar NameChar*
 // NameStartChar ::= ':' | [A-Z] | '_' | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
 // NameChar ::= NameStartChar | '-' | '.' | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
-pub(crate) fn ncname<'a>() -> impl Fn(ParseInput) -> ParseResult<String> + 'a {
+pub(crate) fn ncname<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     map(
         tuple2(
             wellformed(take_one(), is_ncnamestartchar),
@@ -45,7 +46,7 @@ pub(crate) fn ncname<'a>() -> impl Fn(ParseInput) -> ParseResult<String> + 'a {
     )
 }
 
-pub(crate) fn name() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn name<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     map(
         tuple2(
             wellformed(take_one(), is_namestartchar),

--- a/src/parser/xml/reference.rs
+++ b/src/parser/xml/reference.rs
@@ -1,52 +1,41 @@
 use std::rc::Rc;
-use crate::item::NodeType;
+use crate::item::{Node, NodeType};
 use crate::parser::combinators::delimited::delimited;
 use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::take::take_until;
 use crate::parser::xml::dtd::extsubset::extsubset;
 use crate::parser::xml::element::content;
-use crate::parser::{ParseError, ParseInput, ParseResult};
-use crate::trees::intmuttree::{NodeBuilder, RNode};
-use crate::{Node, Value};
+use crate::parser::{ParseError, ParseInput};
+use crate::value::Value;
 
 // Reference ::= EntityRef | CharRef
 // \Its important to note, we pre-populate the standard char references in the DTD.
-pub(crate) fn reference() -> impl Fn(ParseInput) -> ParseResult<Vec<RNode>> {
+pub(crate) fn reference<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, Vec<N>), ParseError> {
     move |(input, state)| {
-        let e = delimited(tag("&"), take_until(";"), tag(";"))((input, state));
+        let e = delimited(tag("&"), take_until(";"), tag(";"))((input, state.clone()));
         match e {
             Err(e) => Err(e),
             Ok(((input1, mut state1), entitykey)) => {
                 match entitykey.as_str() {
                     "amp" => Ok((
                         (input1, state1),
-                        vec![NodeBuilder::new(NodeType::Text)
-                            .value(Rc::new(Value::String("&".to_string())))
-                            .build()],
+                        vec![state.doc.clone().unwrap().new_text(Rc::new(Value::String("&".to_string()))).expect("unable to create text node")],
                     )),
                     "gt" => Ok((
                         (input1, state1),
-                        vec![NodeBuilder::new(NodeType::Text)
-                            .value(Rc::new(Value::String(">".to_string())))
-                            .build()],
+                        vec![state.doc.clone().unwrap().new_text(Rc::new(Value::String(">".to_string()))).expect("unable to create text node")],
                     )),
                     "lt" => Ok((
                         (input1, state1),
-                        vec![NodeBuilder::new(NodeType::Text)
-                            .value(Rc::new(Value::String("<".to_string())))
-                            .build()],
+                        vec![state.doc.clone().unwrap().new_text(Rc::new(Value::String("<".to_string()))).expect("unable to create text node")],
                     )),
                     "quot" => Ok((
                         (input1, state1),
-                        vec![NodeBuilder::new(NodeType::Text)
-                            .value(Rc::new(Value::String("\"".to_string())))
-                            .build()],
+                        vec![state.doc.clone().unwrap().new_text(Rc::new(Value::String("\"".to_string()))).expect("unable to create text node")],
                     )),
                     "apos" => Ok((
                         (input1, state1),
-                        vec![NodeBuilder::new(NodeType::Text)
-                            .value(Rc::new(Value::String("'".to_string())))
-                            .build()],
+                        vec![state.doc.clone().unwrap().new_text(Rc::new(Value::String("'".to_string()))).expect("unable to create text node")],
                     )),
                     _ => {
                         match state1.clone().dtd.generalentities.get(&entitykey as &str) {
@@ -162,7 +151,7 @@ pub(crate) fn reference() -> impl Fn(ParseInput) -> ParseResult<Vec<RNode>> {
     }
 }
 
-pub(crate) fn textreference() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn textreference<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     move |(input, state)| {
         let e = delimited(tag("&"), take_until(";"), tag(";"))((input, state));
         match e {

--- a/src/parser/xml/strings.rs
+++ b/src/parser/xml/strings.rs
@@ -1,3 +1,4 @@
+use crate::item::Node;
 use crate::parser::combinators::alt::{alt2, alt3};
 use crate::parser::combinators::delimited::delimited;
 use crate::parser::combinators::many::many0;
@@ -6,12 +7,12 @@ use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::take::take_while;
 use crate::parser::xml::chardata::chardata_escapes;
 use crate::parser::xml::chardata::chardata_unicode_codepoint;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseInput, ParseError};
 
-pub(crate) fn delimited_string() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn delimited_string<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     alt2(string_single(), string_double())
 }
-fn string_single() -> impl Fn(ParseInput) -> ParseResult<String> {
+fn string_single<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     delimited(
         tag("\'"),
         map(
@@ -25,7 +26,7 @@ fn string_single() -> impl Fn(ParseInput) -> ParseResult<String> {
         tag("\'"),
     )
 }
-fn string_double() -> impl Fn(ParseInput) -> ParseResult<String> {
+fn string_double<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     delimited(
         tag("\""),
         map(

--- a/src/parser/xml/xmldecl.rs
+++ b/src/parser/xml/xmldecl.rs
@@ -1,3 +1,4 @@
+use crate::item::Node;
 use crate::parser::combinators::alt::alt2;
 use crate::parser::combinators::map::map;
 use crate::parser::combinators::opt::opt;
@@ -7,10 +8,10 @@ use crate::parser::combinators::tuple::{tuple2, tuple3, tuple5, tuple6, tuple8};
 use crate::parser::combinators::wellformed::wellformed;
 use crate::parser::combinators::whitespace::{whitespace0, whitespace1};
 use crate::parser::xml::strings::delimited_string;
-use crate::parser::{ParseError, ParseInput, ParseResult};
-use crate::trees::intmuttree::XMLDecl;
+use crate::parser::{ParseError, ParseInput};
+use crate::xmldecl::XMLDecl;
 
-fn xmldeclversion() -> impl Fn(ParseInput) -> ParseResult<String> {
+fn xmldeclversion<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     move |input| match tuple5(
         tag("version"),
         whitespace0(),
@@ -36,7 +37,7 @@ fn xmldeclversion() -> impl Fn(ParseInput) -> ParseResult<String> {
     }
 }
 
-fn xmldeclstandalone() -> impl Fn(ParseInput) -> ParseResult<String> {
+fn xmldeclstandalone<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     move |(input, state)| match map(
         wellformed(
             tuple6(
@@ -62,7 +63,7 @@ fn xmldeclstandalone() -> impl Fn(ParseInput) -> ParseResult<String> {
     }
 }
 
-pub(crate) fn encodingdecl() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn encodingdecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     map(
         tuple6(
             whitespace1(),
@@ -100,7 +101,7 @@ pub(crate) fn encodingdecl() -> impl Fn(ParseInput) -> ParseResult<String> {
     )
 }
 
-pub(crate) fn xmldecl() -> impl Fn(ParseInput) -> ParseResult<XMLDecl> {
+pub(crate) fn xmldecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, XMLDecl), ParseError> {
     move |(input, state)| match tuple8(
         tag("<?xml"),
         whitespace1(),

--- a/src/parser/xpath/compare.rs
+++ b/src/parser/xpath/compare.rs
@@ -8,13 +8,13 @@ use crate::parser::combinators::tag::anytag;
 use crate::parser::combinators::tuple::tuple3;
 use crate::parser::combinators::whitespace::xpwhitespace;
 use crate::parser::xpath::strings::stringconcat_expr;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::Transform;
 use crate::value::Operator;
 
 // ComparisonExpr ::= StringConcatExpr ( (ValueComp | GeneralComp | NodeComp) StringConcatExpr)?
 pub(crate) fn comparison_expr<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         pair(
             stringconcat_expr::<N>(),

--- a/src/parser/xpath/context.rs
+++ b/src/parser/xpath/context.rs
@@ -3,11 +3,11 @@
 use crate::item::Node;
 use crate::parser::combinators::map::map;
 use crate::parser::combinators::tag::tag;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::Transform;
 
 // ContextItemExpr ::= '.'
 pub(crate) fn context_item<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(tag("."), |_| Transform::ContextItem))
 }

--- a/src/parser/xpath/expressions.rs
+++ b/src/parser/xpath/expressions.rs
@@ -3,7 +3,7 @@
 use crate::item::Node;
 use crate::parser::combinators::alt::{alt2, alt5};
 use crate::parser::combinators::map::map;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 //use crate::parser::combinators::debug::inspect;
 use crate::parser::combinators::delimited::delimited;
 use crate::parser::combinators::tag::tag;
@@ -17,13 +17,13 @@ use crate::transform::Transform;
 // PostfixExpr ::= PrimaryExpr (Predicate | ArgumentList | Lookup)*
 // TODO: predicates, arg list, lookup
 pub(crate) fn postfix_expr<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(primary_expr::<N>())
 }
 
 // PrimaryExpr ::= Literal | VarRef | ParenthesizedExpr | ContextItemExpr | FunctionCall | FunctionItemExpr | MapConstructor | ArrayConstructor | UnaryLookup
 // TODO: finish this parser
-fn primary_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+fn primary_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(alt5(
         literal::<N>(),
         context_item::<N>(),
@@ -35,18 +35,18 @@ fn primary_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Tra
 
 // ParenthesizedExpr ::= '(' Expr? ')'
 pub(crate) fn parenthesized_expr<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(alt2(
         parenthesized_expr_empty::<N>(),
         parenthesized_expr_nonempty::<N>(),
     ))
 }
 fn parenthesized_expr_empty<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(tag("()"), |_| Transform::Empty))
 }
 fn parenthesized_expr_nonempty<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(delimited(
         tag("("),
         map(expr_wrapper::<N>(true), |e| e),

--- a/src/parser/xpath/flwr.rs
+++ b/src/parser/xpath/flwr.rs
@@ -11,12 +11,12 @@ use crate::parser::combinators::whitespace::xpwhitespace;
 use crate::parser::xpath::nodetests::qualname_test;
 use crate::parser::xpath::support::get_nt_localname;
 use crate::parser::xpath::{expr_single_wrapper, expr_wrapper};
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::Transform;
 
 // IfExpr ::= 'if' '(' Expr ')' 'then' ExprSingle 'else' ExprSingle
 pub(crate) fn if_expr<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         pair(
             // need tuple15
@@ -48,7 +48,7 @@ pub(crate) fn if_expr<'a, N: Node + 'a>(
 
 // ForExpr ::= SimpleForClause 'return' ExprSingle
 pub(crate) fn for_expr<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         tuple3(
             simple_for_clause::<N>(),
@@ -62,7 +62,7 @@ pub(crate) fn for_expr<'a, N: Node + 'a>(
 // SimpleForClause ::= 'for' SimpleForBinding (',' SimpleForBinding)*
 // SimpleForBinding ::= '$' VarName 'in' ExprSingle
 fn simple_for_clause<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Vec<(String, Transform<N>)>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Vec<(String, Transform<N>)>), ParseError> + 'a> {
     Box::new(map(
         tuple3(
             tag("for"),
@@ -88,7 +88,7 @@ fn simple_for_clause<'a, N: Node + 'a>(
 
 // LetExpr ::= SimpleLetClause 'return' ExprSingle
 pub(crate) fn let_expr<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         tuple3(
             simple_let_clause::<N>(),
@@ -116,7 +116,7 @@ pub(crate) fn let_expr<'a, N: Node + 'a>(
 // SimpleLetBinding ::= '$' VarName ':=' ExprSingle
 // TODO: handle multiple bindings
 fn simple_let_clause<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Vec<(String, Transform<N>)>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Vec<(String, Transform<N>)>), ParseError> + 'a> {
     Box::new(map(
         tuple3(
             tag("let"),

--- a/src/parser/xpath/functions.rs
+++ b/src/parser/xpath/functions.rs
@@ -15,13 +15,13 @@ use crate::parser::xpath::expr_single_wrapper;
 use crate::parser::xpath::expressions::parenthesized_expr;
 use crate::parser::xpath::nodetests::qualname_test;
 use crate::parser::xpath::numbers::unary_expr;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::{NameTest, NodeTest, Transform, WildcardOrName};
 use crate::xdmerror::ErrorKind;
 
 // ArrowExpr ::= UnaryExpr ( '=>' ArrowFunctionSpecifier ArgumentList)*
 pub(crate) fn arrow_expr<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         pair(
             unary_expr::<N>(),
@@ -47,7 +47,7 @@ pub(crate) fn arrow_expr<'a, N: Node + 'a>(
 // ArrowFunctionSpecifier ::= EQName | VarRef | ParenthesizedExpr
 // TODO: finish this parser with EQName and VarRef
 fn arrowfunctionspecifier<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         alt2(
             map(qualname(), |_| ()),
@@ -59,7 +59,7 @@ fn arrowfunctionspecifier<'a, N: Node + 'a>(
 
 // FunctionCall ::= EQName ArgumentList
 pub(crate) fn function_call<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         pair(qualname_test(), argumentlist::<N>()),
         |(qn, mut a)| match qn {
@@ -392,7 +392,7 @@ pub(crate) fn function_call<'a, N: Node + 'a>(
 
 // ArgumentList ::= '(' (Argument (',' Argument)*)? ')'
 // TODO: finish this parser with actual arguments
-fn argumentlist<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Vec<Transform<N>>> + 'a>
+fn argumentlist<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Vec<Transform<N>>), ParseError> + 'a>
 {
     Box::new(map(
         tuple3(
@@ -409,6 +409,6 @@ fn argumentlist<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Vec
 
 // Argument ::= ExprSingle | ArgumentPlaceHolder
 // TODO: ArgumentPlaceHolder
-fn argument<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+fn argument<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(expr_single_wrapper::<N>(true))
 }

--- a/src/parser/xpath/literals.rs
+++ b/src/parser/xpath/literals.rs
@@ -13,7 +13,7 @@ use crate::parser::combinators::pair::pair;
 use crate::parser::combinators::tag::{anychar, tag};
 use crate::parser::combinators::tuple::{tuple3, tuple4};
 use crate::parser::xpath::support::{digit0, digit1, none_of};
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::Transform;
 use crate::value::Value;
 
@@ -21,12 +21,12 @@ use rust_decimal::Decimal;
 
 // Literal ::= NumericLiteral | StringLiteral
 pub(crate) fn literal<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(alt2(numeric_literal::<N>(), string_literal::<N>()))
 }
 
 // NumericLiteral ::= IntegerLiteral | DecimalLiteral | DoubleLiteral
-fn numeric_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a>
+fn numeric_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a>
 {
     Box::new(alt3(
         double_literal::<N>(),
@@ -35,7 +35,7 @@ fn numeric_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<
     ))
 }
 // IntegerLiteral ::= Digits
-fn integer_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a>
+fn integer_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a>
 {
     Box::new(map(digit1(), |s: String| {
         let n = s.parse::<i64>().unwrap();
@@ -44,7 +44,7 @@ fn integer_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<
 }
 // DecimalLiteral ::= ('.' Digits) | (Digits '.' [0-9]*)
 // Construct a double, but if that fails fall back to decimal
-fn decimal_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a>
+fn decimal_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a>
 {
     Box::new(alt2(
         decimal_literal_frac::<N>(),
@@ -52,7 +52,7 @@ fn decimal_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<
     ))
 }
 fn decimal_literal_frac<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(pair(tag("."), digit1()), |(_, mut f)| {
         f.insert(0, '.');
         let n = f.parse::<f64>();
@@ -67,7 +67,7 @@ fn decimal_literal_frac<'a, N: Node + 'a>(
     }))
 }
 fn decimal_literal_comp<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(tuple3(digit1(), tag("."), digit0()), |(w, _, f)| {
         let s = format!("{}.{}", w, f);
         let n = s.parse::<f64>();
@@ -81,12 +81,12 @@ fn decimal_literal_comp<'a, N: Node + 'a>(
 
 // DoubleLiteral ::= (('.' Digits) | (Digits ('.' [0-9]*)?)) [eE] [+-]? Digits
 // Construct a double
-fn double_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+fn double_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(alt2(double_literal_frac::<N>(), double_literal_comp::<N>()))
 }
 
 fn double_literal_frac<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         tuple4(
             pair(tag("."), digit1()),
@@ -105,7 +105,7 @@ fn double_literal_frac<'a, N: Node + 'a>(
     ))
 }
 fn double_literal_comp<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         tuple4(
             tuple3(digit1(), tag("."), digit1()),
@@ -126,7 +126,7 @@ fn double_literal_comp<'a, N: Node + 'a>(
 
 // StringLiteral ::= double- or single-quote delimited with double-delimiter escape
 fn string_literal_double<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         delimited(
             anychar('"'),
@@ -139,7 +139,7 @@ fn string_literal_double<'a, N: Node + 'a>(
     ))
 }
 fn string_literal_single<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         delimited(
             anychar('\''),
@@ -151,7 +151,7 @@ fn string_literal_single<'a, N: Node + 'a>(
         |s| Transform::Literal(Item::Value(Rc::new(Value::from(s)))),
     ))
 }
-fn string_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+fn string_literal<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(alt2(
         string_literal_double::<N>(),
         string_literal_single::<N>(),

--- a/src/parser/xpath/logic.rs
+++ b/src/parser/xpath/logic.rs
@@ -7,12 +7,12 @@ use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::tuple::tuple3;
 use crate::parser::combinators::whitespace::xpwhitespace;
 use crate::parser::xpath::compare::comparison_expr;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::Transform;
 
 // OrExpr ::= AndExpr ('or' AndExpr)*
 pub(crate) fn or_expr<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         separated_list1(
             map(tuple3(xpwhitespace(), tag("or"), xpwhitespace()), |_| ()),
@@ -29,7 +29,7 @@ pub(crate) fn or_expr<'a, N: Node + 'a>(
 }
 
 // AndExpr ::= ComparisonExpr ('and' ComparisonExpr)*
-fn and_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+fn and_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         separated_list1(
             map(tuple3(xpwhitespace(), tag("and"), xpwhitespace()), |_| ()),

--- a/src/parser/xpath/nodetests.rs
+++ b/src/parser/xpath/nodetests.rs
@@ -1,19 +1,20 @@
 //! Functions that produce tests for nodes.
 
+use crate::item::Node;
 use crate::parser::combinators::alt::{alt2, alt5};
 use crate::parser::combinators::map::map;
 use crate::parser::combinators::opt::opt;
 use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::tuple::tuple3;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::{KindTest, NameTest, NodeTest, WildcardOrName};
 //use crate::parser::combinators::debug::inspect;
 use crate::parser::xml::qname::{ncname, qualname};
 
-pub(crate) fn qualname_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+pub(crate) fn qualname_test<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     Box::new(alt2(prefixed_name(), unprefixed_name()))
 }
-fn unprefixed_name() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn unprefixed_name<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     Box::new(map(ncname(), |localpart| {
         NodeTest::Name(NameTest {
             ns: None,
@@ -22,7 +23,7 @@ fn unprefixed_name() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
         })
     }))
 }
-fn prefixed_name() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn prefixed_name<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     Box::new(map(
         tuple3(ncname(), tag(":"), ncname()),
         |(prefix, _, localpart)| {
@@ -37,12 +38,12 @@ fn prefixed_name() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
 
 // NodeTest ::= KindTest | NameTest
 // NameTest ::= EQName | Wildcard
-pub(crate) fn nodetest() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+pub(crate) fn nodetest<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     Box::new(alt2(kindtest(), nametest()))
 }
 
 // KindTest ::= DocumentTest | ElementTest | AttributeTest | SchemaElementTest | SchemaAttributeTest | PITest | CommentTest | TextTest | NamespaceNodeTest | AnyKindTest
-fn kindtest() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn kindtest<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     // Need alt10
     Box::new(alt2(
         alt5(
@@ -62,14 +63,14 @@ fn kindtest() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
     ))
 }
 // DocumentTest ::= "document-node" "(" ElementTest | SchemaElementTest ")"
-fn document_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn document_test<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     // TODO: ElementTest|SchemaElementTest
     Box::new(map(tag("document-node()"), |_| {
         NodeTest::Kind(KindTest::Document)
     }))
 }
 // ElementTest ::= "element" "(" (ElementNameOrWildcard ("," TypeName)?)? ")"
-fn element_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn element_test<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     // TODO: ElementTest|SchemaElementTest
     Box::new(map(
         tuple3(
@@ -84,7 +85,7 @@ fn element_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
     ))
 }
 // SchemaElementTest ::= "schema-element" "(" ElementNameDeclaration ")"
-fn schema_element_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn schema_element_test<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     // TODO: ElementTest|SchemaElementTest
     Box::new(map(
         tuple3(tag("schema-element("), qualname(), tag(")")),
@@ -92,7 +93,7 @@ fn schema_element_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
     ))
 }
 // AttributeTest ::= "attribute" "(" (AttribNameOrWildcard ("," TypeName))? ")"
-fn attribute_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn attribute_test<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     Box::new(map(
         tuple3(
             tag("attribute("),
@@ -106,7 +107,7 @@ fn attribute_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
     ))
 }
 // SchemaAttributeTest ::= "attribute" "(" AttributeDeclaration ")"
-fn schema_attribute_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn schema_attribute_test<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     // TODO: AttributeDeclaration
     Box::new(map(
         tuple3(tag("schema-attribute("), qualname(), tag(")")),
@@ -114,40 +115,40 @@ fn schema_attribute_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
     ))
 }
 // PITest ::= "processing-instruction" "(" (NCName | StringLiteral)? ")"
-fn pi_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn pi_test<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     // TODO: NCName | StringLiteral
     Box::new(map(tag("processing-instruction()"), |_| {
         NodeTest::Kind(KindTest::PI)
     }))
 }
 // CommentTest ::= "comment" "(" ")"
-fn comment_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn comment_test<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     Box::new(map(tag("comment()"), |_| NodeTest::Kind(KindTest::Comment)))
 }
 // TextTest ::= "text" "(" ")"
-fn text_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn text_test<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     Box::new(map(tag("text()"), |_| NodeTest::Kind(KindTest::Text)))
 }
 // NamespaceNodeTest ::= "namespace-node" "(" ")"
-fn namespace_node_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn namespace_node_test<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     Box::new(map(tag("namespace-node()"), |_| {
         NodeTest::Kind(KindTest::Namespace)
     }))
 }
 // NamespaceNodeTest ::= "namespace-node" "(" ")"
-fn any_kind_test() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn any_kind_test<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     Box::new(map(tag("node()"), |_| NodeTest::Kind(KindTest::Any)))
 }
 
 // NameTest ::= EQName | Wildcard
 // TODO: allow EQName rather than QName
-fn nametest() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn nametest<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     Box::new(alt2(qualname_test(), wildcard()))
 }
 
 // Wildcard ::= '*' | (NCName ':*') | ('*:' NCName) | (BracedURILiteral '*')
 // TODO: more specific wildcards
-fn wildcard() -> Box<dyn Fn(ParseInput) -> ParseResult<NodeTest>> {
+fn wildcard<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, NodeTest), ParseError> + 'a> {
     Box::new(map(tag("*"), |_| {
         NodeTest::Name(NameTest {
             ns: Some(WildcardOrName::Wildcard),

--- a/src/parser/xpath/predicates.rs
+++ b/src/parser/xpath/predicates.rs
@@ -6,19 +6,19 @@ use crate::parser::combinators::map::map;
 use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::tuple::tuple3;
 use crate::parser::combinators::whitespace::xpwhitespace;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::Transform;
 //use crate::parser::combinators::debug::inspect;
 use crate::parser::xpath::expr_wrapper;
 
 // PredicateList ::= Predicate*
 pub(crate) fn predicate_list<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(many0(predicate::<N>()), |v| Transform::Compose(v)))
 }
 
 // Predicate ::= "[" expr "]"
-fn predicate<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+fn predicate<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         tuple3(
             map(tuple3(xpwhitespace(), tag("["), xpwhitespace()), |_| ()),

--- a/src/parser/xpath/strings.rs
+++ b/src/parser/xpath/strings.rs
@@ -7,12 +7,12 @@ use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::tuple::tuple3;
 use crate::parser::combinators::whitespace::xpwhitespace;
 use crate::parser::xpath::numbers::range_expr;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::Transform;
 
 // StringConcatExpr ::= RangeExpr ( '||' RangeExpr)*
 pub(crate) fn stringconcat_expr<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         separated_list1(
             map(tuple3(xpwhitespace(), tag("||"), xpwhitespace()), |_| ()),

--- a/src/parser/xpath/support.rs
+++ b/src/parser/xpath/support.rs
@@ -1,7 +1,7 @@
 //! Supporting functions.
 
 use crate::item::Node;
-use crate::parser::{ParseError, ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::{NameTest, NodeTest, Transform, WildcardOrName};
 
 pub(crate) fn get_nt_localname(nt: &NodeTest) -> String {
@@ -16,7 +16,7 @@ pub(crate) fn get_nt_localname(nt: &NodeTest) -> String {
 }
 
 /// Return zero or more digits from the input stream. Be careful not to consume non-digit input.
-pub(crate) fn digit0() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn digit0<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     move |(input, state)| {
         match input.find(|c| !(c >= '0' && c <= '9')) {
             Some(0) => Err(ParseError::Combinator),
@@ -35,7 +35,7 @@ pub(crate) fn digit0() -> impl Fn(ParseInput) -> ParseResult<String> {
     }
 }
 /// Return one or more digits from the input stream.
-pub(crate) fn digit1() -> impl Fn(ParseInput) -> ParseResult<String> {
+pub(crate) fn digit1<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     move |(input, state)| {
         if input.starts_with(|c| (c >= '0' && c <= '9')) {
             match input.find(|c| !(c >= '0' && c <= '9')) {
@@ -50,7 +50,7 @@ pub(crate) fn digit1() -> impl Fn(ParseInput) -> ParseResult<String> {
 }
 
 /// Return the next character if it is not from the given set
-pub(crate) fn none_of(s: &str) -> impl Fn(ParseInput) -> ParseResult<char> + '_ {
+pub(crate) fn none_of<N: Node>(s: &str) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, char), ParseError> + '_ {
     move |(input, state)| {
         if input.is_empty() {
             Err(ParseError::Combinator)
@@ -64,6 +64,6 @@ pub(crate) fn none_of(s: &str) -> impl Fn(ParseInput) -> ParseResult<char> + '_ 
     }
 }
 
-pub(crate) fn noop<N: Node>() -> impl Fn(ParseInput) -> ParseResult<Transform<N>> {
+pub(crate) fn noop<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> {
     move |_| Err(ParseError::Combinator)
 }

--- a/src/parser/xpath/types.rs
+++ b/src/parser/xpath/types.rs
@@ -9,12 +9,12 @@ use crate::parser::combinators::tuple::tuple6;
 use crate::parser::combinators::whitespace::xpwhitespace;
 use crate::parser::xpath::functions::arrow_expr;
 use crate::parser::xpath::nodetests::qualname_test;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::Transform;
 
 // InstanceOfExpr ::= TreatExpr ( 'instance' 'of' SequenceType)?
 pub(crate) fn instanceof_expr<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         pair(
             treat_expr::<N>(),
@@ -39,7 +39,7 @@ pub(crate) fn instanceof_expr<'a, N: Node + 'a>(
 
 // SequenceType ::= ( 'empty-sequence' '(' ')' | (ItemType OccurrenceIndicator?)
 // TODO: implement this parser fully
-fn sequencetype_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a>
+fn sequencetype_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a>
 {
     Box::new(map(tag("empty-sequence()"), |_| {
         Transform::NotImplemented("sequencetype_expr".to_string())
@@ -47,7 +47,7 @@ fn sequencetype_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResul
 }
 
 // TreatExpr ::= CastableExpr ( 'treat' 'as' SequenceType)?
-fn treat_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+fn treat_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         pair(
             castable_expr::<N>(),
@@ -71,7 +71,7 @@ fn treat_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Trans
 }
 
 // CastableExpr ::= CastExpr ( 'castable' 'as' SingleType)?
-fn castable_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+fn castable_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         pair(
             cast_expr::<N>(),
@@ -107,7 +107,7 @@ fn castable_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Tr
 // NCName ::= Name - (Char* ':' Char*)
 // Char ::= #x9 | #xA |#xD | [#x20-#xD7FF] | [#xE000-#xFFFD | [#x10000-#x10FFFF]
 // TODO: implement this parser fully
-fn singletype_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a>
+fn singletype_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a>
 {
     Box::new(map(pair(qualname_test(), tag("?")), |_| {
         Transform::NotImplemented("singletype_expr".to_string())
@@ -115,7 +115,7 @@ fn singletype_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<
 }
 
 // CastExpr ::= ArrowExpr ( 'cast' 'as' SingleType)?
-fn cast_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+fn cast_expr<'a, N: Node + 'a>() -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(
         pair(
             arrow_expr::<N>(),

--- a/src/parser/xpath/variables.rs
+++ b/src/parser/xpath/variables.rs
@@ -7,12 +7,12 @@ use crate::parser::combinators::tag::tag;
 //use crate::parser::combinators::debug::inspect;
 use crate::parser::xpath::nodetests::qualname_test;
 use crate::parser::xpath::support::get_nt_localname;
-use crate::parser::{ParseInput, ParseResult};
+use crate::parser::{ParseError, ParseInput};
 use crate::transform::Transform;
 
 // VarRef ::= '$' VarName
 pub(crate) fn variable_reference<'a, N: Node + 'a>(
-) -> Box<dyn Fn(ParseInput) -> ParseResult<Transform<N>> + 'a> {
+) -> Box<dyn Fn(ParseInput<N>) -> Result<(ParseInput<N>, Transform<N>), ParseError> + 'a> {
     Box::new(map(pair(tag("$"), qualname_test()), |(_, qn)| {
         Transform::VariableReference(get_nt_localname(&qn))
     }))

--- a/src/qname.rs
+++ b/src/qname.rs
@@ -7,6 +7,7 @@ use core::hash::{Hash, Hasher};
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Formatter;
+use crate::trees::nullo::Nullo;
 
 #[derive(Clone, Debug)]
 pub struct QualifiedName {
@@ -90,7 +91,7 @@ impl Hash for QualifiedName {
 impl TryFrom<&str> for QualifiedName {
     type Error = Error;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        let state = ParserState::new(None, None);
+        let state: ParserState<Nullo> = ParserState::new(None, None, None);
         match qualname()((s, state)) {
             Ok((_, qn)) => Ok(qn),
             Err(_) => Err(Error::new(

--- a/src/testutils/pattern_tests.rs
+++ b/src/testutils/pattern_tests.rs
@@ -13,7 +13,7 @@ macro_rules! pattern_tests (
             let p: Pattern<$t> = Pattern::try_from(".[self::a]").expect("unable to parse \".[self::a]\"");
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $x();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -42,7 +42,7 @@ macro_rules! pattern_tests (
             let p: Pattern<$t> = Pattern::try_from(".[self::a]").expect("unable to parse \".[self::a]\"");
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $x();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -72,7 +72,7 @@ macro_rules! pattern_tests (
 		let p: Pattern<$t> = Pattern::try_from("/").expect("unable to parse \"/\"");
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $x();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -101,7 +101,7 @@ macro_rules! pattern_tests (
 		let p: Pattern<$t> = Pattern::try_from("/").expect("unable to parse \"/\"");
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $x();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -130,7 +130,7 @@ macro_rules! pattern_tests (
             let p: Pattern<$t> = Pattern::try_from("child::a").expect("unable to parse \"child::a\"");
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $x();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -159,7 +159,7 @@ macro_rules! pattern_tests (
             let p: Pattern<$t> = Pattern::try_from("child::a").expect("unable to parse \"child::a\"");
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $x();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -189,7 +189,7 @@ macro_rules! pattern_tests (
 			.expect("unable to parse \"child::Test/child::a\"");
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $x();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -218,7 +218,7 @@ macro_rules! pattern_tests (
             let p: Pattern<$t> = Pattern::try_from("child::Test/child::a").expect("unable to parse \"child::Test/child::a\"");
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $x();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("NotATest")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -245,10 +245,9 @@ macro_rules! pattern_tests (
 	#[test]
 	fn pattern_sel_text_kind_1_pos() {
             let p: Pattern<$t> = Pattern::try_from("child::text()").expect("unable to parse \"child::text()\"");
-			eprintln!("pattern {}", p);
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $x();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())

--- a/src/testutils/transform_tests.rs
+++ b/src/testutils/transform_tests.rs
@@ -216,7 +216,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_set_attribute() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut n = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(n.clone())
@@ -261,7 +261,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_copy_context_node() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut n = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(n.clone())
@@ -289,7 +289,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_deep_copy() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut n = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(n.clone())
@@ -451,7 +451,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_root() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut n = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(n.clone())
@@ -495,7 +495,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut n = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(n.clone())
@@ -524,7 +524,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut n = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(n.clone())
@@ -570,7 +570,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut n = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(n.clone())
@@ -622,7 +622,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut n = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(n.clone())
@@ -666,7 +666,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut n = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(n.clone())
@@ -712,7 +712,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut n = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(n.clone())
@@ -764,7 +764,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut n = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(n.clone())
@@ -798,7 +798,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -833,7 +833,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -876,7 +876,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -919,7 +919,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -962,7 +962,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1005,7 +1005,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1049,7 +1049,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1097,7 +1097,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1145,7 +1145,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1206,7 +1206,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1277,7 +1277,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1332,7 +1332,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1383,7 +1383,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1434,7 +1434,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1498,7 +1498,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1729,7 +1729,7 @@ macro_rules! transform_tests (
 	    );
 
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -1774,7 +1774,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_for_each() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to element node");
 	    sd.push(t.clone())
@@ -1899,7 +1899,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_apply_templates_builtins() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_text(Rc::new(Value::from("Test")))
 		.expect("unable to text node");
 	    sd.push(t.clone())
@@ -1944,7 +1944,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_apply_templates_1() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create new element");
 	    sd.push(t.clone());
@@ -2010,7 +2010,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_apply_templates_2() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create new element");
 	    sd.push(t.clone());
@@ -2077,7 +2077,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_apply_templates_import() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create new element");
 	    sd.push(t.clone());
@@ -2158,7 +2158,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_apply_templates_next_match() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create new element");
 	    sd.push(t.clone());
@@ -2325,7 +2325,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_localname_0() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())
@@ -2353,7 +2353,7 @@ macro_rules! transform_tests (
 	#[test]
 	fn tr_name_0() {
 	    // Setup a source document
-	    let mut sd = NodeBuilder::new(NodeType::Document).build();
+	    let mut sd = $y();
 	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
 		.expect("unable to create element");
 	    sd.push(t.clone())

--- a/src/testutils/xpath_tests.rs
+++ b/src/testutils/xpath_tests.rs
@@ -26,8 +26,9 @@ macro_rules! xpath_tests (
 	fn xpath_path_1_pos() {
 		let ev = parse::<$t>("/child::a").expect("not an XPath expression");
 	    let rd = $x();
+		let sd = $y();
 	    let mut ctxt = ContextBuilder::new()
-		.current(vec![$y()])
+		.current(vec![sd])
 		.result_document(rd)
 		.build();
 	    let seq = ctxt.dispatch(&mut StaticContext::<F>::new(), &ev).expect("evaluation failed");

--- a/src/transform/datetime.rs
+++ b/src/transform/datetime.rs
@@ -41,7 +41,7 @@ pub fn format_date_time<N: Node, F: FnMut(&str) -> Result<(), Error>>(
     _place: &Option<Box<Transform<N>>>,
 ) -> Result<Sequence<N>, Error> {
     let dt = ctxt.dispatch(stctxt, value)?;
-    let pic = picture_parse(&ctxt.dispatch(stctxt, picture)?.to_string())?;
+    let pic = picture_parse::<N>(&ctxt.dispatch(stctxt, picture)?.to_string())?;
     match dt.len() {
         0 => Ok(vec![]), // Empty value returns empty sequence
         1 => {
@@ -92,7 +92,7 @@ pub fn format_date<N: Node, F: FnMut(&str) -> Result<(), Error>>(
     _place: &Option<Box<Transform<N>>>,
 ) -> Result<Sequence<N>, Error> {
     let dt = ctxt.dispatch(stctxt, value)?;
-    let pic = picture_parse(&ctxt.dispatch(stctxt, picture)?.to_string())?;
+    let pic = picture_parse::<N>(&ctxt.dispatch(stctxt, picture)?.to_string())?;
     match dt.len() {
         0 => Ok(vec![]), // Empty value returns empty sequence
         1 => {
@@ -144,7 +144,7 @@ pub fn format_time<N: Node, F: FnMut(&str) -> Result<(), Error>>(
     _place: &Option<Box<Transform<N>>>,
 ) -> Result<Sequence<N>, Error> {
     let dt = ctxt.dispatch(stctxt, value)?;
-    let pic = picture_parse(&ctxt.dispatch(stctxt, picture)?.to_string())?;
+    let pic = picture_parse::<N>(&ctxt.dispatch(stctxt, picture)?.to_string())?;
     match dt.len() {
         0 => Ok(vec![]), // Empty value returns empty sequence
         1 => {

--- a/src/transform/navigate.rs
+++ b/src/transform/navigate.rs
@@ -17,12 +17,14 @@ pub(crate) fn root<N: Node>(ctxt: &Context<N>) -> Result<Sequence<N>, Error> {
         // TODO: check all context items.
         // If any of them is not a Node then error.
         match &ctxt.cur[0] {
-            Item::Node(n) => match n.node_type() {
-                NodeType::Document => Ok(vec![Item::Node(n.clone())]),
-                _ => n
-                    .ancestor_iter()
-                    .last()
-                    .map_or(Ok(vec![]), |m| Ok(vec![Item::Node(m)])),
+            Item::Node(n) => {
+                match n.node_type() {
+                    NodeType::Document => Ok(vec![Item::Node(n.clone())]),
+                    _ => n
+                        .ancestor_iter()
+                        .last()
+                        .map_or(Ok(vec![]), |m| Ok(vec![Item::Node(m)])),
+                }
             },
             _ => Err(Error::new(
                 ErrorKind::ContextNotNode,

--- a/src/trees/mod.rs
+++ b/src/trees/mod.rs
@@ -6,3 +6,4 @@ pub mod intmuttree;
 /// Interior Mutability Tuple-Struct with Enum.
 /// This tree implementation is an evolution of intmuttree that represents each type of node as variants in an enum, wrapped in a tuple struct.
 pub mod smite;
+pub(crate) mod nullo;

--- a/src/trees/nullo.rs
+++ b/src/trees/nullo.rs
@@ -1,0 +1,129 @@
+/// A null tree implementation
+///
+/// This tree implementation implements nothing.
+/// The parser combinator is generic in [Node].
+/// Occasionally, a module using the parser, but not needing a [Node],
+/// nevertheless requires a concrete type that has the [Node] trait.
+
+use std::rc::Rc;
+use std::cmp::Ordering;
+use crate::xdmerror::{Error, ErrorKind};
+use crate::item::{Node, NodeType};
+use crate::output::OutputDefinition;
+use crate::qname::QualifiedName;
+use crate::value::Value;
+use crate::xmldecl::{XMLDecl, XMLDeclBuilder};
+
+#[derive(Clone)]
+pub struct Nullo();
+
+impl Node for Nullo {
+    type NodeIterator = Box<dyn Iterator<Item = Nullo>>;
+
+    fn node_type(&self) -> NodeType {
+        NodeType::Unknown
+    }
+    fn name(&self) -> QualifiedName {
+        QualifiedName::new(None, None, String::new())
+    }
+    fn value(&self) -> Rc<Value> {
+        Rc::new(Value::from(""))
+    }
+    fn to_string(&self) -> String {
+        String::new()
+    }
+    fn to_xml(&self) -> String {
+        String::new()
+    }
+    fn to_xml_with_options(&self, _: &OutputDefinition) -> String {
+        String::new()
+    }
+    fn to_json(&self) -> String {
+        String::new()
+    }
+    fn is_same(&self, _: &Self) -> bool {
+        false
+    }
+    fn document_order(&self) -> Vec<usize> {
+        vec![]
+    }
+    fn cmp_document_order(&self, _: &Self) -> Ordering {
+        Ordering::Equal
+    }
+    fn is_element(&self) -> bool {
+        false
+    }
+    fn child_iter(&self) -> Self::NodeIterator {
+        Box::new(NulloIter::new())
+    }
+    fn ancestor_iter(&self) -> Self::NodeIterator { Box::new(NulloIter::new()) }
+    fn descend_iter(&self) -> Self::NodeIterator { Box::new(NulloIter::new()) }
+    fn next_iter(&self) -> Self::NodeIterator {
+        Box::new(NulloIter::new())
+    }
+    fn prev_iter(&self) -> Self::NodeIterator {
+        Box::new(NulloIter::new())
+    }
+    fn attribute_iter(&self) -> Self::NodeIterator {
+        Box::new(NulloIter::new())
+    }
+    fn get_attribute(&self, _: &QualifiedName) -> Rc<Value> {
+        Rc::new(Value::from(""))
+    }
+    fn owner_document(&self) -> Self {
+        self.clone()
+    }
+    fn get_canonical(&self) -> Result<Self, Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn new_element(&self, _: QualifiedName) -> Result<Self, Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn new_text(&self, _: Rc<Value>) -> Result<Self, Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn new_attribute(&self, _: QualifiedName, _: Rc<Value>) -> Result<Self, Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn new_comment(&self, _: Rc<Value>) -> Result<Self, Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn new_processing_instruction(&self, _: QualifiedName, _: Rc<Value>) -> Result<Self, Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn push(&mut self, _: Self) -> Result<(), Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn pop(&mut self) -> Result<(), Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn insert_before(&mut self, _: Self) -> Result<(), Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn add_attribute(&self, _: Self) -> Result<(), Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn shallow_copy(&self) -> Result<Self, Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn deep_copy(&self) -> Result<Self, Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+    fn xmldecl(&self) -> XMLDecl {
+        XMLDeclBuilder::new().build()
+    }
+    fn set_xmldecl(&mut self, _: XMLDecl) -> Result<(), Error> {
+        Err(Error::new(ErrorKind::NotImplemented, String::from("not implemented")))
+    }
+}
+
+pub struct NulloIter();
+impl NulloIter {
+    fn new() -> Self {NulloIter()}
+}
+impl Iterator for NulloIter {
+    type Item = Nullo;
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}

--- a/src/trees/smite.rs
+++ b/src/trees/smite.rs
@@ -56,7 +56,7 @@ use std::rc::{Rc, Weak};
 pub type RNode = Rc<Node>;
 
 enum NodeInner {
-    Document(RefCell<Option<XMLDecl>>, RefCell<Vec<RNode>>), // to be well-formed, only one of these can be an element-type node
+    Document(RefCell<Option<XMLDecl>>, RefCell<Vec<RNode>>, RefCell<Vec<RNode>>), // to be well-formed, only one of these can be an element-type node
     Element(
         RefCell<Weak<Node>>, // Parent: must be a Document or an Element
         Rc<QualifiedName>, // name
@@ -73,7 +73,7 @@ pub struct Node(NodeInner);
 impl Node {
     /// Only documents are created new. All other types of nodes are created using new_* methods.
     pub fn new() -> Self {
-        Node(NodeInner::Document(RefCell::new(None), RefCell::new(vec![])))
+        Node(NodeInner::Document(RefCell::new(None), RefCell::new(vec![]), RefCell::new(vec![])))
     }
     pub fn set_nsuri(&mut self, uri: String) -> Result<(), Error>{
         match &self.0 {
@@ -97,7 +97,7 @@ impl ItemNode for RNode {
 
     fn node_type(&self) -> NodeType {
         match &self.0 {
-            NodeInner::Document(_, _) => NodeType::Document,
+            NodeInner::Document(_, _, _) => NodeType::Document,
             NodeInner::Element(_, _, _, _) => NodeType::Element,
             NodeInner::Attribute(_, _, _) => NodeType::Attribute,
             NodeInner::Text(_, _) => NodeType::Text,
@@ -127,7 +127,7 @@ impl ItemNode for RNode {
     }
     fn to_string(&self) -> String {
         match &self.0 {
-            NodeInner::Document(_, c) |
+            NodeInner::Document(_, c, _) |
             NodeInner::Element(_, _, _, c) => c.borrow().iter()
                 .fold(String::new(), |mut acc, n| {acc.push_str(n.to_string().as_str()); acc}),
             NodeInner::Attribute(_, _, v) |
@@ -152,7 +152,7 @@ impl ItemNode for RNode {
     // There is always a document node, so this will not panic.
     fn owner_document(&self) -> Self {
         match &self.0 {
-            NodeInner::Document(_, _) => self.clone(),
+            NodeInner::Document(_, _, _) => self.clone(),
             _ => self.ancestor_iter().last().unwrap()
         }
     }
@@ -205,53 +205,59 @@ impl ItemNode for RNode {
         }
     }
     fn new_element(&self, qn: QualifiedName) -> Result<Self, Error> {
-        let child = Rc::new(Node ( NodeInner::Element (RefCell::new(Rc::downgrade(self)), Rc::new(qn), RefCell::new(HashMap::new()), RefCell::new(vec![]))));
-        push_node(self, child.clone())?;
+        let child = Rc::new(Node ( NodeInner::Element (RefCell::new(Rc::downgrade(&self.owner_document())), Rc::new(qn), RefCell::new(HashMap::new()), RefCell::new(vec![]))));
+        unattached(self, child.clone());
         Ok(child)
     }
     fn new_text(&self, v: Rc<Value>) -> Result<Self, Error> {
-        let child = Rc::new(Node ( NodeInner::Text (RefCell::new(Rc::downgrade(self)), v)));
-        push_node(self, child.clone())?;
+        let child = Rc::new(Node ( NodeInner::Text (RefCell::new(Rc::downgrade(&self.owner_document())), v)));
+        unattached(self, child.clone());
         Ok(child)
     }
     fn new_attribute(&self, qn: QualifiedName, v: Rc<Value>) -> Result<Self, Error> {
         let att = Rc::new(Node ( NodeInner::Attribute (RefCell::new(Rc::downgrade(self)), Rc::new(qn.clone()), v)));
-        match &self.0 {
-            NodeInner::Element(_, _, patt, _) => patt.borrow_mut().insert(Rc::new(qn), att.clone()),
-            _ => return Err(Error::new(ErrorKind::TypeError, String::from("unable to add attribute node"))),
-        };
+        unattached(self, att.clone());
         Ok(att)
     }
     fn new_comment(&self, v: Rc<Value>) -> Result<Self, Error> {
-        let child = Rc::new(Node ( NodeInner::Comment (RefCell::new(Rc::downgrade(self)), v)));
-        push_node(self, child.clone())?;
+        let child = Rc::new(Node ( NodeInner::Comment (RefCell::new(Rc::downgrade(&self.owner_document())), v)));
+        unattached(self, child.clone());
         Ok(child)
     }
     fn new_processing_instruction(&self, qn: QualifiedName, v: Rc<Value>) -> Result<Self, Error> {
-        let child = Rc::new(Node ( NodeInner::ProcessingInstruction (RefCell::new(Rc::downgrade(self)), Rc::new(qn.clone()), v)));
-        push_node(self, child.clone())?;
+        let child = Rc::new(Node ( NodeInner::ProcessingInstruction (RefCell::new(Rc::downgrade(&self.owner_document())), Rc::new(qn.clone()), v)));
+        unattached(self, child.clone());
         Ok(child)
     }
     // Append a node to the child list of the new parent.
     // Must first detach the node from its current position in the tree.
     fn push(&mut self, n: Self) -> Result<(), Error> {
+        if n.node_type() == NodeType::Document ||
+            n.node_type() == NodeType::Attribute {
+            return Err(Error::new(ErrorKind::TypeError, String::from("document or attribute type nodes cannot be inserted as a child")))
+        }
+
         let mut m = n.clone();
         m.pop()?;
         push_node(self, n)?;
         Ok(())
     }
-    // Remove a node from the tree. If the node is unattached (i.e. ?), then this has no effect.
-    // In this implementation, nodes always have a parent, so create a temporary tree. But where does the tmp tree go? i.e. who owns it?
-    // Leave the parent field in the child unchanged, which is invalid. But the node is no longer accessible from the tree.
+    // Remove a node from the tree. If the node is unattached, then this has no effect.
+    // The node is added to the unattached list of the owner document.
     fn pop(&mut self) -> Result<(), Error> {
         match &self.0 {
-            NodeInner::Document(_, _) => return Err(Error::new(ErrorKind::TypeError, String::from("cannot remove document node"))),
+            NodeInner::Document(_, _, _) => return Err(Error::new(ErrorKind::TypeError, String::from("cannot remove document node"))),
             NodeInner::Attribute(parent, qn, _) => {
                 // Remove this node from the attribute hashmap
                 match Weak::upgrade(&parent.borrow()) {
                     Some(p) => {
                         match &p.0 {
-                            NodeInner::Element(_, _, att, _) => att.borrow_mut().remove(qn).ok_or(Error::new(ErrorKind::DynamicAbsent, String::from("unable to find attribute")))?,
+                            NodeInner::Element(_, _, att, _) => {
+                                att.borrow_mut().remove(qn).ok_or(Error::new(ErrorKind::DynamicAbsent, String::from("unable to find attribute")))?;
+                                let doc = self.owner_document();
+                                unattached(&doc, self.clone());
+                            },
+                            NodeInner::Document(_, _, _) => {}, // attr was in the unattached list
                             _ => return Err(Error::new(ErrorKind::TypeError, String::from("parent is not an element")))
                         }
                     }
@@ -263,17 +269,20 @@ impl ItemNode for RNode {
             NodeInner::Comment(parent, _) |
             NodeInner::ProcessingInstruction(parent, _, _) => {
                 // Remove this node from the old parent's child list
-                match Weak::upgrade(&parent.borrow()) {
-                    Some(p) => {
-                        match &p.0 {
-                            NodeInner::Element(_, _, _, c) => {
-                                let idx = find_index(&p, self)?;
-                                c.borrow_mut().remove(idx)
-                            }
-                            _ => return Err(Error::new(ErrorKind::TypeError, String::from("parent is not an element")))
-                        }
+                let p = if let Some(q) = Weak::upgrade(&parent.borrow()) {
+                    q
+                } else {
+                    return Err(Error::new(ErrorKind::Unknown, String::from("unable to access parent")))
+                };
+                match &p.0 {
+                    NodeInner::Element(_, _, _, c) => {
+                        let idx = find_index(&p, self)?;
+                        c.borrow_mut().remove(idx);
+                        let doc = self.owner_document();
+                        unattached(&doc, self.clone())
                     }
-                    None => return Err(Error::new(ErrorKind::Unknown, String::from("unable to find parent")))
+                    NodeInner::Document(_, _, _) => {}, // node was in the unattached list
+                    _ => return Err(Error::new(ErrorKind::TypeError, String::from("parent is not an element")))
                 }
             }
         };
@@ -287,11 +296,15 @@ impl ItemNode for RNode {
                 // Firstly, make sure the node is removed from its old parent
                 let mut m = att.clone();
                 m.pop()?;
+                // Popping will put the node in the unattached list,
+                // so remove it from there
+                detach(att.clone());
                 // Now add to this parent
                 // TODO: deal with same name being redefined
                 if let NodeInner::Attribute(_, qn, _) = &att.0 {
-                    let _ = patt.borrow_mut().insert(qn.clone(), att);
+                    let _ = patt.borrow_mut().insert(qn.clone(), att.clone());
                 }
+                make_parent(att, self.clone());
                 Ok(())
             }
             _ => Err(Error::new(ErrorKind::TypeError, String::from("cannot add an attribute to this type of node"))),
@@ -303,6 +316,7 @@ impl ItemNode for RNode {
         // Detach from current location
         let mut m = n.clone();
         m.pop()?;
+        detach(n.clone());
         // Now insert into parent's child list
         match &self.0 {
             NodeInner::Element(p, _, _, _) |
@@ -312,9 +326,10 @@ impl ItemNode for RNode {
                 let parent = Weak::upgrade(&p.borrow()).unwrap();
                 let idx = find_index(&parent, self)?;
                 match &parent.0 {
-                    NodeInner::Document(_, children) |
+                    NodeInner::Document(_, children, _) |
                     NodeInner::Element(_, _, _, children) => {
-                        children.borrow_mut().insert(idx, n)
+                        children.borrow_mut().insert(idx, n.clone());
+                        make_parent(n, parent.clone())
                     }
                     _ => return Err(Error::new(ErrorKind::TypeError, String::from("parent is not an element")))
                 }
@@ -325,7 +340,7 @@ impl ItemNode for RNode {
     }
     fn shallow_copy(&self) -> Result<Self, Error> {
         match &self.0 {
-            NodeInner::Document(x, _) => Ok(Rc::new(Node(NodeInner::Document(x.clone(), RefCell::new(vec![]))))),
+            NodeInner::Document(x, _, _) => Ok(Rc::new(Node(NodeInner::Document(x.clone(), RefCell::new(vec![]), RefCell::new(vec![]))))),
             NodeInner::Element(p, qn, _, _) => Ok(Rc::new(Node(NodeInner::Element(p.clone(), qn.clone(), RefCell::new(HashMap::new()), RefCell::new(vec![]))))),
             NodeInner::Attribute(p, qn, v) => Ok(Rc::new(Node(NodeInner::Attribute(p.clone(), qn.clone(), v.clone())))),
             NodeInner::Text(p, v) => Ok(Rc::new(Node(NodeInner::Text(p.clone(), v.clone())))),
@@ -347,7 +362,7 @@ impl ItemNode for RNode {
     }
     fn get_canonical(&self) -> Result<Self, Error> {
         match &self.0 {
-            NodeInner::Document(_, _) |
+            NodeInner::Document(_, _, _) |
             NodeInner::Comment(_, _) |
             NodeInner::ProcessingInstruction(_, _, _) => Err(Error::new(ErrorKind::TypeError, "invalid node type".to_string())),
             NodeInner::Text(_, v) => {
@@ -377,7 +392,7 @@ impl ItemNode for RNode {
     }
     fn set_xmldecl(&mut self, decl: XMLDecl) -> Result<(), Error> {
         match &self.0 {
-            NodeInner::Document(x, _) => {
+            NodeInner::Document(x, _, _) => {
                 *x.borrow_mut() = Some(decl);
                 Ok(())
             }
@@ -387,7 +402,7 @@ impl ItemNode for RNode {
     }
     fn xmldecl(&self) -> XMLDecl {
         match &self.0 {
-            NodeInner::Document(d, _) => d.borrow().clone().map_or_else(|| XMLDeclBuilder::new().build(), |x| x.clone()),
+            NodeInner::Document(d, _, _) => d.borrow().clone().map_or_else(|| XMLDeclBuilder::new().build(), |x| x.clone()),
             _ => {
                 self.owner_document().xmldecl()
             },
@@ -398,7 +413,7 @@ impl ItemNode for RNode {
 impl Debug for Node {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self.0 {
-            NodeInner::Document(_, _) => write!(f, "document"),
+            NodeInner::Document(_, _, _) => write!(f, "document"),
             NodeInner::Element(_, qn, _, _) => write!(f, "element-type node \"{}\"", qn.to_string()),
             NodeInner::Attribute(_, qn, _) => write!(f, "attribute-type node \"{}\"", qn.to_string()),
             NodeInner::Text(_, v) => write!(f, "text-type node \"{}\"", v.to_string()),
@@ -408,26 +423,87 @@ impl Debug for Node {
     }
 }
 
+// Put the given node in the unattached list for the document "d".
+// This is for use when the node is newly created.
+fn unattached(d: &RNode, n: RNode) {
+    match &d.0 {
+        NodeInner::Document(_, _, u) => {
+            u.borrow_mut().push(n.clone());
+            make_parent(n, d.clone())
+        }
+        NodeInner::Element(_, _, _, _) => {
+            let doc = d.owner_document();
+            if let NodeInner::Document(_, _, u) = &doc.0 {
+                u.borrow_mut().push(n.clone());
+                make_parent(n, doc.clone())
+            } else {
+                panic!("cannot find document node")
+            }
+        }
+        _ => panic!("not a document node"),
+    }
+}
+// Make the parent of the node be the given new parent
+fn make_parent(n: RNode, b: RNode) {
+    match &n.0 {
+        NodeInner::Element(p, _, _, _) |
+        NodeInner::Attribute(p, _, _) |
+        NodeInner::Text(p, _) |
+        NodeInner::Comment(p, _) |
+        NodeInner::ProcessingInstruction(p, _, _) => {
+            *p.borrow_mut() = Rc::downgrade(&b)
+        }
+        _ => panic!("unable to change parent"),
+    }
+}
+// Remove an unattached node from the unattached list.
+// This is in preparation for it being added to the tree.
+fn detach(n: RNode) {
+    match &n.0 {
+        NodeInner::Element(p, _, _, _) |
+        NodeInner::Attribute(p, _, _) |
+        NodeInner::Text(p, _) |
+        NodeInner::Comment(p, _) |
+        NodeInner::ProcessingInstruction(p, _, _) => {
+            let doc = Weak::upgrade(&p.borrow()).unwrap();
+            match &doc.0 {
+                        NodeInner::Document(_, _, u) => {
+                            let i = u.borrow().iter().position(|x| Rc::ptr_eq(x, &n));
+                            match i {
+                                Some(i) => {
+                                    u.borrow_mut().remove(i);
+                                }
+                                None => {} // nothing to do. should this be an error?
+                            }
+                        }
+                        _ => panic!("not a document")
+            }
+        }
+        _ => panic!("unable to change parent"),
+    }
+}
+
 fn push_node(parent: &RNode, child: RNode) -> Result<(), Error> {
     if child.node_type() == NodeType::Attribute || child.node_type() == NodeType::Document {
         return Err(Error::new(ErrorKind::TypeError, String::from("cannot append an attribute or document node as a child node")))
     }
     match &parent.0 {
-        NodeInner::Document(_, c) => {
-            c.borrow_mut().push(child);
+        NodeInner::Document(_, c, _) => {
+            c.borrow_mut().push(child.clone());
         }
         NodeInner::Element(_, _, _, c) => {
-            c.borrow_mut().push(child);
+            c.borrow_mut().push(child.clone());
         }
         _ => return Err(Error::new(ErrorKind::TypeError, String::from("unable to add child node"))),
     }
+    make_parent(child, parent.clone());
     Ok(())
 }
 
 // Find the document order of ancestors
 fn doc_order(n: &RNode) -> Vec<usize> {
     match &n.0 {
-        NodeInner::Document(_, _) => vec![1 as usize],
+        NodeInner::Document(_, _, _) => vec![1 as usize],
         NodeInner::Attribute(_, _, _) => {
             let mut a = doc_order(&n.parent().unwrap());
             a.push(2);
@@ -453,7 +529,7 @@ fn doc_order(n: &RNode) -> Vec<usize> {
 // Find the position of this node in the parent's child list.
 fn find_index(parent: &RNode, child: &RNode) -> Result<usize, Error> {
     let idx = match &parent.0 {
-        NodeInner::Document(_, c) |
+        NodeInner::Document(_, c, _) |
         NodeInner::Element(_, _, _, c) => {
             c.borrow().iter()
                 .enumerate()
@@ -486,7 +562,7 @@ fn to_xml_int(
     indent: usize,
 ) -> String {
     match &node.0 {
-        NodeInner::Document(_, _) => node
+        NodeInner::Document(_, _, _) => node
             .child_iter()
             .fold(String::new(), |mut result, c| {
                 result.push_str(to_xml_int(&c, od, ns.clone(), indent + 2).as_str());
@@ -612,7 +688,7 @@ pub struct Children {
 impl Children {
     fn new(n: &RNode) -> Self {
         match &n.0 {
-            NodeInner::Document(_, c) |
+            NodeInner::Document(_, c, _) |
             NodeInner::Element(_, _, _, c) => Children {
                 v: c.borrow().clone(),
                 i: 0,
@@ -650,7 +726,7 @@ impl Iterator for Ancestors {
 
     fn next(&mut self) -> Option<RNode> {
         let parent = match &self.cur.0 {
-            NodeInner::Document(_, _) => None,
+            NodeInner::Document(_, _, _) => None,
             NodeInner::Element(p, _, _, _) |
             NodeInner::Attribute(p, _, _) |
             NodeInner::Text(p, _) |
@@ -780,13 +856,13 @@ mod tests {
     use crate::xmldecl::XMLDeclBuilder;
 
     #[test]
-    fn newnode_new() {
+    fn smite_new() {
         let _ = Node::new();
         assert!(true)
     }
 
     #[test]
-    fn newnode_xmldecl() {
+    fn smite_xmldecl() {
         let mut d = Rc::new(Node::new());
         let x = XMLDeclBuilder::new()
             .version(String::from("1.1"))
@@ -795,19 +871,22 @@ mod tests {
         assert!(true)
     }
     #[test]
-    fn newnode_element_1() {
-        let root = Rc::new(Node::new());
-        root.new_element(QualifiedName::new(None, None, String::from("Test")))
+    fn smite_element_1() {
+        let mut root = Rc::new(Node::new());
+        let c = root.new_element(QualifiedName::new(None, None, String::from("Test")))
             .expect("unable to create element node");
+        root.push(c).expect("unable to add node");
         assert_eq!(root.to_xml(), "<Test></Test>")
     }
     #[test]
-    fn newnode_element_2() {
-        let root = Rc::new(Node::new());
-        let child1 = root.new_element(QualifiedName::new(None, None, String::from("Test")))
+    fn smite_element_2() {
+        let mut root = Rc::new(Node::new());
+        let mut child1 = root.new_element(QualifiedName::new(None, None, String::from("Test")))
             .expect("unable to create element node");
-        child1.new_element(QualifiedName::new(None, None, String::from("MoreTest")))
+        root.push(child1.clone()).expect("unable to add node");
+        let child2 = child1.new_element(QualifiedName::new(None, None, String::from("MoreTest")))
             .expect("unable to create child element");
+        child1.push(child2).expect("unable to add node");
         assert_eq!(root.to_xml(), "<Test><MoreTest></MoreTest></Test>")
     }
 

--- a/tests/intmuttree.rs
+++ b/tests/intmuttree.rs
@@ -36,20 +36,17 @@ fn make_sd_raw() -> RNode {
 }
 fn make_sd() -> Item<RNode> {
     let r = make_sd_raw();
-    let e = r.clone();
-    let mut d = NodeBuilder::new(NodeType::Document).build();
-    d.push(e).expect("unable to append node");
-    Item::Node(d)
+    //let e = r.clone();
+    //let mut d = NodeBuilder::new(NodeType::Document).build();
+    //d.push(e).expect("unable to append node");
+    //Item::Node(d)
+    Item::Node(r)
 }
 
 fn make_from_str(s: &str) -> Result<RNode, Error> {
-    let e = Document::try_from((s, None, None))
-        .expect("failed to parse XML")
+    Ok(Document::try_from((s, None, None))?
         .content[0]
-        .clone();
-    let mut d = NodeBuilder::new(NodeType::Document).build();
-    d.push(e).expect("unable to append node");
-    Ok(d)
+        .clone())
 }
 
 item_value_tests!(RNode);


### PR DESCRIPTION
and for the last one...

The previous PR created a new tree implementation, but the XML parser was hard-coded to create an old intmuttree.

This PR makes the XML parser generic. The parser state has a new field, doc, that is a generic object implementing the Node trait. The Node trait's creation methods are then used to build the components of the tree. This has required changing a few things around, like figuring out the namespace URI for an element or attribute before creating it. "doc" must be a Document type node.

Making ParserState generic caused a huge ripple effect across the whole module. One thing I couldn't work out was making ParseResult work properly, so I pulled it out and made all return results explicit.

I haven't changed the conformance tests to be generic, so they still use intmuttree. I may look into how "use" works to improve the way tests work, coz making the tests a macro is a PITA.

It might be a good idea to put out a 0.9.1 release once this PR is accepted.

