### PR TITLE
Starting to remove intmuttree dependencies

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -45,10 +45,16 @@ pub enum ParseError {
 }
 
 pub struct ParserConfig {
+    /// If you need to resolve external DTDs, you will need to provide your own resolver.
     pub ext_dtd_resolver: Option<URLResolver>,
+    /// The location of the string being parsed, which can be provided to your resolver to work out
+    /// relative URLs
     pub docloc: Option<String>,
-    pub namespace_nodes: bool,
+    /// How many recursive layers on entity expansion. Default is 8 levels.
     pub entitydepth: usize,
+    /// Default is false, sets the parser to generate XDM namespace nodes on elements.
+    /// Does not affect namespaces on elements and attributes.
+    pub namespace_nodes: bool,
 }
 
 impl ParserConfig {

--- a/src/parser/xml/mod.rs
+++ b/src/parser/xml/mod.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 pub fn parse<N: Node>(
     doc: N,
     input: &str,
-    config: ParserConfig,
+    config: Option<ParserConfig>,
     //entityresolver: Option<URLResolver>,
     //docloc: Option<String>,
 ) -> Result<N, Error> {
@@ -37,11 +37,17 @@ pub fn parse<N: Node>(
 pub fn parse_with_ns<N: Node>(
     doc: N,
     input: &str,
-    config: ParserConfig,
+    config: Option<ParserConfig>,
     //entityresolver: Option<URLResolver>,
     //docloc: Option<String>,
 ) -> Result<(N, Vec<HashMap<String, String>>), Error> {
-    let state = ParserState::new(Some(doc), config.ext_dtd_resolver, config.docloc);
+    let pc = if config.is_none(){
+        ParserConfig::new()
+    } else {
+        config.unwrap()
+    };
+
+    let state = ParserState::new(Some(doc), pc.ext_dtd_resolver, pc.docloc);
     match document((input, state)) {
         Ok(((_, state1), xmldoc)) => Ok((xmldoc, state1.namespaces_ref().clone())),
         Err(err) => {

--- a/src/parser/xml/mod.rs
+++ b/src/parser/xml/mod.rs
@@ -17,31 +17,31 @@ use crate::parser::xml::dtd::doctypedecl;
 use crate::parser::xml::element::element;
 use crate::parser::xml::misc::misc;
 use crate::parser::xml::xmldecl::xmldecl;
-use crate::parser::{ParseError, ParseInput, ParserState};
+use crate::parser::{ParseError, ParseInput, ParserConfig, ParserState};
 use crate::xdmerror::{Error, ErrorKind};
 use crate::xmldecl::XMLDecl;
 use std::collections::HashMap;
 
-// For backward compatibility
-//pub type XMLDocument = Document;
 
 pub fn parse<N: Node>(
     doc: N,
     input: &str,
-    entityresolver: Option<URLResolver>,
-    docloc: Option<String>,
+    config: ParserConfig,
+    //entityresolver: Option<URLResolver>,
+    //docloc: Option<String>,
 ) -> Result<N, Error> {
-    let (xmldoc, _) = parse_with_ns(doc, input, entityresolver, docloc)?;
+    let (xmldoc, _) = parse_with_ns(doc, input, config)?;
     Ok(xmldoc)
 }
 
 pub fn parse_with_ns<N: Node>(
     doc: N,
     input: &str,
-    entityresolver: Option<URLResolver>,
-    docloc: Option<String>,
+    config: ParserConfig,
+    //entityresolver: Option<URLResolver>,
+    //docloc: Option<String>,
 ) -> Result<(N, Vec<HashMap<String, String>>), Error> {
-    let state = ParserState::new(Some(doc), entityresolver, docloc);
+    let state = ParserState::new(Some(doc), config.ext_dtd_resolver, config.docloc);
     match document((input, state)) {
         Ok(((_, state1), xmldoc)) => Ok((xmldoc, state1.namespaces_ref().clone())),
         Err(err) => {

--- a/src/trees/intmuttree.rs
+++ b/src/trees/intmuttree.rs
@@ -52,6 +52,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::rc::{Rc, Weak};
+use crate::parser::ParserConfig;
 
 //pub(crate) type ExtDTDresolver = fn(Option<String>, String) -> Result<String, Error>;
 
@@ -171,8 +172,12 @@ impl Document {
 impl TryFrom<(String, Option<URLResolver>, Option<String>)> for Document {
     type Error = Error;
     fn try_from(s: (String, Option<URLResolver>, Option<String>)) -> Result<Self, Self::Error> {
+
+        let mut pc = ParserConfig::new();
+        pc.ext_dtd_resolver = s.1;
+        pc.docloc = s.2;
         let doc = NodeBuilder::new(NodeType::Document).build();
-        parse(doc.clone(), s.0.as_str(), s.1, s.2)?;
+        parse(doc.clone(), s.0.as_str(), pc)?;
         let result = DocumentBuilder::new().content(vec![doc]).build();
         Ok(result)
     }
@@ -180,8 +185,11 @@ impl TryFrom<(String, Option<URLResolver>, Option<String>)> for Document {
 impl TryFrom<(&str, Option<URLResolver>, Option<String>)> for Document {
     type Error = Error;
     fn try_from(s: (&str, Option<URLResolver>, Option<String>)) -> Result<Self, Self::Error> {
+        let mut pc = ParserConfig::new();
+        pc.ext_dtd_resolver = s.1;
+        pc.docloc = s.2;
         let doc = NodeBuilder::new(NodeType::Document).build();
-        parse(doc.clone(), s.0, s.1, s.2)?;
+        parse(doc.clone(), s.0, pc)?;
         let result = DocumentBuilder::new().content(vec![doc]).build();
         Ok(result)
     }

--- a/src/trees/intmuttree.rs
+++ b/src/trees/intmuttree.rs
@@ -177,7 +177,7 @@ impl TryFrom<(String, Option<URLResolver>, Option<String>)> for Document {
         pc.ext_dtd_resolver = s.1;
         pc.docloc = s.2;
         let doc = NodeBuilder::new(NodeType::Document).build();
-        parse(doc.clone(), s.0.as_str(), pc)?;
+        parse(doc.clone(), s.0.as_str(), Some(pc))?;
         let result = DocumentBuilder::new().content(vec![doc]).build();
         Ok(result)
     }
@@ -189,7 +189,7 @@ impl TryFrom<(&str, Option<URLResolver>, Option<String>)> for Document {
         pc.ext_dtd_resolver = s.1;
         pc.docloc = s.2;
         let doc = NodeBuilder::new(NodeType::Document).build();
-        parse(doc.clone(), s.0, pc)?;
+        parse(doc.clone(), s.0, Some(pc))?;
         let result = DocumentBuilder::new().content(vec![doc]).build();
         Ok(result)
     }

--- a/src/trees/smite.rs
+++ b/src/trees/smite.rs
@@ -412,13 +412,13 @@ impl ItemNode for RNode {
                 m.pop()?;
                 // Popping will put the node in the unattached list,
                 // so remove it from there
-                detach(att.clone());
+                detach(m.clone());
                 // Now add to this parent
                 // TODO: deal with same name being redefined
-                if let NodeInner::Attribute(_, qn, _) = &att.0 {
-                    let _ = patt.borrow_mut().insert(qn.clone(), att.clone());
+                if let NodeInner::Attribute(_, qn, _) = &m.0 {
+                    let _ = patt.borrow_mut().insert(qn.clone(), m.clone());
                 }
-                make_parent(att, self.clone());
+                make_parent(m, self.clone());
                 Ok(())
             }
             _ => Err(Error::new(
@@ -570,26 +570,33 @@ impl ItemNode for RNode {
     }
     fn get_canonical(&self) -> Result<Self, Error> {
         match &self.0 {
-            NodeInner::Document(_, _, _)
-            | NodeInner::Comment(_, _)
+            NodeInner::Document(_, e, _) => {
+                let mut result = self.shallow_copy()?;
+                result.push(e.borrow_mut().first().unwrap().get_canonical()?)?;
+                Ok(result)
+            }
+            NodeInner::Comment(_, _)
             | NodeInner::ProcessingInstruction(_, _, _)
             | NodeInner::Namespace(_,_,_) => Err(Error::new(
                 ErrorKind::TypeError,
                 "invalid node type".to_string(),
             )),
             NodeInner::Text(_, v) => {
+                let d = self.owner_document();
                 let mut w = v.clone();
                 if let Value::String(s) = (*v.clone()).clone() {
                     w = Rc::new(Value::String(s.replace("\r\n", "\n").replace("\n\n", "\n")))
                 }
-                Ok(self.new_text(w)?)
+                Ok(d.new_text(w)?)
             }
             NodeInner::Attribute(_, _, _) => self.shallow_copy(),
             NodeInner::Element(_, _, _, _, _) => {
                 let mut result = self.shallow_copy()?;
 
+                let d = result.owner_document();
                 self.attribute_iter().try_for_each(|a| {
-                    result.add_attribute(a.deep_copy()?)?;
+                    result.add_attribute(d.new_attribute(a.name(), a.value())?)?;
+                    //result.add_attribute(a.get_canonical()?)?;
                     Ok::<(), Error>(())
                 })?;
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -2,7 +2,7 @@ pub mod relaxng;
 
 use std::rc::Rc;
 use crate::trees::smite::{RNode, Node as SmiteNode};
-use crate::parser::xml;
+use crate::parser::{ParserConfig, xml};
 use crate::validators::relaxng::validate_relaxng;
 
 
@@ -23,7 +23,7 @@ pub(crate) fn validate(doc: &RNode, s: Schema) -> Result<(), ValidationError>  {
     match s {
         Schema::RelaxNG(schema) => {
             let schemadoc = Rc::new(SmiteNode::new());
-            let _ = xml::parse(schemadoc.clone(), schema.as_str(), None, None);
+            let _ = xml::parse(schemadoc.clone(), schema.as_str(), ParserConfig::new());
             validate_relaxng(doc, &schemadoc)
         }
     }

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -23,7 +23,7 @@ pub(crate) fn validate(doc: &RNode, s: Schema) -> Result<(), ValidationError>  {
     match s {
         Schema::RelaxNG(schema) => {
             let schemadoc = Rc::new(SmiteNode::new());
-            let _ = xml::parse(schemadoc.clone(), schema.as_str(), ParserConfig::new());
+            let _ = xml::parse(schemadoc.clone(), schema.as_str(), None);
             validate_relaxng(doc, &schemadoc)
         }
     }

--- a/src/validators/relaxng/pattern.rs
+++ b/src/validators/relaxng/pattern.rs
@@ -556,12 +556,12 @@ pub(super) fn prepare(schemadoc: &RNode) -> Result<(RNode, HashMap<String,RNode>
 
 fn parse_from_str(s: &str) -> Result<RNode, Error> {
     let doc = Rc::new(SmiteNode::new());
-    xmlparse(doc.clone(), s, ParserConfig::new())?;
+    xmlparse(doc.clone(), s, None)?;
     Ok(doc)
 }
 
 fn parse_from_str_with_ns(s: &str) -> Result<(RNode, Vec<HashMap<String, String>>), Error> {
     let doc = Rc::new(SmiteNode::new());
-    let r = parse_with_ns(doc.clone(), s, ParserConfig::new())?;
+    let r = parse_with_ns(doc.clone(), s, None)?;
     Ok(r)
 }

--- a/src/validators/relaxng/pattern.rs
+++ b/src/validators/relaxng/pattern.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
-use crate::{Node};
-use crate::trees::smite::RNode;
-
+use std::rc::Rc;
+use crate::{Context, Error, Item};
+use crate::parser::ParserConfig;
+use crate::trees::smite::{Node as SmiteNode, RNode};
+use crate::parser::xml::{parse as xmlparse, parse_with_ns};
+use crate::transform::context::StaticContext;
+use crate::xslt::from_document;
 
 pub(crate) type Param = (String, String);
 
@@ -13,9 +17,530 @@ pub(crate) enum PatternError<'a>{
     Other(&'a str)
 }
 
+type F = Box<dyn FnMut(&str) -> Result<(), Error>>;
+
 pub(super) fn prepare(schemadoc: &RNode) -> Result<(RNode, HashMap<String,RNode>), PatternError> {
     //TODO implement
 
+    let patternprepper = r#"<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="2.0"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                exclude-result-prefixes="rng"
+>
+
+    <xsl:output
+            method="xml"
+            encoding="utf-8"
+            indent="yes"
+    />
+    <xsl:mode name="Step4.1" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.2" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.3" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.4" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.5" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.6" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.7" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.8" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.9" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.10" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.11" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.12" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.13" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.14" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.15" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.16" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.17" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.18" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.19" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.20" on-no-match="shallow-copy"/>
+    <xsl:mode name="Step4.21" on-no-match="shallow-copy"/>
+
+
+    <xsl:template match="/">
+        <xsl:variable name="s4.1" ><xsl:apply-templates mode="Step4.1"  select="/"      /></xsl:variable>
+        <xsl:variable name="s4.2" ><xsl:apply-templates mode="Step4.2"  select="$s4.1"  /></xsl:variable>
+        <xsl:variable name="s4.3" ><xsl:apply-templates mode="Step4.3"  select="$s4.2"  /></xsl:variable>
+        <xsl:variable name="s4.4" ><xsl:apply-templates mode="Step4.4"  select="$s4.3"  /></xsl:variable>
+        <xsl:variable name="s4.5" ><xsl:apply-templates mode="Step4.5"  select="$s4.4"  /></xsl:variable>
+        <xsl:variable name="s4.6" ><xsl:apply-templates mode="Step4.6"  select="$s4.5"  /></xsl:variable>
+        <xsl:variable name="s4.7" ><xsl:apply-templates mode="Step4.7"  select="$s4.6"  /></xsl:variable>
+        <xsl:variable name="s4.8" ><xsl:apply-templates mode="Step4.8"  select="$s4.7"  /></xsl:variable>
+        <xsl:variable name="s4.9" ><xsl:apply-templates mode="Step4.9"  select="$s4.8"  /></xsl:variable>
+        <xsl:variable name="s4.10"><xsl:apply-templates mode="Step4.10" select="$s4.9"  /></xsl:variable>
+        <xsl:variable name="s4.11"><xsl:apply-templates mode="Step4.11" select="$s4.10" /></xsl:variable>
+        <xsl:variable name="s4.12"><xsl:apply-templates mode="Step4.12" select="$s4.11" /></xsl:variable>
+        <xsl:variable name="s4.13"><xsl:apply-templates mode="Step4.13" select="$s4.12" /></xsl:variable>
+        <xsl:variable name="s4.14"><xsl:apply-templates mode="Step4.14" select="$s4.13" /></xsl:variable>
+        <xsl:variable name="s4.15"><xsl:apply-templates mode="Step4.15" select="$s4.14" /></xsl:variable>
+        <xsl:variable name="s4.16"><xsl:apply-templates mode="Step4.16" select="$s4.15" /></xsl:variable>
+        <xsl:variable name="s4.17"><xsl:apply-templates mode="Step4.17" select="$s4.16" /></xsl:variable>
+        <xsl:variable name="s4.18"><xsl:apply-templates mode="Step4.18" select="$s4.17" /></xsl:variable>
+        <xsl:variable name="s4.19"><xsl:apply-templates mode="Step4.19" select="$s4.18" /></xsl:variable>
+        <xsl:variable name="s4.20"><xsl:apply-templates mode="Step4.20" select="$s4.19" /></xsl:variable>
+        <xsl:variable name="s4.21"><xsl:apply-templates mode="Step4.21" select="$s4.20" /></xsl:variable>
+        <xsl:copy-of select="$s4.21"/>
+    </xsl:template>
+
+    <!-- 4.1 Annotations -->
+    <xsl:template mode="Step4.1" match="*[namespace-uri() != 'http://relaxng.org/ns/structure/1.0']"/>
+    <xsl:template mode="Step4.1" match="@*[name() != 'ns' and
+                                        name() != 'type' and
+                                        name() != 'href' and
+                                        name() != 'combine' and
+                                        name() != 'datatypeLibrary' and
+                                        name() != 'name']"/>
+    <xsl:template mode="Step4.1" match="comment()"/>
+    <xsl:template mode="Step4.1" match="processing-instruction()"/>
+    <!-- 4.2 Whitespace -->
+    <xsl:template mode="Step4.2" match="text()[normalize-space(.) = '' and ancestor::*[not(self::value or self::param)]]"/>
+
+    <!-- 4.3 datatypeLibrary attribute -->
+    <xsl:template mode="Step4.3" match="rng:*[name()='data' or name()='value'][not(@datatypeLibrary)]">
+        <xsl:copy>
+            <!-- Add or inherit "datatypeLibrary" attribute -->
+            <xsl:if test="not(@datatypeLibrary)">
+                <xsl:attribute name="datatypeLibrary">
+                    <xsl:choose>
+                        <!-- If nearest ancestor has the attribute, inherit it -->
+                        <xsl:when test="ancestor::rng:*[@datatypeLibrary][1]/@datatypeLibrary">
+                            <xsl:value-of select="ancestor::*[@datatypeLibrary][1]/@datatypeLibrary"/>
+                        </xsl:when>
+                        <!-- Otherwise, default to a predefined value or remove if desired -->
+                        <xsl:otherwise>default_value</xsl:otherwise>
+                    </xsl:choose>
+                </xsl:attribute>
+            </xsl:if>
+            <!-- Copy existing attributes -->
+            <xsl:apply-templates mode="Step4.3" select="@*"/>
+            <!-- Process child nodes -->
+            <xsl:apply-templates mode="Step4.3" select="node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- 4.4 type attribute of value element -->
+    <xsl:template mode="Step4.4" match="rng:value[not(@type)]">
+        <xsl:copy>
+            <xsl:attribute name="type">token</xsl:attribute>
+            <xsl:attribute name="datatypeLibrary"/>
+            <!-- Copy existing attributes -->
+            <xsl:apply-templates mode="Step4.4" select="@*"/>
+            <!-- Process child nodes -->
+            <xsl:apply-templates mode="Step4.4" select="node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+
+    <!-- 4.5 href attribute -->
+    <!-- 4.6 externalRef element -->
+    <xsl:template mode="Step4.6" match="rng:externalRef">
+        <xsl:value-of select="doc(@href)"/>
+    </xsl:template>
+
+    <!-- 4.7 include element -->
+    <!--
+    <xsl:template mode="Step1" match="rng:include"/>
+    -->
+
+    <!-- 4.8 name attribute of element and attribute elements -->
+    <xsl:template mode="Step4.8" match="rng:element">
+        <xsl:copy>
+            <xsl:apply-templates mode="Step4.8" select="@*[name() != 'name']"/>
+            <rng:name><xsl:value-of select="@name"/></rng:name>
+            <xsl:apply-templates mode="Step4.8" select="node()"/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template mode="Step4.8" match="rng:attribute">
+        <xsl:copy>
+            <xsl:apply-templates mode="Step4.8" select="@*[name() != 'name']"/>
+            <rng:name>
+                <xsl:if test="@name and not(@ns)">
+                    <xsl:attribute name="ns"></xsl:attribute>
+                </xsl:if>
+                <xsl:value-of select="@name"/>
+            </rng:name>
+            <xsl:apply-templates mode="Step4.8" select="node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- 4.9 ns attribute -->
+    <xsl:template  mode="Step4.9" match="rng:value[not(@ns)] | rng:name[not(@ns)] | rng:nsname[not(@ns)] ">
+        <xsl:copy>
+            <xsl:attribute name="ns" select="ancestor::*[value|name|nsname][@ns]"/>
+            <xsl:apply-templates mode="Step4.9"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template  mode="Step4.9" match="*[not(rng:name or rng:nsname or rng:value) and @ns]">
+        <xsl:copy>
+            <xsl:attribute name="ns"/>
+            <xsl:apply-templates mode="Step4.9"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- 4.10 QNames -->
+    <!-- TODO -->
+
+
+    <!-- 4.11 div -->
+    <xsl:template mode="Step4.11" match="rng:div">
+        <xsl:apply-templates mode="Step4.11"/>
+    </xsl:template>
+
+
+    <!-- 4.12 number of child elements -->
+    <xsl:template mode="Step4.12" match="*[rng:define|rng:oneOrMore|rng:zeroOrMore|rng:optional|rng:list|rng:mixed][count(*) &gt; 1]">
+        <xsl:copy>
+            <rng:group>
+                <xsl:apply-templates mode="Step4.12"/>
+            </rng:group>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template mode="Step41.12" match="rng:element[count(*) &gt; 2]">
+        <xsl:copy>
+            <xsl:copy select="rng:name"/>
+            <rng:group>
+                <xsl:apply-templates mode="Step4.12" select="*[name() != 'name']"/>
+            </rng:group>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template mode="Step4.12" match="rng:except[count(*) &gt; 1]">
+        <xsl:copy>
+            <rng:choice>
+                <xsl:apply-templates mode="Step4.12"/>
+            </rng:choice>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template mode="Step4.12" match="rng:except[count(*) &gt; 1]">
+        <xsl:copy>
+            <rng:choice>
+                <xsl:apply-templates mode="Step4.12"/>
+            </rng:choice>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template mode="Step4.12" match="rng:attribute[count(*) = 1 and name() = 'name']">
+        <xsl:copy>
+            <rng:text/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template mode="Step4.12" match="[rng:choice|rng:group|rng:interleave][count(*) = 1]">
+        <xsl:apply-templates mode="Step4.12"/>
+    </xsl:template>
+
+    <xsl:template mode="Step4.12" match="rng:choice[count(*) &gt; 2]">
+        <xsl:call-template name="choices_splitter">
+            <xsl:with-param name="choices" select="./child::*"/>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template name="choices_splitter">
+        <xsl:param name="choices"/>
+        <xsl:choose>
+            <xsl:when test="count($choices) = 1">
+                <xsl:apply-templates mode="Step4.12" select="$choices"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <rng:choice>
+                    <xsl:apply-templates mode="Step4.12" select="$choices[position() = 1]"/>
+                    <xsl:call-template name="choices_splitter">
+                        <xsl:with-param name="choices" select="$choices[position() &gt; 1]"/>
+                    </xsl:call-template>
+                </rng:choice>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template mode="Step4.12" match="rng:group[count(*) &gt; 2]">
+        <xsl:call-template name="groups_splitter">
+            <xsl:with-param name="groups" select="./child::*"/>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template name="groups_splitter">
+        <xsl:param name="groups"/>
+        <xsl:choose>
+            <xsl:when test="count($groups) = 1">
+                <xsl:apply-templates mode="Step4.12" select="$groups"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <rng:group>
+                    <xsl:apply-templates mode="Step4.12" select="$groups[position() = 1]"/>
+                    <xsl:call-template name="groups_splitter">
+                        <xsl:with-param name="groups" select="$groups[position() &gt; 1]"/>
+                    </xsl:call-template>
+                </rng:group>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template mode="Step4.12" match="rng:interleave[count(*) &gt; 2]">
+        <xsl:call-template name="interleave_splitter">
+            <xsl:with-param name="interleaves" select="./child::*"/>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template name="interleave_splitter">
+        <xsl:param name="interleaves"/>
+        <xsl:choose>
+            <xsl:when test="count($interleaves) = 1">
+                <xsl:apply-templates mode="Step4.12" select="$interleaves"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <rng:group>
+                    <xsl:apply-templates mode="Step4.12" select="$interleaves[position() = 1]"/>
+                    <xsl:call-template name="interleave_splitter">
+                        <xsl:with-param name="interleaves" select="$interleaves[position() &gt; 1]"/>
+                    </xsl:call-template>
+                </rng:group>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+
+    <!-- 4.13  mixed element -->
+    <xsl:template match="rng:mixed" mode="Step4.13">
+        <rng:interleave>
+            <xsl:apply-templates mode="Step4.13"/>
+            <rng:text/>
+        </rng:interleave>
+    </xsl:template>
+
+    <!-- 4.14 optional element -->
+    <xsl:template match="rng:optional" mode="Step4.14">
+        <rng:choice>
+            <xsl:apply-templates mode="Step4.14"/>
+            <rng:empty/>
+        </rng:choice>
+    </xsl:template>
+
+    <!-- 4.15 zeroOrMore element -->
+    <xsl:template match="rng:zeroOrMore" mode="Step4.15">
+        <rng:choice>
+            <rng:oneOrMore>
+                <xsl:apply-templates mode="Step4.15"/>
+            </rng:oneOrMore>
+            <rng:empty/>
+        </rng:choice>
+    </xsl:template>
+
+    <!-- 4.16 Constraints -->
+    <!-- TODO -->
+
+    <!-- 4.17 combine attribute -->
+    <xsl:template mode="Step4.17" match="rng:grammar">
+        <xsl:copy>
+            <xsl:for-each-group select=".//rng:define[@combine='choice']" group-by="@name">
+                <rng:define>
+                    <xsl:attribute name="name" select="@name"/>
+                    <rng:choice>
+                        <xsl:value-of select="current-group()"/>
+                    </rng:choice>
+                </rng:define>
+            </xsl:for-each-group>
+            <xsl:for-each-group select="//rng:define[@combine='interleave']" group-by="@name">
+                <rng:define>
+                    <xsl:attribute name="name" select="@name"/>
+                    <rng:interleave>
+                        <xsl:value-of select="current-group()"/>
+                    </rng:interleave>
+                </rng:define>
+            </xsl:for-each-group>
+            <xsl:apply-templates mode="Step4.17"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- 4.18 grammar element -->
+    <xsl:template mode="Step4.18" match="/*[not(local-name()='grammar')]">
+        <rng:grammar>
+            <rng:start>
+                <xsl:copy-of select="."/>
+            </rng:start>
+            <xsl:copy-of select="//rng:define"/>
+        </rng:grammar>
+    </xsl:template>
+
+    <xsl:template mode="Step4.18" match="/rng:grammar">
+        <xsl:copy>
+            <xsl:choose>
+                <xsl:when test="rng:group/rng:start">
+                    <xsl:copy-of select="rng:group/rng:start"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <rng:start>
+                        <xsl:copy-of select="*"/>
+                    </rng:start>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:copy-of select="//rng:define"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- All except root node -->
+    <xsl:template mode="Step4.18" match="rng:grammar[parent::*]"/>
+
+    <!-- 4.19. define and ref elements -->
+    <xsl:template mode="Step4.19" match="rng:element[not(ancestor::rng:define)]">
+        <rng:ref>
+            <xsl:attribute name="name">
+                <xsl:value-of select="./rng:name"/>
+            </xsl:attribute>
+        </rng:ref>
+    </xsl:template>
+    <xsl:template mode="Step4.19" match="/rng:grammar">
+        <xsl:copy>
+            <xsl:apply-templates mode="Step4.19"/>
+            <xsl:for-each select="//rng:element[not(ancestor::rng:define)]">
+                <rng:define>
+                    <xsl:attribute name="name">
+                        <xsl:value-of select="./rng:name"/>
+                    </xsl:attribute>
+                    <xsl:copy-of select="/rng:grammar/rng:start/*"/>
+                </rng:define>
+            </xsl:for-each>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- 4.20. notAllowed element -->
+    <xsl:template mode="Step4.20" match="rng:attribute[rng:notAllowed]"><rng:notAllowed/></xsl:template>
+    <xsl:template mode="Step4.20" match="rng:list[rng:notAllowed]"><rng:notAllowed/></xsl:template>
+    <xsl:template mode="Step4.20" match="rng:group[rng:notAllowed]"><rng:notAllowed/></xsl:template>
+    <xsl:template mode="Step4.20" match="rng:interleave[rng:notAllowed]"><rng:notAllowed/></xsl:template>
+    <xsl:template mode="Step4.20" match="rng:oneOrMore[rng:notAllowed]"><rng:notAllowed/></xsl:template>
+
+    <xsl:template mode="Step4.20" match="rng:choice[count(rng:notAllowed) = 2]">
+        <rng:notAllowed/>
+    </xsl:template>
+
+    <xsl:template mode="Step4.20" match="rng:choice[count(rng:notAllowed) != 2]">
+        <xsl:variable name="child1">
+            <xsl:apply-templates mode="Step4.20" select="*[1]"/>
+        </xsl:variable>
+        <xsl:variable name="child2">
+            <xsl:apply-templates mode="Step4.20" select="*[2]"/>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when test="name($child1)= 'notAllowed' and name($child2)= 'notAllowed'">
+                <rng:notAllowed/>
+            </xsl:when>
+            <xsl:otherwise>
+                <rng:choice>
+                    <xsl:copy-of select="$child1"/>
+                    <xsl:copy-of select="$child2"/>
+                </rng:choice>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template mode="Step4.20" match="rng:except[rng:notAllowed]"/>
+
+
+    <!-- 4.21. empty element -->
+    <xsl:template mode="Step4.21" match="rng:group">
+        <xsl:variable name="child1">
+            <xsl:apply-templates mode="Step4.21" select="*[1]"/>
+        </xsl:variable>
+        <xsl:variable name="child2">
+            <xsl:apply-templates mode="Step4.21" select="*[2]"/>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when test="name($child1)= 'empty' and name($child2)= 'empty'">
+                <rng:empty/>
+            </xsl:when>
+            <xsl:when test="name($child1)= 'empty'">
+                <xsl:copy-of select="$child2"/>
+            </xsl:when>
+            <xsl:when test="name($child2)= 'empty'">
+                <xsl:copy-of select="$child1"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <rng:group>
+                    <xsl:copy-of select="$child1"/>
+                    <xsl:copy-of select="$child2"/>
+                </rng:group>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template mode="Step4.21" match="rng:interleave">
+        <xsl:variable name="child1">
+            <xsl:apply-templates mode="Step4.21" select="*[1]"/>
+        </xsl:variable>
+        <xsl:variable name="child2">
+            <xsl:apply-templates mode="Step4.21" select="*[2]"/>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when test="name($child1)= 'empty' and name($child2)= 'empty'">
+                <rng:empty/>
+            </xsl:when>
+            <xsl:when test="name($child1)= 'empty'">
+                <xsl:copy-of select="$child2"/>
+            </xsl:when>
+            <xsl:when test="name($child2)= 'empty'">
+                <xsl:copy-of select="$child1"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <rng:interleave>
+                    <xsl:copy-of select="$child1"/>
+                    <xsl:copy-of select="$child2"/>
+                </rng:interleave>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template mode="Step4.21" match="rng:choice">
+        <xsl:variable name="child1">
+            <xsl:apply-templates mode="Step4.21" select="*[1]"/>
+        </xsl:variable>
+        <xsl:variable name="child2">
+            <xsl:apply-templates mode="Step4.21" select="*[2]"/>
+        </xsl:variable>
+        <xsl:choose>
+            <xsl:when test="name($child1)= 'empty' and name($child2)= 'empty'">
+                <rng:empty/>
+            </xsl:when>
+            <xsl:when test="name($child2)= 'empty'">
+                <rng:choice>
+                    <xsl:copy-of select="$child2"/>
+                    <xsl:copy-of select="$child1"/>
+                </rng:choice>
+            </xsl:when>
+            <xsl:otherwise>
+                <rng:choice>
+                    <xsl:copy-of select="$child1"/>
+                    <xsl:copy-of select="$child2"/>
+                </rng:choice>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+</xsl:stylesheet>"#;
+
+    let (styledoc, stylens) = parse_from_str_with_ns(patternprepper).expect("TODO: panic message");
+    let mut stctxt = StaticContext::<F>::new();
+    let mut c = from_document(
+        styledoc,
+        stylens,
+        None,
+        |s| Ok(Rc::new(SmiteNode::new())),
+        |_| Ok(String::new()),
+    );
+    match c {
+        Ok(mut ctxt) => {
+            ctxt.context(vec![Item::Node(schemadoc.clone())], 0);
+            ctxt.result_document(Rc::new(SmiteNode::new()));
+            ctxt.populate_key_values(&mut stctxt, schemadoc.clone()).expect("TODO: panic message");
+            let rest =  ctxt.evaluate(&mut stctxt);
+            println!("res-{:?}",rest);
+        }
+        Err(e) => {
+            println!("reserre-{:?}",e);
+
+        }
+    }
+
+        /*
     let mut ci = schemadoc.child_iter();
     let pat = ci.next().unwrap();
     let mut refs = HashMap::new();
@@ -23,4 +548,20 @@ pub(super) fn prepare(schemadoc: &RNode) -> Result<(RNode, HashMap<String,RNode>
         refs.insert(r.name().get_localname(), r);
     }
     Ok((pat, refs))
+
+         */
+    //println!("res-{:?}",rest);
+    Ok((Rc::new(SmiteNode::new()), HashMap::new()))
+}
+
+fn parse_from_str(s: &str) -> Result<RNode, Error> {
+    let doc = Rc::new(SmiteNode::new());
+    xmlparse(doc.clone(), s, ParserConfig::new())?;
+    Ok(doc)
+}
+
+fn parse_from_str_with_ns(s: &str) -> Result<(RNode, Vec<HashMap<String, String>>), Error> {
+    let doc = Rc::new(SmiteNode::new());
+    let r = parse_with_ns(doc.clone(), s, ParserConfig::new())?;
+    Ok(r)
 }

--- a/tests/conformance/relaxng/jamesclark.rs
+++ b/tests/conformance/relaxng/jamesclark.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::rc::Rc;
 //use xrust::item::Node;
-use xrust::parser::xml;
+use xrust::parser::{ParserConfig, xml};
 use xrust::trees::smite::{Node as SmiteNode};
 use xrust::validators::relaxng::validate_relaxng;
 
@@ -17,11 +17,11 @@ fn relaxng_incorrect_001_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/001/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -39,11 +39,11 @@ fn relaxng_incorrect_002_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/002/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -61,11 +61,11 @@ fn relaxng_incorrect_003_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/003/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -83,11 +83,11 @@ fn relaxng_incorrect_004_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/004/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -105,11 +105,11 @@ fn relaxng_incorrect_005_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/005/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -127,11 +127,11 @@ fn relaxng_incorrect_006_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/006/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -149,11 +149,11 @@ fn relaxng_incorrect_007_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/007/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -171,11 +171,11 @@ fn relaxng_incorrect_008_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/008/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -193,11 +193,11 @@ fn relaxng_incorrect_009_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/009/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -215,11 +215,11 @@ fn relaxng_incorrect_010_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/010/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -237,11 +237,11 @@ fn relaxng_incorrect_011_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/011/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -259,11 +259,11 @@ fn relaxng_incorrect_012_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/012/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -281,11 +281,11 @@ fn relaxng_incorrect_013_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/013/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -303,11 +303,11 @@ fn relaxng_incorrect_014_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/014/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -325,11 +325,11 @@ fn relaxng_incorrect_015_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/015/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -347,11 +347,11 @@ fn relaxng_incorrect_016_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/016/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -369,11 +369,11 @@ fn relaxng_incorrect_017_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/017/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -391,11 +391,11 @@ fn relaxng_incorrect_018_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/018/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -413,11 +413,11 @@ fn relaxng_incorrect_019_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/019/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -435,11 +435,11 @@ fn relaxng_incorrect_020_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/020/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -457,11 +457,11 @@ fn relaxng_incorrect_021_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/021/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -479,11 +479,11 @@ fn relaxng_incorrect_022_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/022/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -501,11 +501,11 @@ fn relaxng_incorrect_023_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/023/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -523,11 +523,11 @@ fn relaxng_incorrect_024_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/024/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -545,11 +545,11 @@ fn relaxng_incorrect_025_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/025/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -567,11 +567,11 @@ fn relaxng_incorrect_026_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/026/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -589,11 +589,11 @@ fn relaxng_incorrect_027_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/027/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -611,11 +611,11 @@ fn relaxng_incorrect_028_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/028/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -633,11 +633,11 @@ fn relaxng_incorrect_029_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/029/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -655,11 +655,11 @@ fn relaxng_incorrect_030_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/030/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -677,11 +677,11 @@ fn relaxng_incorrect_031_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/031/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -699,11 +699,11 @@ fn relaxng_incorrect_032_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/032/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -721,11 +721,11 @@ fn relaxng_incorrect_033_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/033/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -743,11 +743,11 @@ fn relaxng_incorrect_034_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/034/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -765,11 +765,11 @@ fn relaxng_incorrect_035_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/035/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -787,11 +787,11 @@ fn relaxng_incorrect_036_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/036/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -809,11 +809,11 @@ fn relaxng_incorrect_037_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/037/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -831,11 +831,11 @@ fn relaxng_incorrect_038_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/038/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -853,11 +853,11 @@ fn relaxng_incorrect_039_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/039/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -875,11 +875,11 @@ fn relaxng_incorrect_040_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/040/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -897,11 +897,11 @@ fn relaxng_incorrect_041_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/041/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -919,11 +919,11 @@ fn relaxng_incorrect_042_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/042/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -941,11 +941,11 @@ fn relaxng_incorrect_043_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/043/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -963,11 +963,11 @@ fn relaxng_incorrect_044_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/044/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -985,11 +985,11 @@ fn relaxng_incorrect_045_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/045/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1007,11 +1007,11 @@ fn relaxng_incorrect_046_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/046/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1029,11 +1029,11 @@ fn relaxng_incorrect_047_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/047/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1051,11 +1051,11 @@ fn relaxng_incorrect_048_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/048/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1073,11 +1073,11 @@ fn relaxng_valid_049_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/049/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/049/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1096,11 +1096,11 @@ fn relaxng_valid_050_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/050/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/050/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1119,11 +1119,11 @@ fn relaxng_incorrect_053_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/053/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1142,11 +1142,11 @@ fn relaxng_valid_054_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/054/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/054/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1165,11 +1165,11 @@ fn relaxng_valid_055_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/055/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/055/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1188,11 +1188,11 @@ fn relaxng_incorrect_056_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/056/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1211,11 +1211,11 @@ fn relaxng_incorrect_057_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/057/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1234,11 +1234,11 @@ fn relaxng_incorrect_058_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/058/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1257,11 +1257,11 @@ fn relaxng_valid_059_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/059/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/059/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1280,11 +1280,11 @@ fn relaxng_incorrect_060_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/060/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1303,11 +1303,11 @@ fn relaxng_incorrect_061_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/061/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1326,11 +1326,11 @@ fn relaxng_incorrect_062_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/062/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1349,11 +1349,11 @@ fn relaxng_incorrect_063_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/063/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1371,11 +1371,11 @@ fn relaxng_valid_064_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/064/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/064/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1393,11 +1393,11 @@ fn relaxng_valid_065_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/065/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/065/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1415,11 +1415,11 @@ fn relaxng_valid_066_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/066/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/066/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1438,11 +1438,11 @@ fn relaxng_incorrect_067_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/067/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1461,11 +1461,11 @@ fn relaxng_incorrect_068_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/068/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1483,11 +1483,11 @@ fn relaxng_valid_069_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/069/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/069/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1505,11 +1505,11 @@ fn relaxng_incorrect_070_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/070/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1527,11 +1527,11 @@ fn relaxng_incorrect_071_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/071/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1549,11 +1549,11 @@ fn relaxng_incorrect_072_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/072/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1571,11 +1571,11 @@ fn relaxng_incorrect_073_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/073/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1593,11 +1593,11 @@ fn relaxng_incorrect_074_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/074/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1615,11 +1615,11 @@ fn relaxng_valid_075_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/075/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/075/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1637,11 +1637,11 @@ fn relaxng_incorrect_076_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/076/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1659,11 +1659,11 @@ fn relaxng_incorrect_077_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/077/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1681,11 +1681,11 @@ fn relaxng_incorrect_078_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/078/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1703,11 +1703,11 @@ fn relaxng_incorrect_079_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/079/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1725,11 +1725,11 @@ fn relaxng_incorrect_080_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/080/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1747,11 +1747,11 @@ fn relaxng_incorrect_081_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/081/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1769,11 +1769,11 @@ fn relaxng_incorrect_082_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/082/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1791,11 +1791,11 @@ fn relaxng_incorrect_083_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/083/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1813,11 +1813,11 @@ fn relaxng_incorrect_084_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/084/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1835,11 +1835,11 @@ fn relaxng_incorrect_085_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/085/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1857,11 +1857,11 @@ fn relaxng_incorrect_086_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/086/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1879,11 +1879,11 @@ fn relaxng_incorrect_087_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/087/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1901,11 +1901,11 @@ fn relaxng_valid_088_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/088/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/088/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1923,11 +1923,11 @@ fn relaxng_valid_089_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/089/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/089/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1945,11 +1945,11 @@ fn relaxng_valid_090_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/090/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/090/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1967,11 +1967,11 @@ fn relaxng_valid_091_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/091/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/091/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1989,11 +1989,11 @@ fn relaxng_valid_092_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/092/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/092/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2011,11 +2011,11 @@ fn relaxng_valid_093_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/093/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/093/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2032,11 +2032,11 @@ fn relaxng_valid_094_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/094/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/094/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2053,11 +2053,11 @@ fn relaxng_valid_095_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/095/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/095/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2074,11 +2074,11 @@ fn relaxng_invalid_095_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/095/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/095/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2095,11 +2095,11 @@ fn relaxng_valid_096_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/096/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/096/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2116,11 +2116,11 @@ fn relaxng_valid_097_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/097/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/097/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2137,11 +2137,11 @@ fn relaxng_valid_098_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/098/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/098/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2158,11 +2158,11 @@ fn relaxng_valid_099_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2179,11 +2179,11 @@ fn relaxng_valid_099_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2200,11 +2200,11 @@ fn relaxng_valid_099_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2221,11 +2221,11 @@ fn relaxng_invalid_099_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2242,11 +2242,11 @@ fn relaxng_invalid_099_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2263,11 +2263,11 @@ fn relaxng_valid_100_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/100/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/100/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2284,11 +2284,11 @@ fn relaxng_invalid_100_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/100/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/100/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2305,11 +2305,11 @@ fn relaxng_valid_101_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/101/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/101/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2326,11 +2326,11 @@ fn relaxng_invalid_101_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/101/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/101/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2347,11 +2347,11 @@ fn relaxng_incorrect_102_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/102/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2368,11 +2368,11 @@ fn relaxng_valid_103_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/103/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/103/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2389,11 +2389,11 @@ fn relaxng_invalid_103_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/103/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/103/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2410,11 +2410,11 @@ fn relaxng_valid_104_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/104/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/104/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2431,11 +2431,11 @@ fn relaxng_invalid_104_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/104/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/104/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2452,11 +2452,11 @@ fn relaxng_incorrect_105_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/105/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2473,11 +2473,11 @@ fn relaxng_incorrect_106_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/106/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2494,11 +2494,11 @@ fn relaxng_incorrect_107_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/107/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2516,11 +2516,11 @@ fn relaxng_valid_108_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/108/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/108/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2538,11 +2538,11 @@ fn relaxng_invalid_108_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/108/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/108/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2559,11 +2559,11 @@ fn relaxng_valid_109_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/109/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/109/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2580,11 +2580,11 @@ fn relaxng_invalid_109_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/109/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/109/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2601,11 +2601,11 @@ fn relaxng_valid_110_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/110/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/110/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2622,11 +2622,11 @@ fn relaxng_invalid_110_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/110/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/110/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2643,11 +2643,11 @@ fn relaxng_valid_111_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/111/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/111/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2664,11 +2664,11 @@ fn relaxng_invalid_111_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/111/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/111/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2685,11 +2685,11 @@ fn relaxng_incorrect_112_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/112/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2706,11 +2706,11 @@ fn relaxng_incorrect_113_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/113/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2727,11 +2727,11 @@ fn relaxng_incorrect_114_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/114/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2748,11 +2748,11 @@ fn relaxng_valid_115_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/115/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/115/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2769,11 +2769,11 @@ fn relaxng_invalid_115_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/115/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/115/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2790,11 +2790,11 @@ fn relaxng_incorrect_116_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/116/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2811,11 +2811,11 @@ fn relaxng_valid_117_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/117/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/117/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2832,11 +2832,11 @@ fn relaxng_invalid_117_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/117/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/117/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2853,11 +2853,11 @@ fn relaxng_incorrect_118_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/118/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2874,11 +2874,11 @@ fn relaxng_valid_119_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/119/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/119/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2895,11 +2895,11 @@ fn relaxng_invalid_119_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/119/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/119/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2916,11 +2916,11 @@ fn relaxng_valid_120_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2937,11 +2937,11 @@ fn relaxng_valid_120_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2958,11 +2958,11 @@ fn relaxng_invalid_120_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2979,11 +2979,11 @@ fn relaxng_incorrect_121_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/121/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3000,11 +3000,11 @@ fn relaxng_valid_122_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/122/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/122/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3021,11 +3021,11 @@ fn relaxng_invalid_122_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/122/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/122/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3042,11 +3042,11 @@ fn relaxng_invalid_123_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/123/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/123/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3063,11 +3063,11 @@ fn relaxng_valid_123_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/123/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/123/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3084,11 +3084,11 @@ fn relaxng_valid_124_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/124/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/124/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3105,11 +3105,11 @@ fn relaxng_invalid_124_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/124/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/124/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3126,11 +3126,11 @@ fn relaxng_valid_125_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/125/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/125/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3147,11 +3147,11 @@ fn relaxng_invalid_125_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/125/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/125/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3167,11 +3167,11 @@ fn relaxng_valid_126_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/126/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/126/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3187,11 +3187,11 @@ fn relaxng_invalid_126_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/126/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/126/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3207,11 +3207,11 @@ fn relaxng_valid_127_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/127/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/127/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3227,11 +3227,11 @@ fn relaxng_invalid_127_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/127/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/127/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3247,11 +3247,11 @@ fn relaxng_valid_128_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/128/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/128/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3267,11 +3267,11 @@ fn relaxng_invalid_128_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/128/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/128/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3288,11 +3288,11 @@ fn relaxng_incorrect_129_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/129/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3309,11 +3309,11 @@ fn relaxng_valid_130_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/130/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/130/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3330,11 +3330,11 @@ fn relaxng_invalid_130_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/130/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/130/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3351,11 +3351,11 @@ fn relaxng_valid_131_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/131/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/131/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3372,11 +3372,11 @@ fn relaxng_invalid_131_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/131/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/131/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3393,11 +3393,11 @@ fn relaxng_valid_132_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/132/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/132/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3414,11 +3414,11 @@ fn relaxng_invalid_132_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/132/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/132/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3435,11 +3435,11 @@ fn relaxng_valid_133_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/133/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/133/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3456,11 +3456,11 @@ fn relaxng_invalid_133_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/133/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/133/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3477,11 +3477,11 @@ fn relaxng_valid_134_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3498,11 +3498,11 @@ fn relaxng_invalid_134_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3519,11 +3519,11 @@ fn relaxng_invalid_134_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3540,11 +3540,11 @@ fn relaxng_invalid_134_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3561,11 +3561,11 @@ fn relaxng_invalid_134_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3582,11 +3582,11 @@ fn relaxng_invalid_134_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3603,11 +3603,11 @@ fn relaxng_invalid_134_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3624,11 +3624,11 @@ fn relaxng_invalid_134_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3645,11 +3645,11 @@ fn relaxng_valid_135_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3666,11 +3666,11 @@ fn relaxng_valid_135_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3687,11 +3687,11 @@ fn relaxng_invalid_135_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3708,11 +3708,11 @@ fn relaxng_invalid_135_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3729,11 +3729,11 @@ fn relaxng_invalid_135_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3750,11 +3750,11 @@ fn relaxng_invalid_135_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3771,11 +3771,11 @@ fn relaxng_invalid_135_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3792,11 +3792,11 @@ fn relaxng_invalid_135_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3813,11 +3813,11 @@ fn relaxng_valid_136_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3834,11 +3834,11 @@ fn relaxng_valid_136_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3855,11 +3855,11 @@ fn relaxng_invalid_136_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3876,11 +3876,11 @@ fn relaxng_invalid_136_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3897,11 +3897,11 @@ fn relaxng_valid_136_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3918,11 +3918,11 @@ fn relaxng_invalid_136_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3939,11 +3939,11 @@ fn relaxng_invalid_136_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3960,11 +3960,11 @@ fn relaxng_invalid_136_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3981,11 +3981,11 @@ fn relaxng_valid_137_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4002,11 +4002,11 @@ fn relaxng_invalid_137_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4023,11 +4023,11 @@ fn relaxng_invalid_137_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4044,11 +4044,11 @@ fn relaxng_invalid_137_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4065,11 +4065,11 @@ fn relaxng_valid_137_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4086,11 +4086,11 @@ fn relaxng_invalid_137_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4107,11 +4107,11 @@ fn relaxng_invalid_137_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4128,11 +4128,11 @@ fn relaxng_invalid_137_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4149,11 +4149,11 @@ fn relaxng_valid_138_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/138/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/138/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4170,11 +4170,11 @@ fn relaxng_invalid_138_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/138/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/138/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4191,11 +4191,11 @@ fn relaxng_valid_139_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4212,11 +4212,11 @@ fn relaxng_invalid_139_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4233,11 +4233,11 @@ fn relaxng_invalid_139_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4254,11 +4254,11 @@ fn relaxng_invalid_139_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4275,11 +4275,11 @@ fn relaxng_invalid_139_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4296,11 +4296,11 @@ fn relaxng_valid_139_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/6.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4317,11 +4317,11 @@ fn relaxng_invalid_139_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4338,11 +4338,11 @@ fn relaxng_invalid_139_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4359,11 +4359,11 @@ fn relaxng_valid_140_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4380,11 +4380,11 @@ fn relaxng_invalid_140_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4401,11 +4401,11 @@ fn relaxng_invalid_140_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4422,11 +4422,11 @@ fn relaxng_invalid_140_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4443,11 +4443,11 @@ fn relaxng_invalid_140_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4464,11 +4464,11 @@ fn relaxng_invalid_140_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4485,11 +4485,11 @@ fn relaxng_invalid_140_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4506,11 +4506,11 @@ fn relaxng_invalid_140_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4527,11 +4527,11 @@ fn relaxng_valid_141_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4548,11 +4548,11 @@ fn relaxng_invalid_141_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4569,11 +4569,11 @@ fn relaxng_invalid_141_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4590,11 +4590,11 @@ fn relaxng_invalid_141_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4611,11 +4611,11 @@ fn relaxng_valid_142_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4632,11 +4632,11 @@ fn relaxng_valid_142_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4653,11 +4653,11 @@ fn relaxng_invalid_142_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4674,11 +4674,11 @@ fn relaxng_invalid_142_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4695,11 +4695,11 @@ fn relaxng_invalid_142_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4716,11 +4716,11 @@ fn relaxng_valid_143_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4737,11 +4737,11 @@ fn relaxng_valid_143_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4758,11 +4758,11 @@ fn relaxng_invalid_143_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4779,11 +4779,11 @@ fn relaxng_valid_144_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4800,11 +4800,11 @@ fn relaxng_valid_144_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4821,11 +4821,11 @@ fn relaxng_invalid_144_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4842,11 +4842,11 @@ fn relaxng_valid_145_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4863,11 +4863,11 @@ fn relaxng_invalid_145_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4884,11 +4884,11 @@ fn relaxng_invalid_145_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4905,11 +4905,11 @@ fn relaxng_invalid_145_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4926,11 +4926,11 @@ fn relaxng_invalid_145_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4947,11 +4947,11 @@ fn relaxng_invalid_145_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4968,11 +4968,11 @@ fn relaxng_invalid_145_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4989,11 +4989,11 @@ fn relaxng_invalid_145_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5010,11 +5010,11 @@ fn relaxng_valid_146_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5031,11 +5031,11 @@ fn relaxng_valid_146_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5052,11 +5052,11 @@ fn relaxng_valid_146_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5073,11 +5073,11 @@ fn relaxng_invalid_146_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5094,11 +5094,11 @@ fn relaxng_valid_147_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5115,11 +5115,11 @@ fn relaxng_valid_147_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5136,11 +5136,11 @@ fn relaxng_valid_147_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5157,11 +5157,11 @@ fn relaxng_valid_147_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5178,11 +5178,11 @@ fn relaxng_valid_147_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5199,11 +5199,11 @@ fn relaxng_valid_147_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/6.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5220,11 +5220,11 @@ fn relaxng_invalid_147_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5241,11 +5241,11 @@ fn relaxng_invalid_147_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5262,11 +5262,11 @@ fn relaxng_valid_148_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/148/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/148/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5283,11 +5283,11 @@ fn relaxng_invalid_148_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/148/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/148/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5304,11 +5304,11 @@ fn relaxng_valid_149_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/149/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/149/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5325,11 +5325,11 @@ fn relaxng_invalid_149_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/149/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/149/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5346,11 +5346,11 @@ fn relaxng_valid_150_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/150/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/150/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5367,11 +5367,11 @@ fn relaxng_invalid_150_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/150/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/150/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5388,11 +5388,11 @@ fn relaxng_valid_151_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5409,11 +5409,11 @@ fn relaxng_valid_151_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5430,11 +5430,11 @@ fn relaxng_valid_151_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5451,11 +5451,11 @@ fn relaxng_valid_151_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5472,11 +5472,11 @@ fn relaxng_invalid_151_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5493,11 +5493,11 @@ fn relaxng_invalid_151_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5514,11 +5514,11 @@ fn relaxng_valid_152_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5535,11 +5535,11 @@ fn relaxng_valid_152_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5556,11 +5556,11 @@ fn relaxng_invalid_152_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5577,11 +5577,11 @@ fn relaxng_invalid_152_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5598,11 +5598,11 @@ fn relaxng_valid_153_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5619,11 +5619,11 @@ fn relaxng_valid_153_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5640,11 +5640,11 @@ fn relaxng_invalid_153_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5661,11 +5661,11 @@ fn relaxng_invalid_153_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5682,11 +5682,11 @@ fn relaxng_valid_153_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5703,11 +5703,11 @@ fn relaxng_incorrect_154_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/154/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5724,11 +5724,11 @@ fn relaxng_incorrect_155_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/155/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5745,11 +5745,11 @@ fn relaxng_incorrect_156_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/156/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5766,11 +5766,11 @@ fn relaxng_incorrect_157_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/157/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5787,11 +5787,11 @@ fn relaxng_incorrect_158_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/158/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5808,11 +5808,11 @@ fn relaxng_incorrect_159_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/159/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5830,11 +5830,11 @@ fn relaxng_incorrect_160_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/160/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5852,11 +5852,11 @@ fn relaxng_incorrect_161_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/161/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5873,11 +5873,11 @@ fn relaxng_incorrect_162_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/162/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5894,11 +5894,11 @@ fn relaxng_valid_163_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/163/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/163/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5915,11 +5915,11 @@ fn relaxng_incorrect_164_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/164/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5936,11 +5936,11 @@ fn relaxng_incorrect_165_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/165/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5957,11 +5957,11 @@ fn relaxng_incorrect_166_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/166/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5978,11 +5978,11 @@ fn relaxng_incorrect_167_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/167/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5999,11 +5999,11 @@ fn relaxng_incorrect_168_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/168/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6020,11 +6020,11 @@ fn relaxng_incorrect_169_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/169/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6041,11 +6041,11 @@ fn relaxng_incorrect_170_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/170/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6062,11 +6062,11 @@ fn relaxng_incorrect_171_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/171/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6083,11 +6083,11 @@ fn relaxng_incorrect_172_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/172/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6104,11 +6104,11 @@ fn relaxng_incorrect_173_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/173/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6125,11 +6125,11 @@ fn relaxng_incorrect_174_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/174/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6146,11 +6146,11 @@ fn relaxng_incorrect_175_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/175/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6167,11 +6167,11 @@ fn relaxng_valid_176_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/176/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/176/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6188,11 +6188,11 @@ fn relaxng_incorrect_177_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/177/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6209,11 +6209,11 @@ fn relaxng_incorrect_178_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/178/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6230,11 +6230,11 @@ fn relaxng_incorrect_179_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/179/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6251,11 +6251,11 @@ fn relaxng_incorrect_180_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/180/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6272,11 +6272,11 @@ fn relaxng_incorrect_181_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/181/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6293,11 +6293,11 @@ fn relaxng_incorrect_182_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/182/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6314,11 +6314,11 @@ fn relaxng_incorrect_183_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/183/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6335,11 +6335,11 @@ fn relaxng_incorrect_184_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/184/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6356,11 +6356,11 @@ fn relaxng_incorrect_185_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/185/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6377,11 +6377,11 @@ fn relaxng_incorrect_186_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/186/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6398,11 +6398,11 @@ fn relaxng_incorrect_187_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/187/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6419,11 +6419,11 @@ fn relaxng_incorrect_188_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/188/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6440,11 +6440,11 @@ fn relaxng_incorrect_189_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/189/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6461,11 +6461,11 @@ fn relaxng_valid_190_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6482,11 +6482,11 @@ fn relaxng_valid_190_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6503,11 +6503,11 @@ fn relaxng_valid_190_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6524,11 +6524,11 @@ fn relaxng_invalid_190_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6545,11 +6545,11 @@ fn relaxng_valid_191_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6566,11 +6566,11 @@ fn relaxng_valid_191_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6587,11 +6587,11 @@ fn relaxng_valid_191_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6608,11 +6608,11 @@ fn relaxng_invalid_191_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6629,11 +6629,11 @@ fn relaxng_incorrect_192_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/192/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6650,11 +6650,11 @@ fn relaxng_incorrect_193_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/193/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6671,11 +6671,11 @@ fn relaxng_valid_194_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6692,11 +6692,11 @@ fn relaxng_valid_194_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6713,11 +6713,11 @@ fn relaxng_valid_194_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6734,11 +6734,11 @@ fn relaxng_invalid_194_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6755,11 +6755,11 @@ fn relaxng_valid_195_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6776,11 +6776,11 @@ fn relaxng_valid_195_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6797,11 +6797,11 @@ fn relaxng_valid_195_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6818,11 +6818,11 @@ fn relaxng_invalid_195_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6839,11 +6839,11 @@ fn relaxng_incorrect_196_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/196/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6860,11 +6860,11 @@ fn relaxng_incorrect_197_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/197/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6882,11 +6882,11 @@ fn relaxng_incorrect_198_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/198/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6904,11 +6904,11 @@ fn relaxng_incorrect_199_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/199/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6926,11 +6926,11 @@ fn relaxng_incorrect_200_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/200/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6948,11 +6948,11 @@ fn relaxng_incorrect_201_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/201/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6970,11 +6970,11 @@ fn relaxng_incorrect_202_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/202/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6992,11 +6992,11 @@ fn relaxng_incorrect_203_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/203/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7014,11 +7014,11 @@ fn relaxng_incorrect_204_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/204/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7036,11 +7036,11 @@ fn relaxng_incorrect_205_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/205/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7058,11 +7058,11 @@ fn relaxng_incorrect_206_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/206/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7079,11 +7079,11 @@ fn relaxng_incorrect_207_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/207/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7100,11 +7100,11 @@ fn relaxng_valid_208_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/208/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/208/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7121,11 +7121,11 @@ fn relaxng_valid_209_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/209/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/209/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7142,11 +7142,11 @@ fn relaxng_invalid_209_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/209/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/209/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7163,11 +7163,11 @@ fn relaxng_valid_210_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/210/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/210/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7184,11 +7184,11 @@ fn relaxng_invalid_210_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/210/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/210/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7205,11 +7205,11 @@ fn relaxng_incorrect_211_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/211/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7226,11 +7226,11 @@ fn relaxng_valid_212_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7247,11 +7247,11 @@ fn relaxng_valid_212_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7268,11 +7268,11 @@ fn relaxng_invalid_212_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7289,11 +7289,11 @@ fn relaxng_valid_213_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/213/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/213/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7312,11 +7312,11 @@ normalization of notAllowed.
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/214/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7333,11 +7333,11 @@ fn relaxng_valid_215_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/215/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/215/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7354,11 +7354,11 @@ fn relaxng_valid_215_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/215/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/215/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7375,11 +7375,11 @@ fn relaxng_invalid_216_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7396,11 +7396,11 @@ fn relaxng_valid_216_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7417,11 +7417,11 @@ fn relaxng_valid_216_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7438,11 +7438,11 @@ fn relaxng_invalid_217_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/217/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/217/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7459,11 +7459,11 @@ fn relaxng_valid_217_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/217/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/217/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7480,11 +7480,11 @@ fn relaxng_valid_218_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/218/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/218/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7501,11 +7501,11 @@ fn relaxng_invalid_218_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/218/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/218/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7522,11 +7522,11 @@ fn relaxng_invalid_219_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7543,11 +7543,11 @@ fn relaxng_invalid_219_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7564,11 +7564,11 @@ fn relaxng_invalid_219_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7585,11 +7585,11 @@ fn relaxng_valid_219_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7606,11 +7606,11 @@ fn relaxng_invalid_220_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7627,11 +7627,11 @@ fn relaxng_invalid_220_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7648,11 +7648,11 @@ fn relaxng_valid_220_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7669,11 +7669,11 @@ fn relaxng_invalid_221_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7690,11 +7690,11 @@ fn relaxng_invalid_221_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7711,11 +7711,11 @@ fn relaxng_valid_221_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7732,11 +7732,11 @@ fn relaxng_valid_221_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7753,11 +7753,11 @@ fn relaxng_valid_222_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7774,11 +7774,11 @@ fn relaxng_invalid_222_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7795,11 +7795,11 @@ fn relaxng_invalid_222_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7816,11 +7816,11 @@ fn relaxng_invalid_222_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7837,11 +7837,11 @@ fn relaxng_invalid_223_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7858,11 +7858,11 @@ fn relaxng_valid_223_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7879,11 +7879,11 @@ fn relaxng_invalid_223_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7900,11 +7900,11 @@ fn relaxng_invalid_223_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7921,11 +7921,11 @@ fn relaxng_invalid_224_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7942,11 +7942,11 @@ fn relaxng_valid_224_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7963,11 +7963,11 @@ fn relaxng_valid_224_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7984,11 +7984,11 @@ fn relaxng_valid_225_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8005,11 +8005,11 @@ fn relaxng_valid_225_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8026,11 +8026,11 @@ fn relaxng_invalid_225_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8047,11 +8047,11 @@ fn relaxng_valid_226_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8068,11 +8068,11 @@ fn relaxng_valid_226_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8089,11 +8089,11 @@ fn relaxng_invalid_226_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8110,11 +8110,11 @@ fn relaxng_invalid_226_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8131,11 +8131,11 @@ fn relaxng_invalid_226_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8152,11 +8152,11 @@ fn relaxng_invalid_226_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8173,11 +8173,11 @@ fn relaxng_invalid_226_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8194,11 +8194,11 @@ fn relaxng_valid_227_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8215,11 +8215,11 @@ fn relaxng_valid_227_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8236,11 +8236,11 @@ fn relaxng_invalid_227_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8257,11 +8257,11 @@ fn relaxng_invalid_227_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8278,11 +8278,11 @@ fn relaxng_invalid_227_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8299,11 +8299,11 @@ fn relaxng_invalid_227_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8320,11 +8320,11 @@ fn relaxng_invalid_227_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8341,11 +8341,11 @@ fn relaxng_valid_228_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8362,11 +8362,11 @@ fn relaxng_valid_228_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8383,11 +8383,11 @@ fn relaxng_invalid_228_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8404,11 +8404,11 @@ fn relaxng_invalid_228_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8425,11 +8425,11 @@ fn relaxng_invalid_228_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8446,11 +8446,11 @@ fn relaxng_invalid_228_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8467,11 +8467,11 @@ fn relaxng_invalid_228_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8488,11 +8488,11 @@ fn relaxng_valid_229_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8509,11 +8509,11 @@ fn relaxng_invalid_229_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8530,11 +8530,11 @@ fn relaxng_invalid_229_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8551,11 +8551,11 @@ fn relaxng_invalid_229_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8572,11 +8572,11 @@ fn relaxng_invalid_229_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8593,11 +8593,11 @@ fn relaxng_invalid_229_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8614,11 +8614,11 @@ fn relaxng_valid_230_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/230/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/230/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8635,11 +8635,11 @@ fn relaxng_invalid_230_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/230/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/230/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8656,11 +8656,11 @@ fn relaxng_valid_231_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8677,11 +8677,11 @@ fn relaxng_invalid_231_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8698,11 +8698,11 @@ fn relaxng_invalid_231_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8719,11 +8719,11 @@ fn relaxng_invalid_231_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8740,11 +8740,11 @@ fn relaxng_valid_232_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8761,11 +8761,11 @@ fn relaxng_invalid_232_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8782,11 +8782,11 @@ fn relaxng_invalid_232_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8803,11 +8803,11 @@ fn relaxng_invalid_232_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8824,11 +8824,11 @@ fn relaxng_valid_233_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8845,11 +8845,11 @@ fn relaxng_invalid_233_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8866,11 +8866,11 @@ fn relaxng_invalid_233_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8887,11 +8887,11 @@ fn relaxng_invalid_233_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8908,11 +8908,11 @@ fn relaxng_valid_234_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8929,11 +8929,11 @@ fn relaxng_invalid_234_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8950,11 +8950,11 @@ fn relaxng_invalid_234_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8971,11 +8971,11 @@ fn relaxng_invalid_234_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8992,11 +8992,11 @@ fn relaxng_valid_235_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9013,11 +9013,11 @@ fn relaxng_valid_235_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9034,11 +9034,11 @@ fn relaxng_valid_235_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9055,11 +9055,11 @@ fn relaxng_valid_235_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9076,11 +9076,11 @@ fn relaxng_invalid_235_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9097,11 +9097,11 @@ fn relaxng_invalid_235_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9118,11 +9118,11 @@ fn relaxng_invalid_235_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9139,11 +9139,11 @@ fn relaxng_valid_236_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9160,11 +9160,11 @@ fn relaxng_valid_236_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9181,11 +9181,11 @@ fn relaxng_invalid_236_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9202,11 +9202,11 @@ fn relaxng_valid_237_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9223,11 +9223,11 @@ fn relaxng_valid_237_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9244,11 +9244,11 @@ fn relaxng_invalid_237_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9265,11 +9265,11 @@ fn relaxng_invalid_237_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9286,11 +9286,11 @@ fn relaxng_invalid_237_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9307,11 +9307,11 @@ fn relaxng_valid_238_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9328,11 +9328,11 @@ fn relaxng_valid_238_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9349,11 +9349,11 @@ fn relaxng_invalid_238_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9370,11 +9370,11 @@ fn relaxng_valid_239_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9391,11 +9391,11 @@ fn relaxng_valid_239_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9412,11 +9412,11 @@ fn relaxng_invalid_239_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9433,11 +9433,11 @@ fn relaxng_invalid_239_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9453,11 +9453,11 @@ fn relaxng_valid_240_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9473,11 +9473,11 @@ fn relaxng_valid_240_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9493,11 +9493,11 @@ fn relaxng_invalid_240_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9513,11 +9513,11 @@ fn relaxng_invalid_240_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9534,11 +9534,11 @@ fn relaxng_valid_241_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9555,11 +9555,11 @@ fn relaxng_valid_241_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9576,11 +9576,11 @@ fn relaxng_valid_241_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9597,11 +9597,11 @@ fn relaxng_valid_241_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9618,11 +9618,11 @@ fn relaxng_invalid_241_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9639,11 +9639,11 @@ fn relaxng_valid_242_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9660,11 +9660,11 @@ fn relaxng_valid_242_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9681,11 +9681,11 @@ fn relaxng_valid_242_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9702,11 +9702,11 @@ fn relaxng_valid_242_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9723,11 +9723,11 @@ fn relaxng_invalid_242_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9744,11 +9744,11 @@ fn relaxng_invalid_242_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9765,11 +9765,11 @@ fn relaxng_valid_243_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9786,11 +9786,11 @@ fn relaxng_valid_243_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9807,11 +9807,11 @@ fn relaxng_invalid_243_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9828,11 +9828,11 @@ fn relaxng_valid_243_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9849,11 +9849,11 @@ fn relaxng_invalid_243_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9870,11 +9870,11 @@ fn relaxng_valid_243_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/6.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9891,11 +9891,11 @@ fn relaxng_valid_244_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9912,11 +9912,11 @@ fn relaxng_valid_244_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9933,11 +9933,11 @@ fn relaxng_valid_244_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9954,11 +9954,11 @@ fn relaxng_valid_244_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9975,11 +9975,11 @@ fn relaxng_invalid_244_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9996,11 +9996,11 @@ fn relaxng_valid_244_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/6.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10017,11 +10017,11 @@ fn relaxng_valid_244_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/7.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10038,11 +10038,11 @@ fn relaxng_invalid_244_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10059,11 +10059,11 @@ fn relaxng_valid_245_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10080,11 +10080,11 @@ fn relaxng_valid_245_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10101,11 +10101,11 @@ fn relaxng_valid_245_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10122,11 +10122,11 @@ fn relaxng_invalid_245_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10143,11 +10143,11 @@ fn relaxng_invalid_245_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10164,11 +10164,11 @@ fn relaxng_valid_246_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10185,11 +10185,11 @@ fn relaxng_valid_246_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10206,11 +10206,11 @@ fn relaxng_valid_246_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10227,11 +10227,11 @@ fn relaxng_invalid_246_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10248,11 +10248,11 @@ fn relaxng_valid_247_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10269,11 +10269,11 @@ fn relaxng_valid_247_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10290,11 +10290,11 @@ fn relaxng_valid_247_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10311,11 +10311,11 @@ fn relaxng_invalid_247_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10332,11 +10332,11 @@ fn relaxng_invalid_247_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10353,11 +10353,11 @@ fn relaxng_invalid_247_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10374,11 +10374,11 @@ fn relaxng_valid_248_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10395,11 +10395,11 @@ fn relaxng_valid_248_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10416,11 +10416,11 @@ fn relaxng_valid_248_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10437,11 +10437,11 @@ fn relaxng_invalid_248_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10458,11 +10458,11 @@ fn relaxng_invalid_248_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10479,11 +10479,11 @@ fn relaxng_invalid_248_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10500,11 +10500,11 @@ fn relaxng_valid_249_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10521,11 +10521,11 @@ fn relaxng_valid_249_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10542,11 +10542,11 @@ fn relaxng_valid_249_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10563,11 +10563,11 @@ fn relaxng_invalid_249_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10584,11 +10584,11 @@ fn relaxng_valid_250_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10605,11 +10605,11 @@ fn relaxng_valid_250_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10626,11 +10626,11 @@ fn relaxng_invalid_250_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10647,11 +10647,11 @@ fn relaxng_invalid_250_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10668,11 +10668,11 @@ fn relaxng_invalid_250_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10689,11 +10689,11 @@ fn relaxng_invalid_250_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10710,11 +10710,11 @@ fn relaxng_valid_251_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10731,11 +10731,11 @@ fn relaxng_valid_251_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10752,11 +10752,11 @@ fn relaxng_valid_251_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10773,11 +10773,11 @@ fn relaxng_invalid_251_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10794,11 +10794,11 @@ fn relaxng_invalid_251_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10815,11 +10815,11 @@ fn relaxng_invalid_251_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10836,11 +10836,11 @@ fn relaxng_invalid_251_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10857,11 +10857,11 @@ fn relaxng_invalid_251_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10878,11 +10878,11 @@ fn relaxng_valid_252_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10899,11 +10899,11 @@ fn relaxng_invalid_252_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10920,11 +10920,11 @@ fn relaxng_invalid_252_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10941,11 +10941,11 @@ fn relaxng_invalid_252_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10962,11 +10962,11 @@ fn relaxng_invalid_252_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10983,11 +10983,11 @@ fn relaxng_valid_253_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11004,11 +11004,11 @@ fn relaxng_invalid_253_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11025,11 +11025,11 @@ fn relaxng_invalid_253_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11046,11 +11046,11 @@ fn relaxng_invalid_253_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11067,11 +11067,11 @@ fn relaxng_invalid_253_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11088,11 +11088,11 @@ fn relaxng_valid_254_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11109,11 +11109,11 @@ fn relaxng_invalid_254_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11130,11 +11130,11 @@ fn relaxng_invalid_254_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11151,11 +11151,11 @@ fn relaxng_invalid_254_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11172,11 +11172,11 @@ fn relaxng_invalid_254_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11193,11 +11193,11 @@ fn relaxng_invalid_254_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11214,11 +11214,11 @@ fn relaxng_valid_255_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11235,11 +11235,11 @@ fn relaxng_valid_255_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11256,11 +11256,11 @@ fn relaxng_invalid_255_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11277,11 +11277,11 @@ fn relaxng_invalid_255_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11298,11 +11298,11 @@ fn relaxng_invalid_255_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11319,11 +11319,11 @@ fn relaxng_invalid_255_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11340,11 +11340,11 @@ fn relaxng_invalid_255_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11361,11 +11361,11 @@ fn relaxng_valid_256_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11382,11 +11382,11 @@ fn relaxng_invalid_256_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11403,11 +11403,11 @@ fn relaxng_invalid_256_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11424,11 +11424,11 @@ fn relaxng_valid_257_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11445,11 +11445,11 @@ fn relaxng_valid_257_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11466,11 +11466,11 @@ fn relaxng_valid_257_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11487,11 +11487,11 @@ fn relaxng_invalid_257_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11508,11 +11508,11 @@ fn relaxng_invalid_257_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11529,11 +11529,11 @@ fn relaxng_valid_258_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11550,11 +11550,11 @@ fn relaxng_invalid_258_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11571,11 +11571,11 @@ fn relaxng_invalid_258_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11592,11 +11592,11 @@ fn relaxng_valid_259_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11613,11 +11613,11 @@ fn relaxng_valid_259_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11634,11 +11634,11 @@ fn relaxng_invalid_259_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11655,11 +11655,11 @@ fn relaxng_invalid_260_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11676,11 +11676,11 @@ fn relaxng_invalid_260_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11697,11 +11697,11 @@ fn relaxng_valid_260_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11718,11 +11718,11 @@ fn relaxng_valid_260_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11739,11 +11739,11 @@ fn relaxng_invalid_260_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11760,11 +11760,11 @@ fn relaxng_valid_261_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11781,11 +11781,11 @@ fn relaxng_valid_261_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11802,11 +11802,11 @@ fn relaxng_valid_261_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11823,11 +11823,11 @@ fn relaxng_valid_261_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11844,11 +11844,11 @@ fn relaxng_invalid_261_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11865,11 +11865,11 @@ fn relaxng_invalid_261_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11886,11 +11886,11 @@ fn relaxng_invalid_261_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11907,11 +11907,11 @@ fn relaxng_valid_262_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11928,11 +11928,11 @@ fn relaxng_valid_262_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11949,11 +11949,11 @@ fn relaxng_invalid_262_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11970,11 +11970,11 @@ fn relaxng_valid_262_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11991,11 +11991,11 @@ fn relaxng_valid_262_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12012,11 +12012,11 @@ fn relaxng_invalid_262_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12033,11 +12033,11 @@ fn relaxng_invalid_262_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12054,11 +12054,11 @@ fn relaxng_invalid_262_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12075,11 +12075,11 @@ fn relaxng_valid_263_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12096,11 +12096,11 @@ fn relaxng_valid_263_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12117,11 +12117,11 @@ fn relaxng_invalid_263_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12138,11 +12138,11 @@ fn relaxng_valid_263_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12159,11 +12159,11 @@ fn relaxng_valid_263_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12180,11 +12180,11 @@ fn relaxng_valid_263_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/6.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12201,11 +12201,11 @@ fn relaxng_invalid_263_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12222,11 +12222,11 @@ fn relaxng_valid_263_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/8.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12243,11 +12243,11 @@ fn relaxng_valid_264_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12264,11 +12264,11 @@ fn relaxng_invalid_264_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12285,11 +12285,11 @@ fn relaxng_invalid_264_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12306,11 +12306,11 @@ fn relaxng_invalid_264_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12327,11 +12327,11 @@ fn relaxng_valid_265_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/265/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/265/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12348,11 +12348,11 @@ fn relaxng_valid_266_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/266/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/266/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12369,11 +12369,11 @@ fn relaxng_invalid_267_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/267/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/267/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12390,11 +12390,11 @@ fn relaxng_valid_267_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/267/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/267/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12411,11 +12411,11 @@ fn relaxng_valid_268_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12432,11 +12432,11 @@ fn relaxng_valid_268_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12453,11 +12453,11 @@ fn relaxng_valid_268_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12474,11 +12474,11 @@ fn relaxng_valid_268_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12495,11 +12495,11 @@ fn relaxng_invalid_268_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12516,11 +12516,11 @@ fn relaxng_invalid_268_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12537,11 +12537,11 @@ fn relaxng_valid_269_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12558,11 +12558,11 @@ fn relaxng_valid_269_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12579,11 +12579,11 @@ fn relaxng_valid_269_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12600,11 +12600,11 @@ fn relaxng_valid_269_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12621,11 +12621,11 @@ fn relaxng_invalid_269_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12642,11 +12642,11 @@ fn relaxng_invalid_269_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12663,11 +12663,11 @@ fn relaxng_valid_270_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12684,11 +12684,11 @@ fn relaxng_invalid_270_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12705,11 +12705,11 @@ fn relaxng_invalid_270_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12726,11 +12726,11 @@ fn relaxng_invalid_270_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12747,11 +12747,11 @@ fn relaxng_valid_271_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12768,11 +12768,11 @@ fn relaxng_invalid_271_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12789,11 +12789,11 @@ fn relaxng_invalid_271_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12810,11 +12810,11 @@ fn relaxng_invalid_271_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12831,11 +12831,11 @@ fn relaxng_valid_272_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12852,11 +12852,11 @@ fn relaxng_valid_272_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12873,11 +12873,11 @@ fn relaxng_valid_272_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12894,11 +12894,11 @@ fn relaxng_valid_272_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12915,11 +12915,11 @@ fn relaxng_invalid_272_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12936,11 +12936,11 @@ fn relaxng_invalid_272_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12957,11 +12957,11 @@ fn relaxng_valid_273_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12978,11 +12978,11 @@ fn relaxng_valid_273_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12999,11 +12999,11 @@ fn relaxng_valid_273_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13020,11 +13020,11 @@ fn relaxng_invalid_273_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13041,11 +13041,11 @@ fn relaxng_valid_274_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13062,11 +13062,11 @@ fn relaxng_valid_274_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13083,11 +13083,11 @@ fn relaxng_valid_274_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13104,11 +13104,11 @@ fn relaxng_valid_274_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13125,11 +13125,11 @@ fn relaxng_invalid_274_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13146,11 +13146,11 @@ fn relaxng_invalid_274_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13167,11 +13167,11 @@ fn relaxng_valid_275_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13188,11 +13188,11 @@ fn relaxng_valid_275_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13209,11 +13209,11 @@ fn relaxng_valid_275_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13230,11 +13230,11 @@ fn relaxng_valid_275_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13251,11 +13251,11 @@ fn relaxng_valid_275_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13272,11 +13272,11 @@ fn relaxng_invalid_275_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13293,11 +13293,11 @@ fn relaxng_invalid_275_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13314,11 +13314,11 @@ fn relaxng_incorrect_276_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/276/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13335,11 +13335,11 @@ fn relaxng_incorrect_277_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/277/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13356,11 +13356,11 @@ fn relaxng_incorrect_278_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/278/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13377,11 +13377,11 @@ fn relaxng_incorrect_279_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/279/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13398,11 +13398,11 @@ fn relaxng_valid_280_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13419,11 +13419,11 @@ fn relaxng_valid_280_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13440,11 +13440,11 @@ fn relaxng_invalid_280_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13461,11 +13461,11 @@ fn relaxng_valid_281_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13482,11 +13482,11 @@ fn relaxng_valid_281_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13503,11 +13503,11 @@ fn relaxng_invalid_281_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13524,11 +13524,11 @@ fn relaxng_invalid_281_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13545,11 +13545,11 @@ fn relaxng_valid_282_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13566,11 +13566,11 @@ fn relaxng_valid_282_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13587,11 +13587,11 @@ fn relaxng_valid_282_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13608,11 +13608,11 @@ fn relaxng_invalid_282_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13629,11 +13629,11 @@ fn relaxng_valid_283_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13650,11 +13650,11 @@ fn relaxng_invalid_283_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13671,11 +13671,11 @@ fn relaxng_invalid_283_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13692,11 +13692,11 @@ fn relaxng_invalid_284_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/284/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/284/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13713,11 +13713,11 @@ fn relaxng_incorrect_285_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/285/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13734,11 +13734,11 @@ fn relaxng_incorrect_286_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/286/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13755,11 +13755,11 @@ fn relaxng_incorrect_287_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/287/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13776,11 +13776,11 @@ fn relaxng_incorrect_288_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/288/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13797,11 +13797,11 @@ fn relaxng_incorrect_289_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/289/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13818,11 +13818,11 @@ fn relaxng_incorrect_290_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/290/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13839,11 +13839,11 @@ fn relaxng_incorrect_291_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/291/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13860,11 +13860,11 @@ fn relaxng_incorrect_292_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/292/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13881,11 +13881,11 @@ fn relaxng_incorrect_293_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/293/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13902,11 +13902,11 @@ fn relaxng_incorrect_294_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/294/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13923,11 +13923,11 @@ fn relaxng_incorrect_295_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/295/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13944,11 +13944,11 @@ fn relaxng_incorrect_296_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/296/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13965,11 +13965,11 @@ fn relaxng_incorrect_297_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/297/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13986,11 +13986,11 @@ fn relaxng_incorrect_298_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/298/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14007,11 +14007,11 @@ fn relaxng_incorrect_299_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/299/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14028,11 +14028,11 @@ fn relaxng_incorrect_300_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/300/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14049,11 +14049,11 @@ fn relaxng_incorrect_301_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/301/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14070,11 +14070,11 @@ fn relaxng_incorrect_302_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/302/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14091,11 +14091,11 @@ fn relaxng_incorrect_303_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/303/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14112,11 +14112,11 @@ fn relaxng_incorrect_304_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/304/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14133,11 +14133,11 @@ fn relaxng_incorrect_305_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/305/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14154,11 +14154,11 @@ fn relaxng_incorrect_306_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/306/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14175,11 +14175,11 @@ fn relaxng_incorrect_307_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/307/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14196,11 +14196,11 @@ fn relaxng_incorrect_308_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/308/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14217,11 +14217,11 @@ fn relaxng_incorrect_309_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/309/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14238,11 +14238,11 @@ fn relaxng_incorrect_310_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/310/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14259,11 +14259,11 @@ fn relaxng_incorrect_311_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/311/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14280,11 +14280,11 @@ fn relaxng_incorrect_312_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/312/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14301,11 +14301,11 @@ fn relaxng_incorrect_313_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/313/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14322,11 +14322,11 @@ fn relaxng_incorrect_314_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/314/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14343,11 +14343,11 @@ fn relaxng_incorrect_315_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/315/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14364,11 +14364,11 @@ fn relaxng_incorrect_316_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/316/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14385,11 +14385,11 @@ fn relaxng_incorrect_317_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/317/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14406,11 +14406,11 @@ fn relaxng_incorrect_318_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/318/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14427,11 +14427,11 @@ fn relaxng_incorrect_319_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/319/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14448,11 +14448,11 @@ fn relaxng_incorrect_320_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/320/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14469,11 +14469,11 @@ fn relaxng_incorrect_321_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/321/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14490,11 +14490,11 @@ fn relaxng_incorrect_322_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/322/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14511,11 +14511,11 @@ fn relaxng_incorrect_323_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/323/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14532,11 +14532,11 @@ fn relaxng_incorrect_324_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/324/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14553,11 +14553,11 @@ fn relaxng_incorrect_325_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/325/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14574,11 +14574,11 @@ fn relaxng_incorrect_326_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/326/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14595,11 +14595,11 @@ fn relaxng_incorrect_327_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/327/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14617,11 +14617,11 @@ fn relaxng_valid_328_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/328/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/328/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14638,11 +14638,11 @@ fn relaxng_incorrect_329_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/329/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14659,11 +14659,11 @@ fn relaxng_valid_330_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/330/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/330/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14682,11 +14682,11 @@ of the not allowed.
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/331/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/331/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14704,11 +14704,11 @@ fn relaxng_valid_332_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/332/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/332/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14726,11 +14726,11 @@ fn relaxng_valid_333_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/333/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/333/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14748,11 +14748,11 @@ fn relaxng_valid_334_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/334/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/334/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14769,11 +14769,11 @@ fn relaxng_incorrect_335_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/335/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14792,11 +14792,11 @@ before string sequence checking.
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/336/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/336/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14814,11 +14814,11 @@ fn relaxng_incorrect_337_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/337/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14835,11 +14835,11 @@ fn relaxng_incorrect_338_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/338/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14856,11 +14856,11 @@ fn relaxng_incorrect_339_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/339/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14877,11 +14877,11 @@ fn relaxng_valid_340_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/340/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/340/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14898,11 +14898,11 @@ fn relaxng_incorrect_341_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/341/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14919,11 +14919,11 @@ fn relaxng_incorrect_342_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/342/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14940,11 +14940,11 @@ fn relaxng_incorrect_343_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/343/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14961,11 +14961,11 @@ fn relaxng_incorrect_344_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/344/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14982,11 +14982,11 @@ fn relaxng_valid_345_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15003,11 +15003,11 @@ fn relaxng_valid_345_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15024,11 +15024,11 @@ fn relaxng_invalid_345_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15045,11 +15045,11 @@ fn relaxng_invalid_345_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15066,11 +15066,11 @@ fn relaxng_invalid_345_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15087,11 +15087,11 @@ fn relaxng_incorrect_346_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/346/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15108,11 +15108,11 @@ fn relaxng_incorrect_347_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/347/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15129,11 +15129,11 @@ fn relaxng_incorrect_348_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/348/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15150,11 +15150,11 @@ fn relaxng_incorrect_349_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/349/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15171,11 +15171,11 @@ fn relaxng_incorrect_350_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/350/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15192,11 +15192,11 @@ fn relaxng_incorrect_351_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/351/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15213,11 +15213,11 @@ fn relaxng_incorrect_352_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/352/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15234,11 +15234,11 @@ fn relaxng_valid_353_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15255,11 +15255,11 @@ fn relaxng_invalid_353_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15276,11 +15276,11 @@ fn relaxng_valid_353_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15297,11 +15297,11 @@ fn relaxng_valid_354_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/354/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/354/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15318,11 +15318,11 @@ fn relaxng_valid_355_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/355/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/355/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15339,11 +15339,11 @@ fn relaxng_incorrect_356_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/356/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15360,11 +15360,11 @@ fn relaxng_incorrect_357_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/357/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15381,11 +15381,11 @@ fn relaxng_incorrect_358_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/358/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15402,11 +15402,11 @@ fn relaxng_incorrect_359_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/359/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15423,11 +15423,11 @@ fn relaxng_incorrect_360_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/360/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15444,11 +15444,11 @@ fn relaxng_incorrect_361_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/361/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15465,11 +15465,11 @@ fn relaxng_incorrect_362_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/362/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15486,11 +15486,11 @@ fn relaxng_incorrect_363_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/363/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15507,11 +15507,11 @@ fn relaxng_incorrect_364_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/364/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15528,11 +15528,11 @@ fn relaxng_incorrect_365_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/365/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15549,11 +15549,11 @@ fn relaxng_incorrect_366_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/366/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15570,11 +15570,11 @@ fn relaxng_incorrect_367_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/367/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15591,11 +15591,11 @@ fn relaxng_valid_368_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/368/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/368/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15612,11 +15612,11 @@ fn relaxng_valid_369_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/369/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/369/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15633,11 +15633,11 @@ fn relaxng_incorrect_370_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/370/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15654,11 +15654,11 @@ fn relaxng_incorrect_371_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/371/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15675,11 +15675,11 @@ fn relaxng_valid_372_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/372/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/372/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15696,11 +15696,11 @@ fn relaxng_invalid_373_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/373/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/373/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15717,11 +15717,11 @@ fn relaxng_valid_374_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15738,11 +15738,11 @@ fn relaxng_invalid_374_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15759,11 +15759,11 @@ fn relaxng_invalid_374_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15780,11 +15780,11 @@ fn relaxng_invalid_374_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15801,11 +15801,11 @@ fn relaxng_invalid_374_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15822,11 +15822,11 @@ fn relaxng_invalid_374_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15843,11 +15843,11 @@ fn relaxng_invalid_374_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15864,11 +15864,11 @@ fn relaxng_invalid_374_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15885,11 +15885,11 @@ fn relaxng_invalid_374_9(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/9.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15906,11 +15906,11 @@ fn relaxng_valid_375_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/375/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/375/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15927,11 +15927,11 @@ fn relaxng_invalid_375_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/375/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/375/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15948,11 +15948,11 @@ fn relaxng_valid_376_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15969,11 +15969,11 @@ fn relaxng_valid_376_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15990,11 +15990,11 @@ fn relaxng_invalid_376_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16011,11 +16011,11 @@ fn relaxng_valid_377_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/377/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/377/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16032,11 +16032,11 @@ fn relaxng_invalid_377_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/377/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/377/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16053,11 +16053,11 @@ fn relaxng_valid_378_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16074,11 +16074,11 @@ fn relaxng_invalid_378_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16095,11 +16095,11 @@ fn relaxng_invalid_378_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16116,11 +16116,11 @@ fn relaxng_invalid_378_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16137,11 +16137,11 @@ fn relaxng_valid_379_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16158,11 +16158,11 @@ fn relaxng_valid_379_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16179,11 +16179,11 @@ fn relaxng_invalid_379_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16200,11 +16200,11 @@ fn relaxng_invalid_379_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16221,11 +16221,11 @@ fn relaxng_invalid_379_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16242,11 +16242,11 @@ fn relaxng_valid_380_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16263,11 +16263,11 @@ fn relaxng_valid_380_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16284,11 +16284,11 @@ fn relaxng_invalid_380_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16305,11 +16305,11 @@ fn relaxng_invalid_380_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16326,11 +16326,11 @@ fn relaxng_invalid_380_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16347,11 +16347,11 @@ fn relaxng_valid_381_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16368,11 +16368,11 @@ fn relaxng_invalid_381_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16389,11 +16389,11 @@ fn relaxng_invalid_381_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16410,11 +16410,11 @@ fn relaxng_valid_382_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16431,11 +16431,11 @@ fn relaxng_invalid_382_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16452,11 +16452,11 @@ fn relaxng_invalid_382_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16473,11 +16473,11 @@ fn relaxng_invalid_382_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16494,11 +16494,11 @@ fn relaxng_valid_383_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16515,11 +16515,11 @@ fn relaxng_valid_383_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16536,11 +16536,11 @@ fn relaxng_invalid_383_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16557,11 +16557,11 @@ fn relaxng_invalid_383_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16578,11 +16578,11 @@ fn relaxng_invalid_383_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16599,11 +16599,11 @@ fn relaxng_valid_384_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16620,11 +16620,11 @@ fn relaxng_invalid_384_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16641,11 +16641,11 @@ fn relaxng_valid_384_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16662,11 +16662,11 @@ fn relaxng_invalid_384_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16683,11 +16683,11 @@ fn relaxng_invalid_384_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16704,11 +16704,11 @@ fn relaxng_invalid_384_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16725,11 +16725,11 @@ fn relaxng_invalid_384_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16746,11 +16746,11 @@ fn relaxng_valid_385_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/385/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/385/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16767,11 +16767,11 @@ fn relaxng_invalid_385_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/385/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), None, None);
+    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/385/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), None, None);
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());

--- a/tests/conformance/relaxng/jamesclark.rs
+++ b/tests/conformance/relaxng/jamesclark.rs
@@ -17,11 +17,11 @@ fn relaxng_incorrect_001_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/001/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -39,11 +39,11 @@ fn relaxng_incorrect_002_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/002/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -61,11 +61,11 @@ fn relaxng_incorrect_003_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/003/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -83,11 +83,11 @@ fn relaxng_incorrect_004_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/004/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -105,11 +105,11 @@ fn relaxng_incorrect_005_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/005/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -127,11 +127,11 @@ fn relaxng_incorrect_006_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/006/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -149,11 +149,11 @@ fn relaxng_incorrect_007_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/007/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -171,11 +171,11 @@ fn relaxng_incorrect_008_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/008/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -193,11 +193,11 @@ fn relaxng_incorrect_009_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/009/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -215,11 +215,11 @@ fn relaxng_incorrect_010_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/010/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -237,11 +237,11 @@ fn relaxng_incorrect_011_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/011/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -259,11 +259,11 @@ fn relaxng_incorrect_012_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/012/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -281,11 +281,11 @@ fn relaxng_incorrect_013_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/013/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -303,11 +303,11 @@ fn relaxng_incorrect_014_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/014/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -325,11 +325,11 @@ fn relaxng_incorrect_015_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/015/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -347,11 +347,11 @@ fn relaxng_incorrect_016_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/016/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -369,11 +369,11 @@ fn relaxng_incorrect_017_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/017/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -391,11 +391,11 @@ fn relaxng_incorrect_018_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/018/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -413,11 +413,11 @@ fn relaxng_incorrect_019_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/019/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -435,11 +435,11 @@ fn relaxng_incorrect_020_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/020/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -457,11 +457,11 @@ fn relaxng_incorrect_021_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/021/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -479,11 +479,11 @@ fn relaxng_incorrect_022_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/022/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -501,11 +501,11 @@ fn relaxng_incorrect_023_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/023/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -523,11 +523,11 @@ fn relaxng_incorrect_024_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/024/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -545,11 +545,11 @@ fn relaxng_incorrect_025_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/025/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -567,11 +567,11 @@ fn relaxng_incorrect_026_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/026/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -589,11 +589,11 @@ fn relaxng_incorrect_027_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/027/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -611,11 +611,11 @@ fn relaxng_incorrect_028_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/028/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -633,11 +633,11 @@ fn relaxng_incorrect_029_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/029/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -655,11 +655,11 @@ fn relaxng_incorrect_030_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/030/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -677,11 +677,11 @@ fn relaxng_incorrect_031_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/031/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -699,11 +699,11 @@ fn relaxng_incorrect_032_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/032/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -721,11 +721,11 @@ fn relaxng_incorrect_033_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/033/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -743,11 +743,11 @@ fn relaxng_incorrect_034_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/034/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -765,11 +765,11 @@ fn relaxng_incorrect_035_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/035/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -787,11 +787,11 @@ fn relaxng_incorrect_036_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/036/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -809,11 +809,11 @@ fn relaxng_incorrect_037_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/037/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -831,11 +831,11 @@ fn relaxng_incorrect_038_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/038/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -853,11 +853,11 @@ fn relaxng_incorrect_039_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/039/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -875,11 +875,11 @@ fn relaxng_incorrect_040_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/040/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -897,11 +897,11 @@ fn relaxng_incorrect_041_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/041/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -919,11 +919,11 @@ fn relaxng_incorrect_042_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/042/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -941,11 +941,11 @@ fn relaxng_incorrect_043_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/043/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -963,11 +963,11 @@ fn relaxng_incorrect_044_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/044/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -985,11 +985,11 @@ fn relaxng_incorrect_045_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/045/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1007,11 +1007,11 @@ fn relaxng_incorrect_046_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/046/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1029,11 +1029,11 @@ fn relaxng_incorrect_047_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/047/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1051,11 +1051,11 @@ fn relaxng_incorrect_048_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/048/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1073,11 +1073,11 @@ fn relaxng_valid_049_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/049/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/049/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1096,11 +1096,11 @@ fn relaxng_valid_050_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/050/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/050/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1119,11 +1119,11 @@ fn relaxng_incorrect_053_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/053/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1142,11 +1142,11 @@ fn relaxng_valid_054_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/054/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/054/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1165,11 +1165,11 @@ fn relaxng_valid_055_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/055/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/055/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1188,11 +1188,11 @@ fn relaxng_incorrect_056_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/056/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1211,11 +1211,11 @@ fn relaxng_incorrect_057_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/057/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1234,11 +1234,11 @@ fn relaxng_incorrect_058_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/058/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1257,11 +1257,11 @@ fn relaxng_valid_059_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/059/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/059/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1280,11 +1280,11 @@ fn relaxng_incorrect_060_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/060/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1303,11 +1303,11 @@ fn relaxng_incorrect_061_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/061/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1326,11 +1326,11 @@ fn relaxng_incorrect_062_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/062/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1349,11 +1349,11 @@ fn relaxng_incorrect_063_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/063/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1371,11 +1371,11 @@ fn relaxng_valid_064_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/064/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/064/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1393,11 +1393,11 @@ fn relaxng_valid_065_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/065/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/065/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1415,11 +1415,11 @@ fn relaxng_valid_066_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/066/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/066/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1438,11 +1438,11 @@ fn relaxng_incorrect_067_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/067/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1461,11 +1461,11 @@ fn relaxng_incorrect_068_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/068/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1483,11 +1483,11 @@ fn relaxng_valid_069_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/069/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/069/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1505,11 +1505,11 @@ fn relaxng_incorrect_070_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/070/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1527,11 +1527,11 @@ fn relaxng_incorrect_071_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/071/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1549,11 +1549,11 @@ fn relaxng_incorrect_072_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/072/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1571,11 +1571,11 @@ fn relaxng_incorrect_073_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/073/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1593,11 +1593,11 @@ fn relaxng_incorrect_074_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/074/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1615,11 +1615,11 @@ fn relaxng_valid_075_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/075/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/075/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1637,11 +1637,11 @@ fn relaxng_incorrect_076_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/076/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1659,11 +1659,11 @@ fn relaxng_incorrect_077_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/077/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1681,11 +1681,11 @@ fn relaxng_incorrect_078_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/078/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1703,11 +1703,11 @@ fn relaxng_incorrect_079_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/079/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1725,11 +1725,11 @@ fn relaxng_incorrect_080_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/080/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1747,11 +1747,11 @@ fn relaxng_incorrect_081_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/081/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1769,11 +1769,11 @@ fn relaxng_incorrect_082_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/082/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1791,11 +1791,11 @@ fn relaxng_incorrect_083_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/083/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1813,11 +1813,11 @@ fn relaxng_incorrect_084_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/084/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1835,11 +1835,11 @@ fn relaxng_incorrect_085_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/085/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1857,11 +1857,11 @@ fn relaxng_incorrect_086_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/086/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1879,11 +1879,11 @@ fn relaxng_incorrect_087_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/087/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -1901,11 +1901,11 @@ fn relaxng_valid_088_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/088/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/088/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1923,11 +1923,11 @@ fn relaxng_valid_089_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/089/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/089/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1945,11 +1945,11 @@ fn relaxng_valid_090_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/090/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/090/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1967,11 +1967,11 @@ fn relaxng_valid_091_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/091/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/091/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -1989,11 +1989,11 @@ fn relaxng_valid_092_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/092/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/092/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2011,11 +2011,11 @@ fn relaxng_valid_093_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/093/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/093/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2032,11 +2032,11 @@ fn relaxng_valid_094_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/094/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/094/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2053,11 +2053,11 @@ fn relaxng_valid_095_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/095/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/095/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2074,11 +2074,11 @@ fn relaxng_invalid_095_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/095/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/095/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2095,11 +2095,11 @@ fn relaxng_valid_096_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/096/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/096/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2116,11 +2116,11 @@ fn relaxng_valid_097_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/097/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/097/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2137,11 +2137,11 @@ fn relaxng_valid_098_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/098/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/098/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2158,11 +2158,11 @@ fn relaxng_valid_099_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2179,11 +2179,11 @@ fn relaxng_valid_099_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2200,11 +2200,11 @@ fn relaxng_valid_099_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2221,11 +2221,11 @@ fn relaxng_invalid_099_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2242,11 +2242,11 @@ fn relaxng_invalid_099_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/099/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2263,11 +2263,11 @@ fn relaxng_valid_100_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/100/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/100/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2284,11 +2284,11 @@ fn relaxng_invalid_100_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/100/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/100/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2305,11 +2305,11 @@ fn relaxng_valid_101_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/101/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/101/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2326,11 +2326,11 @@ fn relaxng_invalid_101_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/101/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/101/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2347,11 +2347,11 @@ fn relaxng_incorrect_102_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/102/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2368,11 +2368,11 @@ fn relaxng_valid_103_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/103/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/103/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2389,11 +2389,11 @@ fn relaxng_invalid_103_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/103/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/103/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2410,11 +2410,11 @@ fn relaxng_valid_104_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/104/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/104/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2431,11 +2431,11 @@ fn relaxng_invalid_104_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/104/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/104/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2452,11 +2452,11 @@ fn relaxng_incorrect_105_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/105/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2473,11 +2473,11 @@ fn relaxng_incorrect_106_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/106/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2494,11 +2494,11 @@ fn relaxng_incorrect_107_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/107/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2516,11 +2516,11 @@ fn relaxng_valid_108_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/108/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/108/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2538,11 +2538,11 @@ fn relaxng_invalid_108_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/108/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/108/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2559,11 +2559,11 @@ fn relaxng_valid_109_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/109/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/109/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2580,11 +2580,11 @@ fn relaxng_invalid_109_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/109/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/109/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2601,11 +2601,11 @@ fn relaxng_valid_110_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/110/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/110/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2622,11 +2622,11 @@ fn relaxng_invalid_110_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/110/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/110/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2643,11 +2643,11 @@ fn relaxng_valid_111_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/111/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/111/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2664,11 +2664,11 @@ fn relaxng_invalid_111_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/111/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/111/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2685,11 +2685,11 @@ fn relaxng_incorrect_112_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/112/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2706,11 +2706,11 @@ fn relaxng_incorrect_113_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/113/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2727,11 +2727,11 @@ fn relaxng_incorrect_114_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/114/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2748,11 +2748,11 @@ fn relaxng_valid_115_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/115/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/115/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2769,11 +2769,11 @@ fn relaxng_invalid_115_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/115/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/115/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2790,11 +2790,11 @@ fn relaxng_incorrect_116_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/116/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2811,11 +2811,11 @@ fn relaxng_valid_117_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/117/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/117/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2832,11 +2832,11 @@ fn relaxng_invalid_117_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/117/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/117/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2853,11 +2853,11 @@ fn relaxng_incorrect_118_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/118/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2874,11 +2874,11 @@ fn relaxng_valid_119_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/119/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/119/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2895,11 +2895,11 @@ fn relaxng_invalid_119_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/119/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/119/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2916,11 +2916,11 @@ fn relaxng_valid_120_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2937,11 +2937,11 @@ fn relaxng_valid_120_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -2958,11 +2958,11 @@ fn relaxng_invalid_120_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/120/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -2979,11 +2979,11 @@ fn relaxng_incorrect_121_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/121/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3000,11 +3000,11 @@ fn relaxng_valid_122_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/122/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/122/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3021,11 +3021,11 @@ fn relaxng_invalid_122_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/122/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/122/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3042,11 +3042,11 @@ fn relaxng_invalid_123_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/123/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/123/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3063,11 +3063,11 @@ fn relaxng_valid_123_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/123/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/123/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3084,11 +3084,11 @@ fn relaxng_valid_124_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/124/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/124/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3105,11 +3105,11 @@ fn relaxng_invalid_124_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/124/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/124/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3126,11 +3126,11 @@ fn relaxng_valid_125_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/125/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/125/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3147,11 +3147,11 @@ fn relaxng_invalid_125_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/125/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/125/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3167,11 +3167,11 @@ fn relaxng_valid_126_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/126/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/126/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3187,11 +3187,11 @@ fn relaxng_invalid_126_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/126/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/126/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3207,11 +3207,11 @@ fn relaxng_valid_127_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/127/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/127/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3227,11 +3227,11 @@ fn relaxng_invalid_127_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/127/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/127/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3247,11 +3247,11 @@ fn relaxng_valid_128_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/128/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/128/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3267,11 +3267,11 @@ fn relaxng_invalid_128_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/128/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/128/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3288,11 +3288,11 @@ fn relaxng_incorrect_129_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/129/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3309,11 +3309,11 @@ fn relaxng_valid_130_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/130/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/130/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3330,11 +3330,11 @@ fn relaxng_invalid_130_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/130/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/130/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3351,11 +3351,11 @@ fn relaxng_valid_131_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/131/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/131/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3372,11 +3372,11 @@ fn relaxng_invalid_131_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/131/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/131/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3393,11 +3393,11 @@ fn relaxng_valid_132_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/132/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/132/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3414,11 +3414,11 @@ fn relaxng_invalid_132_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/132/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/132/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3435,11 +3435,11 @@ fn relaxng_valid_133_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/133/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/133/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3456,11 +3456,11 @@ fn relaxng_invalid_133_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/133/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/133/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3477,11 +3477,11 @@ fn relaxng_valid_134_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3498,11 +3498,11 @@ fn relaxng_invalid_134_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3519,11 +3519,11 @@ fn relaxng_invalid_134_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3540,11 +3540,11 @@ fn relaxng_invalid_134_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3561,11 +3561,11 @@ fn relaxng_invalid_134_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3582,11 +3582,11 @@ fn relaxng_invalid_134_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3603,11 +3603,11 @@ fn relaxng_invalid_134_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3624,11 +3624,11 @@ fn relaxng_invalid_134_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/134/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3645,11 +3645,11 @@ fn relaxng_valid_135_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3666,11 +3666,11 @@ fn relaxng_valid_135_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3687,11 +3687,11 @@ fn relaxng_invalid_135_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3708,11 +3708,11 @@ fn relaxng_invalid_135_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3729,11 +3729,11 @@ fn relaxng_invalid_135_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3750,11 +3750,11 @@ fn relaxng_invalid_135_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3771,11 +3771,11 @@ fn relaxng_invalid_135_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3792,11 +3792,11 @@ fn relaxng_invalid_135_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/135/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3813,11 +3813,11 @@ fn relaxng_valid_136_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3834,11 +3834,11 @@ fn relaxng_valid_136_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3855,11 +3855,11 @@ fn relaxng_invalid_136_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3876,11 +3876,11 @@ fn relaxng_invalid_136_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3897,11 +3897,11 @@ fn relaxng_valid_136_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -3918,11 +3918,11 @@ fn relaxng_invalid_136_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3939,11 +3939,11 @@ fn relaxng_invalid_136_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3960,11 +3960,11 @@ fn relaxng_invalid_136_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/136/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -3981,11 +3981,11 @@ fn relaxng_valid_137_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4002,11 +4002,11 @@ fn relaxng_invalid_137_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4023,11 +4023,11 @@ fn relaxng_invalid_137_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4044,11 +4044,11 @@ fn relaxng_invalid_137_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4065,11 +4065,11 @@ fn relaxng_valid_137_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4086,11 +4086,11 @@ fn relaxng_invalid_137_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4107,11 +4107,11 @@ fn relaxng_invalid_137_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4128,11 +4128,11 @@ fn relaxng_invalid_137_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/137/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4149,11 +4149,11 @@ fn relaxng_valid_138_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/138/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/138/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4170,11 +4170,11 @@ fn relaxng_invalid_138_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/138/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/138/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4191,11 +4191,11 @@ fn relaxng_valid_139_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4212,11 +4212,11 @@ fn relaxng_invalid_139_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4233,11 +4233,11 @@ fn relaxng_invalid_139_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4254,11 +4254,11 @@ fn relaxng_invalid_139_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4275,11 +4275,11 @@ fn relaxng_invalid_139_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4296,11 +4296,11 @@ fn relaxng_valid_139_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/6.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4317,11 +4317,11 @@ fn relaxng_invalid_139_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4338,11 +4338,11 @@ fn relaxng_invalid_139_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/139/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4359,11 +4359,11 @@ fn relaxng_valid_140_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4380,11 +4380,11 @@ fn relaxng_invalid_140_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4401,11 +4401,11 @@ fn relaxng_invalid_140_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4422,11 +4422,11 @@ fn relaxng_invalid_140_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4443,11 +4443,11 @@ fn relaxng_invalid_140_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4464,11 +4464,11 @@ fn relaxng_invalid_140_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4485,11 +4485,11 @@ fn relaxng_invalid_140_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4506,11 +4506,11 @@ fn relaxng_invalid_140_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/140/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4527,11 +4527,11 @@ fn relaxng_valid_141_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4548,11 +4548,11 @@ fn relaxng_invalid_141_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4569,11 +4569,11 @@ fn relaxng_invalid_141_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4590,11 +4590,11 @@ fn relaxng_invalid_141_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/141/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4611,11 +4611,11 @@ fn relaxng_valid_142_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4632,11 +4632,11 @@ fn relaxng_valid_142_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4653,11 +4653,11 @@ fn relaxng_invalid_142_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4674,11 +4674,11 @@ fn relaxng_invalid_142_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4695,11 +4695,11 @@ fn relaxng_invalid_142_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/142/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4716,11 +4716,11 @@ fn relaxng_valid_143_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4737,11 +4737,11 @@ fn relaxng_valid_143_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4758,11 +4758,11 @@ fn relaxng_invalid_143_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/143/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4779,11 +4779,11 @@ fn relaxng_valid_144_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4800,11 +4800,11 @@ fn relaxng_valid_144_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4821,11 +4821,11 @@ fn relaxng_invalid_144_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/144/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4842,11 +4842,11 @@ fn relaxng_valid_145_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -4863,11 +4863,11 @@ fn relaxng_invalid_145_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4884,11 +4884,11 @@ fn relaxng_invalid_145_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4905,11 +4905,11 @@ fn relaxng_invalid_145_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4926,11 +4926,11 @@ fn relaxng_invalid_145_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4947,11 +4947,11 @@ fn relaxng_invalid_145_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4968,11 +4968,11 @@ fn relaxng_invalid_145_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -4989,11 +4989,11 @@ fn relaxng_invalid_145_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/145/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5010,11 +5010,11 @@ fn relaxng_valid_146_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5031,11 +5031,11 @@ fn relaxng_valid_146_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5052,11 +5052,11 @@ fn relaxng_valid_146_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5073,11 +5073,11 @@ fn relaxng_invalid_146_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/146/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5094,11 +5094,11 @@ fn relaxng_valid_147_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5115,11 +5115,11 @@ fn relaxng_valid_147_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5136,11 +5136,11 @@ fn relaxng_valid_147_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5157,11 +5157,11 @@ fn relaxng_valid_147_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5178,11 +5178,11 @@ fn relaxng_valid_147_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5199,11 +5199,11 @@ fn relaxng_valid_147_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/6.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5220,11 +5220,11 @@ fn relaxng_invalid_147_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5241,11 +5241,11 @@ fn relaxng_invalid_147_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/147/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5262,11 +5262,11 @@ fn relaxng_valid_148_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/148/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/148/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5283,11 +5283,11 @@ fn relaxng_invalid_148_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/148/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/148/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5304,11 +5304,11 @@ fn relaxng_valid_149_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/149/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/149/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5325,11 +5325,11 @@ fn relaxng_invalid_149_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/149/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/149/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5346,11 +5346,11 @@ fn relaxng_valid_150_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/150/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/150/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5367,11 +5367,11 @@ fn relaxng_invalid_150_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/150/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/150/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5388,11 +5388,11 @@ fn relaxng_valid_151_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5409,11 +5409,11 @@ fn relaxng_valid_151_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5430,11 +5430,11 @@ fn relaxng_valid_151_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5451,11 +5451,11 @@ fn relaxng_valid_151_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5472,11 +5472,11 @@ fn relaxng_invalid_151_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5493,11 +5493,11 @@ fn relaxng_invalid_151_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/151/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5514,11 +5514,11 @@ fn relaxng_valid_152_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5535,11 +5535,11 @@ fn relaxng_valid_152_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5556,11 +5556,11 @@ fn relaxng_invalid_152_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5577,11 +5577,11 @@ fn relaxng_invalid_152_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/152/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5598,11 +5598,11 @@ fn relaxng_valid_153_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5619,11 +5619,11 @@ fn relaxng_valid_153_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5640,11 +5640,11 @@ fn relaxng_invalid_153_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5661,11 +5661,11 @@ fn relaxng_invalid_153_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5682,11 +5682,11 @@ fn relaxng_valid_153_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/153/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5703,11 +5703,11 @@ fn relaxng_incorrect_154_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/154/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5724,11 +5724,11 @@ fn relaxng_incorrect_155_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/155/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5745,11 +5745,11 @@ fn relaxng_incorrect_156_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/156/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5766,11 +5766,11 @@ fn relaxng_incorrect_157_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/157/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5787,11 +5787,11 @@ fn relaxng_incorrect_158_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/158/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5808,11 +5808,11 @@ fn relaxng_incorrect_159_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/159/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5830,11 +5830,11 @@ fn relaxng_incorrect_160_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/160/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5852,11 +5852,11 @@ fn relaxng_incorrect_161_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/161/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5873,11 +5873,11 @@ fn relaxng_incorrect_162_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/162/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5894,11 +5894,11 @@ fn relaxng_valid_163_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/163/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/163/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -5915,11 +5915,11 @@ fn relaxng_incorrect_164_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/164/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5936,11 +5936,11 @@ fn relaxng_incorrect_165_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/165/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5957,11 +5957,11 @@ fn relaxng_incorrect_166_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/166/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5978,11 +5978,11 @@ fn relaxng_incorrect_167_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/167/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -5999,11 +5999,11 @@ fn relaxng_incorrect_168_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/168/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6020,11 +6020,11 @@ fn relaxng_incorrect_169_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/169/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6041,11 +6041,11 @@ fn relaxng_incorrect_170_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/170/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6062,11 +6062,11 @@ fn relaxng_incorrect_171_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/171/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6083,11 +6083,11 @@ fn relaxng_incorrect_172_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/172/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6104,11 +6104,11 @@ fn relaxng_incorrect_173_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/173/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6125,11 +6125,11 @@ fn relaxng_incorrect_174_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/174/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6146,11 +6146,11 @@ fn relaxng_incorrect_175_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/175/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6167,11 +6167,11 @@ fn relaxng_valid_176_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/176/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/176/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6188,11 +6188,11 @@ fn relaxng_incorrect_177_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/177/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6209,11 +6209,11 @@ fn relaxng_incorrect_178_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/178/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6230,11 +6230,11 @@ fn relaxng_incorrect_179_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/179/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6251,11 +6251,11 @@ fn relaxng_incorrect_180_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/180/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6272,11 +6272,11 @@ fn relaxng_incorrect_181_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/181/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6293,11 +6293,11 @@ fn relaxng_incorrect_182_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/182/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6314,11 +6314,11 @@ fn relaxng_incorrect_183_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/183/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6335,11 +6335,11 @@ fn relaxng_incorrect_184_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/184/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6356,11 +6356,11 @@ fn relaxng_incorrect_185_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/185/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6377,11 +6377,11 @@ fn relaxng_incorrect_186_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/186/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6398,11 +6398,11 @@ fn relaxng_incorrect_187_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/187/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6419,11 +6419,11 @@ fn relaxng_incorrect_188_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/188/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6440,11 +6440,11 @@ fn relaxng_incorrect_189_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/189/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6461,11 +6461,11 @@ fn relaxng_valid_190_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6482,11 +6482,11 @@ fn relaxng_valid_190_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6503,11 +6503,11 @@ fn relaxng_valid_190_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6524,11 +6524,11 @@ fn relaxng_invalid_190_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/190/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6545,11 +6545,11 @@ fn relaxng_valid_191_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6566,11 +6566,11 @@ fn relaxng_valid_191_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6587,11 +6587,11 @@ fn relaxng_valid_191_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6608,11 +6608,11 @@ fn relaxng_invalid_191_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/191/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6629,11 +6629,11 @@ fn relaxng_incorrect_192_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/192/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6650,11 +6650,11 @@ fn relaxng_incorrect_193_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/193/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6671,11 +6671,11 @@ fn relaxng_valid_194_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6692,11 +6692,11 @@ fn relaxng_valid_194_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6713,11 +6713,11 @@ fn relaxng_valid_194_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6734,11 +6734,11 @@ fn relaxng_invalid_194_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/194/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6755,11 +6755,11 @@ fn relaxng_valid_195_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6776,11 +6776,11 @@ fn relaxng_valid_195_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6797,11 +6797,11 @@ fn relaxng_valid_195_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -6818,11 +6818,11 @@ fn relaxng_invalid_195_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/195/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6839,11 +6839,11 @@ fn relaxng_incorrect_196_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/196/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6860,11 +6860,11 @@ fn relaxng_incorrect_197_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/197/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6882,11 +6882,11 @@ fn relaxng_incorrect_198_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/198/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6904,11 +6904,11 @@ fn relaxng_incorrect_199_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/199/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6926,11 +6926,11 @@ fn relaxng_incorrect_200_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/200/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6948,11 +6948,11 @@ fn relaxng_incorrect_201_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/201/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6970,11 +6970,11 @@ fn relaxng_incorrect_202_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/202/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -6992,11 +6992,11 @@ fn relaxng_incorrect_203_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/203/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7014,11 +7014,11 @@ fn relaxng_incorrect_204_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/204/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7036,11 +7036,11 @@ fn relaxng_incorrect_205_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/205/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7058,11 +7058,11 @@ fn relaxng_incorrect_206_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/206/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7079,11 +7079,11 @@ fn relaxng_incorrect_207_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/207/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7100,11 +7100,11 @@ fn relaxng_valid_208_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/208/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/208/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7121,11 +7121,11 @@ fn relaxng_valid_209_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/209/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/209/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7142,11 +7142,11 @@ fn relaxng_invalid_209_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/209/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/209/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7163,11 +7163,11 @@ fn relaxng_valid_210_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/210/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/210/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7184,11 +7184,11 @@ fn relaxng_invalid_210_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/210/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/210/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7205,11 +7205,11 @@ fn relaxng_incorrect_211_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/211/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7226,11 +7226,11 @@ fn relaxng_valid_212_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7247,11 +7247,11 @@ fn relaxng_valid_212_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7268,11 +7268,11 @@ fn relaxng_invalid_212_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/212/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7289,11 +7289,11 @@ fn relaxng_valid_213_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/213/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/213/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7312,11 +7312,11 @@ normalization of notAllowed.
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/214/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7333,11 +7333,11 @@ fn relaxng_valid_215_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/215/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/215/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7354,11 +7354,11 @@ fn relaxng_valid_215_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/215/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/215/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7375,11 +7375,11 @@ fn relaxng_invalid_216_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7396,11 +7396,11 @@ fn relaxng_valid_216_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7417,11 +7417,11 @@ fn relaxng_valid_216_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/216/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7438,11 +7438,11 @@ fn relaxng_invalid_217_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/217/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/217/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7459,11 +7459,11 @@ fn relaxng_valid_217_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/217/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/217/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7480,11 +7480,11 @@ fn relaxng_valid_218_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/218/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/218/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7501,11 +7501,11 @@ fn relaxng_invalid_218_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/218/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/218/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7522,11 +7522,11 @@ fn relaxng_invalid_219_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7543,11 +7543,11 @@ fn relaxng_invalid_219_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7564,11 +7564,11 @@ fn relaxng_invalid_219_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7585,11 +7585,11 @@ fn relaxng_valid_219_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/219/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7606,11 +7606,11 @@ fn relaxng_invalid_220_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7627,11 +7627,11 @@ fn relaxng_invalid_220_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7648,11 +7648,11 @@ fn relaxng_valid_220_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/220/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7669,11 +7669,11 @@ fn relaxng_invalid_221_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7690,11 +7690,11 @@ fn relaxng_invalid_221_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7711,11 +7711,11 @@ fn relaxng_valid_221_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7732,11 +7732,11 @@ fn relaxng_valid_221_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/221/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7753,11 +7753,11 @@ fn relaxng_valid_222_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7774,11 +7774,11 @@ fn relaxng_invalid_222_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7795,11 +7795,11 @@ fn relaxng_invalid_222_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7816,11 +7816,11 @@ fn relaxng_invalid_222_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/222/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7837,11 +7837,11 @@ fn relaxng_invalid_223_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7858,11 +7858,11 @@ fn relaxng_valid_223_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7879,11 +7879,11 @@ fn relaxng_invalid_223_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7900,11 +7900,11 @@ fn relaxng_invalid_223_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/223/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7921,11 +7921,11 @@ fn relaxng_invalid_224_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -7942,11 +7942,11 @@ fn relaxng_valid_224_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7963,11 +7963,11 @@ fn relaxng_valid_224_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/224/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -7984,11 +7984,11 @@ fn relaxng_valid_225_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8005,11 +8005,11 @@ fn relaxng_valid_225_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8026,11 +8026,11 @@ fn relaxng_invalid_225_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/225/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8047,11 +8047,11 @@ fn relaxng_valid_226_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8068,11 +8068,11 @@ fn relaxng_valid_226_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8089,11 +8089,11 @@ fn relaxng_invalid_226_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8110,11 +8110,11 @@ fn relaxng_invalid_226_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8131,11 +8131,11 @@ fn relaxng_invalid_226_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8152,11 +8152,11 @@ fn relaxng_invalid_226_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8173,11 +8173,11 @@ fn relaxng_invalid_226_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/226/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8194,11 +8194,11 @@ fn relaxng_valid_227_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8215,11 +8215,11 @@ fn relaxng_valid_227_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8236,11 +8236,11 @@ fn relaxng_invalid_227_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8257,11 +8257,11 @@ fn relaxng_invalid_227_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8278,11 +8278,11 @@ fn relaxng_invalid_227_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8299,11 +8299,11 @@ fn relaxng_invalid_227_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8320,11 +8320,11 @@ fn relaxng_invalid_227_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/227/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8341,11 +8341,11 @@ fn relaxng_valid_228_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8362,11 +8362,11 @@ fn relaxng_valid_228_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8383,11 +8383,11 @@ fn relaxng_invalid_228_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8404,11 +8404,11 @@ fn relaxng_invalid_228_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8425,11 +8425,11 @@ fn relaxng_invalid_228_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8446,11 +8446,11 @@ fn relaxng_invalid_228_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8467,11 +8467,11 @@ fn relaxng_invalid_228_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/228/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8488,11 +8488,11 @@ fn relaxng_valid_229_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8509,11 +8509,11 @@ fn relaxng_invalid_229_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8530,11 +8530,11 @@ fn relaxng_invalid_229_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8551,11 +8551,11 @@ fn relaxng_invalid_229_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8572,11 +8572,11 @@ fn relaxng_invalid_229_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8593,11 +8593,11 @@ fn relaxng_invalid_229_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/229/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8614,11 +8614,11 @@ fn relaxng_valid_230_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/230/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/230/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8635,11 +8635,11 @@ fn relaxng_invalid_230_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/230/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/230/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8656,11 +8656,11 @@ fn relaxng_valid_231_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8677,11 +8677,11 @@ fn relaxng_invalid_231_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8698,11 +8698,11 @@ fn relaxng_invalid_231_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8719,11 +8719,11 @@ fn relaxng_invalid_231_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/231/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8740,11 +8740,11 @@ fn relaxng_valid_232_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8761,11 +8761,11 @@ fn relaxng_invalid_232_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8782,11 +8782,11 @@ fn relaxng_invalid_232_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8803,11 +8803,11 @@ fn relaxng_invalid_232_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/232/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8824,11 +8824,11 @@ fn relaxng_valid_233_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8845,11 +8845,11 @@ fn relaxng_invalid_233_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8866,11 +8866,11 @@ fn relaxng_invalid_233_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8887,11 +8887,11 @@ fn relaxng_invalid_233_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/233/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8908,11 +8908,11 @@ fn relaxng_valid_234_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -8929,11 +8929,11 @@ fn relaxng_invalid_234_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8950,11 +8950,11 @@ fn relaxng_invalid_234_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8971,11 +8971,11 @@ fn relaxng_invalid_234_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/234/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -8992,11 +8992,11 @@ fn relaxng_valid_235_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9013,11 +9013,11 @@ fn relaxng_valid_235_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9034,11 +9034,11 @@ fn relaxng_valid_235_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9055,11 +9055,11 @@ fn relaxng_valid_235_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9076,11 +9076,11 @@ fn relaxng_invalid_235_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9097,11 +9097,11 @@ fn relaxng_invalid_235_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9118,11 +9118,11 @@ fn relaxng_invalid_235_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/235/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9139,11 +9139,11 @@ fn relaxng_valid_236_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9160,11 +9160,11 @@ fn relaxng_valid_236_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9181,11 +9181,11 @@ fn relaxng_invalid_236_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/236/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9202,11 +9202,11 @@ fn relaxng_valid_237_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9223,11 +9223,11 @@ fn relaxng_valid_237_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9244,11 +9244,11 @@ fn relaxng_invalid_237_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9265,11 +9265,11 @@ fn relaxng_invalid_237_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9286,11 +9286,11 @@ fn relaxng_invalid_237_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/237/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9307,11 +9307,11 @@ fn relaxng_valid_238_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9328,11 +9328,11 @@ fn relaxng_valid_238_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9349,11 +9349,11 @@ fn relaxng_invalid_238_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/238/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9370,11 +9370,11 @@ fn relaxng_valid_239_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9391,11 +9391,11 @@ fn relaxng_valid_239_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9412,11 +9412,11 @@ fn relaxng_invalid_239_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9433,11 +9433,11 @@ fn relaxng_invalid_239_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/239/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9453,11 +9453,11 @@ fn relaxng_valid_240_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9473,11 +9473,11 @@ fn relaxng_valid_240_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9493,11 +9493,11 @@ fn relaxng_invalid_240_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9513,11 +9513,11 @@ fn relaxng_invalid_240_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/240/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9534,11 +9534,11 @@ fn relaxng_valid_241_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9555,11 +9555,11 @@ fn relaxng_valid_241_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9576,11 +9576,11 @@ fn relaxng_valid_241_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9597,11 +9597,11 @@ fn relaxng_valid_241_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9618,11 +9618,11 @@ fn relaxng_invalid_241_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/241/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9639,11 +9639,11 @@ fn relaxng_valid_242_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9660,11 +9660,11 @@ fn relaxng_valid_242_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9681,11 +9681,11 @@ fn relaxng_valid_242_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9702,11 +9702,11 @@ fn relaxng_valid_242_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9723,11 +9723,11 @@ fn relaxng_invalid_242_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9744,11 +9744,11 @@ fn relaxng_invalid_242_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/242/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9765,11 +9765,11 @@ fn relaxng_valid_243_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9786,11 +9786,11 @@ fn relaxng_valid_243_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9807,11 +9807,11 @@ fn relaxng_invalid_243_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9828,11 +9828,11 @@ fn relaxng_valid_243_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9849,11 +9849,11 @@ fn relaxng_invalid_243_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9870,11 +9870,11 @@ fn relaxng_valid_243_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/6.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/243/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9891,11 +9891,11 @@ fn relaxng_valid_244_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9912,11 +9912,11 @@ fn relaxng_valid_244_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9933,11 +9933,11 @@ fn relaxng_valid_244_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9954,11 +9954,11 @@ fn relaxng_valid_244_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -9975,11 +9975,11 @@ fn relaxng_invalid_244_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -9996,11 +9996,11 @@ fn relaxng_valid_244_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/6.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10017,11 +10017,11 @@ fn relaxng_valid_244_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/7.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10038,11 +10038,11 @@ fn relaxng_invalid_244_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/244/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10059,11 +10059,11 @@ fn relaxng_valid_245_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10080,11 +10080,11 @@ fn relaxng_valid_245_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10101,11 +10101,11 @@ fn relaxng_valid_245_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10122,11 +10122,11 @@ fn relaxng_invalid_245_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10143,11 +10143,11 @@ fn relaxng_invalid_245_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/245/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10164,11 +10164,11 @@ fn relaxng_valid_246_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10185,11 +10185,11 @@ fn relaxng_valid_246_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10206,11 +10206,11 @@ fn relaxng_valid_246_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10227,11 +10227,11 @@ fn relaxng_invalid_246_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/246/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10248,11 +10248,11 @@ fn relaxng_valid_247_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10269,11 +10269,11 @@ fn relaxng_valid_247_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10290,11 +10290,11 @@ fn relaxng_valid_247_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10311,11 +10311,11 @@ fn relaxng_invalid_247_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10332,11 +10332,11 @@ fn relaxng_invalid_247_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10353,11 +10353,11 @@ fn relaxng_invalid_247_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/247/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10374,11 +10374,11 @@ fn relaxng_valid_248_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10395,11 +10395,11 @@ fn relaxng_valid_248_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10416,11 +10416,11 @@ fn relaxng_valid_248_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10437,11 +10437,11 @@ fn relaxng_invalid_248_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10458,11 +10458,11 @@ fn relaxng_invalid_248_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10479,11 +10479,11 @@ fn relaxng_invalid_248_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/248/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10500,11 +10500,11 @@ fn relaxng_valid_249_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10521,11 +10521,11 @@ fn relaxng_valid_249_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10542,11 +10542,11 @@ fn relaxng_valid_249_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10563,11 +10563,11 @@ fn relaxng_invalid_249_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/249/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10584,11 +10584,11 @@ fn relaxng_valid_250_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10605,11 +10605,11 @@ fn relaxng_valid_250_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10626,11 +10626,11 @@ fn relaxng_invalid_250_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10647,11 +10647,11 @@ fn relaxng_invalid_250_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10668,11 +10668,11 @@ fn relaxng_invalid_250_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10689,11 +10689,11 @@ fn relaxng_invalid_250_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/250/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10710,11 +10710,11 @@ fn relaxng_valid_251_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10731,11 +10731,11 @@ fn relaxng_valid_251_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10752,11 +10752,11 @@ fn relaxng_valid_251_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10773,11 +10773,11 @@ fn relaxng_invalid_251_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10794,11 +10794,11 @@ fn relaxng_invalid_251_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10815,11 +10815,11 @@ fn relaxng_invalid_251_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10836,11 +10836,11 @@ fn relaxng_invalid_251_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10857,11 +10857,11 @@ fn relaxng_invalid_251_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/251/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10878,11 +10878,11 @@ fn relaxng_valid_252_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -10899,11 +10899,11 @@ fn relaxng_invalid_252_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10920,11 +10920,11 @@ fn relaxng_invalid_252_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10941,11 +10941,11 @@ fn relaxng_invalid_252_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10962,11 +10962,11 @@ fn relaxng_invalid_252_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/252/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -10983,11 +10983,11 @@ fn relaxng_valid_253_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11004,11 +11004,11 @@ fn relaxng_invalid_253_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11025,11 +11025,11 @@ fn relaxng_invalid_253_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11046,11 +11046,11 @@ fn relaxng_invalid_253_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11067,11 +11067,11 @@ fn relaxng_invalid_253_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/253/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11088,11 +11088,11 @@ fn relaxng_valid_254_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11109,11 +11109,11 @@ fn relaxng_invalid_254_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11130,11 +11130,11 @@ fn relaxng_invalid_254_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11151,11 +11151,11 @@ fn relaxng_invalid_254_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11172,11 +11172,11 @@ fn relaxng_invalid_254_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11193,11 +11193,11 @@ fn relaxng_invalid_254_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/254/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11214,11 +11214,11 @@ fn relaxng_valid_255_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11235,11 +11235,11 @@ fn relaxng_valid_255_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11256,11 +11256,11 @@ fn relaxng_invalid_255_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11277,11 +11277,11 @@ fn relaxng_invalid_255_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11298,11 +11298,11 @@ fn relaxng_invalid_255_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11319,11 +11319,11 @@ fn relaxng_invalid_255_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11340,11 +11340,11 @@ fn relaxng_invalid_255_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/255/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11361,11 +11361,11 @@ fn relaxng_valid_256_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11382,11 +11382,11 @@ fn relaxng_invalid_256_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11403,11 +11403,11 @@ fn relaxng_invalid_256_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/256/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11424,11 +11424,11 @@ fn relaxng_valid_257_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11445,11 +11445,11 @@ fn relaxng_valid_257_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11466,11 +11466,11 @@ fn relaxng_valid_257_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11487,11 +11487,11 @@ fn relaxng_invalid_257_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11508,11 +11508,11 @@ fn relaxng_invalid_257_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/257/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11529,11 +11529,11 @@ fn relaxng_valid_258_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11550,11 +11550,11 @@ fn relaxng_invalid_258_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11571,11 +11571,11 @@ fn relaxng_invalid_258_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/258/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11592,11 +11592,11 @@ fn relaxng_valid_259_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11613,11 +11613,11 @@ fn relaxng_valid_259_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11634,11 +11634,11 @@ fn relaxng_invalid_259_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/259/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11655,11 +11655,11 @@ fn relaxng_invalid_260_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11676,11 +11676,11 @@ fn relaxng_invalid_260_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11697,11 +11697,11 @@ fn relaxng_valid_260_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11718,11 +11718,11 @@ fn relaxng_valid_260_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11739,11 +11739,11 @@ fn relaxng_invalid_260_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/260/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11760,11 +11760,11 @@ fn relaxng_valid_261_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11781,11 +11781,11 @@ fn relaxng_valid_261_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11802,11 +11802,11 @@ fn relaxng_valid_261_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11823,11 +11823,11 @@ fn relaxng_valid_261_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11844,11 +11844,11 @@ fn relaxng_invalid_261_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11865,11 +11865,11 @@ fn relaxng_invalid_261_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11886,11 +11886,11 @@ fn relaxng_invalid_261_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/261/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11907,11 +11907,11 @@ fn relaxng_valid_262_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11928,11 +11928,11 @@ fn relaxng_valid_262_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11949,11 +11949,11 @@ fn relaxng_invalid_262_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -11970,11 +11970,11 @@ fn relaxng_valid_262_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -11991,11 +11991,11 @@ fn relaxng_valid_262_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12012,11 +12012,11 @@ fn relaxng_invalid_262_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12033,11 +12033,11 @@ fn relaxng_invalid_262_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12054,11 +12054,11 @@ fn relaxng_invalid_262_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/262/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12075,11 +12075,11 @@ fn relaxng_valid_263_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12096,11 +12096,11 @@ fn relaxng_valid_263_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12117,11 +12117,11 @@ fn relaxng_invalid_263_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12138,11 +12138,11 @@ fn relaxng_valid_263_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12159,11 +12159,11 @@ fn relaxng_valid_263_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12180,11 +12180,11 @@ fn relaxng_valid_263_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/6.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12201,11 +12201,11 @@ fn relaxng_invalid_263_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12222,11 +12222,11 @@ fn relaxng_valid_263_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/8.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/263/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12243,11 +12243,11 @@ fn relaxng_valid_264_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12264,11 +12264,11 @@ fn relaxng_invalid_264_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12285,11 +12285,11 @@ fn relaxng_invalid_264_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12306,11 +12306,11 @@ fn relaxng_invalid_264_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/264/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12327,11 +12327,11 @@ fn relaxng_valid_265_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/265/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/265/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12348,11 +12348,11 @@ fn relaxng_valid_266_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/266/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/266/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12369,11 +12369,11 @@ fn relaxng_invalid_267_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/267/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/267/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12390,11 +12390,11 @@ fn relaxng_valid_267_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/267/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/267/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12411,11 +12411,11 @@ fn relaxng_valid_268_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12432,11 +12432,11 @@ fn relaxng_valid_268_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12453,11 +12453,11 @@ fn relaxng_valid_268_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12474,11 +12474,11 @@ fn relaxng_valid_268_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12495,11 +12495,11 @@ fn relaxng_invalid_268_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12516,11 +12516,11 @@ fn relaxng_invalid_268_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/268/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12537,11 +12537,11 @@ fn relaxng_valid_269_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12558,11 +12558,11 @@ fn relaxng_valid_269_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12579,11 +12579,11 @@ fn relaxng_valid_269_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12600,11 +12600,11 @@ fn relaxng_valid_269_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12621,11 +12621,11 @@ fn relaxng_invalid_269_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12642,11 +12642,11 @@ fn relaxng_invalid_269_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/269/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12663,11 +12663,11 @@ fn relaxng_valid_270_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12684,11 +12684,11 @@ fn relaxng_invalid_270_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12705,11 +12705,11 @@ fn relaxng_invalid_270_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12726,11 +12726,11 @@ fn relaxng_invalid_270_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/270/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12747,11 +12747,11 @@ fn relaxng_valid_271_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12768,11 +12768,11 @@ fn relaxng_invalid_271_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12789,11 +12789,11 @@ fn relaxng_invalid_271_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12810,11 +12810,11 @@ fn relaxng_invalid_271_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/271/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12831,11 +12831,11 @@ fn relaxng_valid_272_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12852,11 +12852,11 @@ fn relaxng_valid_272_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12873,11 +12873,11 @@ fn relaxng_valid_272_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12894,11 +12894,11 @@ fn relaxng_valid_272_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12915,11 +12915,11 @@ fn relaxng_invalid_272_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12936,11 +12936,11 @@ fn relaxng_invalid_272_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/272/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -12957,11 +12957,11 @@ fn relaxng_valid_273_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12978,11 +12978,11 @@ fn relaxng_valid_273_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -12999,11 +12999,11 @@ fn relaxng_valid_273_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13020,11 +13020,11 @@ fn relaxng_invalid_273_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/273/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13041,11 +13041,11 @@ fn relaxng_valid_274_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13062,11 +13062,11 @@ fn relaxng_valid_274_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13083,11 +13083,11 @@ fn relaxng_valid_274_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13104,11 +13104,11 @@ fn relaxng_valid_274_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13125,11 +13125,11 @@ fn relaxng_invalid_274_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13146,11 +13146,11 @@ fn relaxng_invalid_274_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/274/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13167,11 +13167,11 @@ fn relaxng_valid_275_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13188,11 +13188,11 @@ fn relaxng_valid_275_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13209,11 +13209,11 @@ fn relaxng_valid_275_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13230,11 +13230,11 @@ fn relaxng_valid_275_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/4.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13251,11 +13251,11 @@ fn relaxng_valid_275_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/5.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13272,11 +13272,11 @@ fn relaxng_invalid_275_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13293,11 +13293,11 @@ fn relaxng_invalid_275_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/275/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13314,11 +13314,11 @@ fn relaxng_incorrect_276_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/276/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13335,11 +13335,11 @@ fn relaxng_incorrect_277_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/277/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13356,11 +13356,11 @@ fn relaxng_incorrect_278_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/278/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13377,11 +13377,11 @@ fn relaxng_incorrect_279_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/279/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13398,11 +13398,11 @@ fn relaxng_valid_280_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13419,11 +13419,11 @@ fn relaxng_valid_280_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13440,11 +13440,11 @@ fn relaxng_invalid_280_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/280/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13461,11 +13461,11 @@ fn relaxng_valid_281_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13482,11 +13482,11 @@ fn relaxng_valid_281_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13503,11 +13503,11 @@ fn relaxng_invalid_281_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13524,11 +13524,11 @@ fn relaxng_invalid_281_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/281/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13545,11 +13545,11 @@ fn relaxng_valid_282_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13566,11 +13566,11 @@ fn relaxng_valid_282_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13587,11 +13587,11 @@ fn relaxng_valid_282_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13608,11 +13608,11 @@ fn relaxng_invalid_282_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/282/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13629,11 +13629,11 @@ fn relaxng_valid_283_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -13650,11 +13650,11 @@ fn relaxng_invalid_283_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13671,11 +13671,11 @@ fn relaxng_invalid_283_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/283/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13692,11 +13692,11 @@ fn relaxng_invalid_284_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/284/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/284/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13713,11 +13713,11 @@ fn relaxng_incorrect_285_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/285/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13734,11 +13734,11 @@ fn relaxng_incorrect_286_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/286/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13755,11 +13755,11 @@ fn relaxng_incorrect_287_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/287/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13776,11 +13776,11 @@ fn relaxng_incorrect_288_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/288/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13797,11 +13797,11 @@ fn relaxng_incorrect_289_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/289/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13818,11 +13818,11 @@ fn relaxng_incorrect_290_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/290/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13839,11 +13839,11 @@ fn relaxng_incorrect_291_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/291/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13860,11 +13860,11 @@ fn relaxng_incorrect_292_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/292/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13881,11 +13881,11 @@ fn relaxng_incorrect_293_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/293/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13902,11 +13902,11 @@ fn relaxng_incorrect_294_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/294/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13923,11 +13923,11 @@ fn relaxng_incorrect_295_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/295/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13944,11 +13944,11 @@ fn relaxng_incorrect_296_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/296/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13965,11 +13965,11 @@ fn relaxng_incorrect_297_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/297/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -13986,11 +13986,11 @@ fn relaxng_incorrect_298_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/298/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14007,11 +14007,11 @@ fn relaxng_incorrect_299_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/299/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14028,11 +14028,11 @@ fn relaxng_incorrect_300_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/300/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14049,11 +14049,11 @@ fn relaxng_incorrect_301_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/301/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14070,11 +14070,11 @@ fn relaxng_incorrect_302_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/302/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14091,11 +14091,11 @@ fn relaxng_incorrect_303_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/303/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14112,11 +14112,11 @@ fn relaxng_incorrect_304_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/304/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14133,11 +14133,11 @@ fn relaxng_incorrect_305_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/305/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14154,11 +14154,11 @@ fn relaxng_incorrect_306_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/306/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14175,11 +14175,11 @@ fn relaxng_incorrect_307_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/307/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14196,11 +14196,11 @@ fn relaxng_incorrect_308_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/308/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14217,11 +14217,11 @@ fn relaxng_incorrect_309_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/309/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14238,11 +14238,11 @@ fn relaxng_incorrect_310_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/310/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14259,11 +14259,11 @@ fn relaxng_incorrect_311_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/311/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14280,11 +14280,11 @@ fn relaxng_incorrect_312_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/312/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14301,11 +14301,11 @@ fn relaxng_incorrect_313_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/313/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14322,11 +14322,11 @@ fn relaxng_incorrect_314_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/314/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14343,11 +14343,11 @@ fn relaxng_incorrect_315_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/315/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14364,11 +14364,11 @@ fn relaxng_incorrect_316_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/316/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14385,11 +14385,11 @@ fn relaxng_incorrect_317_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/317/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14406,11 +14406,11 @@ fn relaxng_incorrect_318_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/318/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14427,11 +14427,11 @@ fn relaxng_incorrect_319_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/319/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14448,11 +14448,11 @@ fn relaxng_incorrect_320_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/320/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14469,11 +14469,11 @@ fn relaxng_incorrect_321_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/321/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14490,11 +14490,11 @@ fn relaxng_incorrect_322_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/322/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14511,11 +14511,11 @@ fn relaxng_incorrect_323_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/323/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14532,11 +14532,11 @@ fn relaxng_incorrect_324_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/324/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14553,11 +14553,11 @@ fn relaxng_incorrect_325_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/325/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14574,11 +14574,11 @@ fn relaxng_incorrect_326_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/326/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14595,11 +14595,11 @@ fn relaxng_incorrect_327_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/327/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14617,11 +14617,11 @@ fn relaxng_valid_328_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/328/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/328/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14638,11 +14638,11 @@ fn relaxng_incorrect_329_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/329/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14659,11 +14659,11 @@ fn relaxng_valid_330_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/330/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/330/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14682,11 +14682,11 @@ of the not allowed.
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/331/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/331/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14704,11 +14704,11 @@ fn relaxng_valid_332_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/332/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/332/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14726,11 +14726,11 @@ fn relaxng_valid_333_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/333/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/333/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14748,11 +14748,11 @@ fn relaxng_valid_334_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/334/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/334/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14769,11 +14769,11 @@ fn relaxng_incorrect_335_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/335/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14792,11 +14792,11 @@ before string sequence checking.
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/336/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/336/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14814,11 +14814,11 @@ fn relaxng_incorrect_337_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/337/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14835,11 +14835,11 @@ fn relaxng_incorrect_338_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/338/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14856,11 +14856,11 @@ fn relaxng_incorrect_339_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/339/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14877,11 +14877,11 @@ fn relaxng_valid_340_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/340/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/340/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -14898,11 +14898,11 @@ fn relaxng_incorrect_341_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/341/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14919,11 +14919,11 @@ fn relaxng_incorrect_342_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/342/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14940,11 +14940,11 @@ fn relaxng_incorrect_343_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/343/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14961,11 +14961,11 @@ fn relaxng_incorrect_344_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/344/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -14982,11 +14982,11 @@ fn relaxng_valid_345_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15003,11 +15003,11 @@ fn relaxng_valid_345_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15024,11 +15024,11 @@ fn relaxng_invalid_345_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15045,11 +15045,11 @@ fn relaxng_invalid_345_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15066,11 +15066,11 @@ fn relaxng_invalid_345_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/345/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15087,11 +15087,11 @@ fn relaxng_incorrect_346_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/346/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15108,11 +15108,11 @@ fn relaxng_incorrect_347_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/347/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15129,11 +15129,11 @@ fn relaxng_incorrect_348_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/348/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15150,11 +15150,11 @@ fn relaxng_incorrect_349_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/349/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15171,11 +15171,11 @@ fn relaxng_incorrect_350_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/350/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15192,11 +15192,11 @@ fn relaxng_incorrect_351_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/351/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15213,11 +15213,11 @@ fn relaxng_incorrect_352_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/352/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15234,11 +15234,11 @@ fn relaxng_valid_353_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15255,11 +15255,11 @@ fn relaxng_invalid_353_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15276,11 +15276,11 @@ fn relaxng_valid_353_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/353/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15297,11 +15297,11 @@ fn relaxng_valid_354_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/354/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/354/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15318,11 +15318,11 @@ fn relaxng_valid_355_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/355/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/355/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15339,11 +15339,11 @@ fn relaxng_incorrect_356_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/356/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15360,11 +15360,11 @@ fn relaxng_incorrect_357_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/357/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15381,11 +15381,11 @@ fn relaxng_incorrect_358_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/358/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15402,11 +15402,11 @@ fn relaxng_incorrect_359_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/359/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15423,11 +15423,11 @@ fn relaxng_incorrect_360_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/360/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15444,11 +15444,11 @@ fn relaxng_incorrect_361_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/361/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15465,11 +15465,11 @@ fn relaxng_incorrect_362_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/362/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15486,11 +15486,11 @@ fn relaxng_incorrect_363_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/363/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15507,11 +15507,11 @@ fn relaxng_incorrect_364_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/364/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15528,11 +15528,11 @@ fn relaxng_incorrect_365_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/365/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15549,11 +15549,11 @@ fn relaxng_incorrect_366_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/366/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15570,11 +15570,11 @@ fn relaxng_incorrect_367_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/367/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15591,11 +15591,11 @@ fn relaxng_valid_368_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/368/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/368/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15612,11 +15612,11 @@ fn relaxng_valid_369_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/369/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/369/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15633,11 +15633,11 @@ fn relaxng_incorrect_370_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/370/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15654,11 +15654,11 @@ fn relaxng_incorrect_371_1(){
 
     let docfile = "<doc/>".to_string();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/371/i.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15675,11 +15675,11 @@ fn relaxng_valid_372_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/372/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/372/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15696,11 +15696,11 @@ fn relaxng_invalid_373_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/373/1.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/373/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15717,11 +15717,11 @@ fn relaxng_valid_374_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15738,11 +15738,11 @@ fn relaxng_invalid_374_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15759,11 +15759,11 @@ fn relaxng_invalid_374_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15780,11 +15780,11 @@ fn relaxng_invalid_374_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15801,11 +15801,11 @@ fn relaxng_invalid_374_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15822,11 +15822,11 @@ fn relaxng_invalid_374_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15843,11 +15843,11 @@ fn relaxng_invalid_374_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15864,11 +15864,11 @@ fn relaxng_invalid_374_8(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/8.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15885,11 +15885,11 @@ fn relaxng_invalid_374_9(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/9.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/374/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15906,11 +15906,11 @@ fn relaxng_valid_375_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/375/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/375/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15927,11 +15927,11 @@ fn relaxng_invalid_375_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/375/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/375/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -15948,11 +15948,11 @@ fn relaxng_valid_376_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15969,11 +15969,11 @@ fn relaxng_valid_376_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -15990,11 +15990,11 @@ fn relaxng_invalid_376_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/376/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16011,11 +16011,11 @@ fn relaxng_valid_377_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/377/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/377/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16032,11 +16032,11 @@ fn relaxng_invalid_377_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/377/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/377/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16053,11 +16053,11 @@ fn relaxng_valid_378_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16074,11 +16074,11 @@ fn relaxng_invalid_378_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16095,11 +16095,11 @@ fn relaxng_invalid_378_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16116,11 +16116,11 @@ fn relaxng_invalid_378_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/378/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16137,11 +16137,11 @@ fn relaxng_valid_379_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16158,11 +16158,11 @@ fn relaxng_valid_379_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16179,11 +16179,11 @@ fn relaxng_invalid_379_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16200,11 +16200,11 @@ fn relaxng_invalid_379_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16221,11 +16221,11 @@ fn relaxng_invalid_379_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/379/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16242,11 +16242,11 @@ fn relaxng_valid_380_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16263,11 +16263,11 @@ fn relaxng_valid_380_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16284,11 +16284,11 @@ fn relaxng_invalid_380_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16305,11 +16305,11 @@ fn relaxng_invalid_380_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16326,11 +16326,11 @@ fn relaxng_invalid_380_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/380/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16347,11 +16347,11 @@ fn relaxng_valid_381_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16368,11 +16368,11 @@ fn relaxng_invalid_381_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16389,11 +16389,11 @@ fn relaxng_invalid_381_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/381/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16410,11 +16410,11 @@ fn relaxng_valid_382_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16431,11 +16431,11 @@ fn relaxng_invalid_382_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16452,11 +16452,11 @@ fn relaxng_invalid_382_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16473,11 +16473,11 @@ fn relaxng_invalid_382_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/382/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16494,11 +16494,11 @@ fn relaxng_valid_383_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16515,11 +16515,11 @@ fn relaxng_valid_383_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/2.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16536,11 +16536,11 @@ fn relaxng_invalid_383_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/3.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16557,11 +16557,11 @@ fn relaxng_invalid_383_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16578,11 +16578,11 @@ fn relaxng_invalid_383_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/383/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16599,11 +16599,11 @@ fn relaxng_valid_384_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16620,11 +16620,11 @@ fn relaxng_invalid_384_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16641,11 +16641,11 @@ fn relaxng_valid_384_3(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/3.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16662,11 +16662,11 @@ fn relaxng_invalid_384_4(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/4.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16683,11 +16683,11 @@ fn relaxng_invalid_384_5(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/5.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16704,11 +16704,11 @@ fn relaxng_invalid_384_6(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/6.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16725,11 +16725,11 @@ fn relaxng_invalid_384_7(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/7.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/384/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());
@@ -16746,11 +16746,11 @@ fn relaxng_valid_385_1(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/385/1.v.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/385/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
@@ -16767,11 +16767,11 @@ fn relaxng_invalid_385_2(){
 
     let docfile = fs::read_to_string("tests/conformance/relaxng/jamesclark/385/2.i.xml").unwrap();
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), docfile.as_str(), ParserConfig::new());
+    let _ = xml::parse(doc.clone(), docfile.as_str(), None);
 
     let schemafile = fs::read_to_string("tests/conformance/relaxng/jamesclark/385/c.rng").unwrap();
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), schemafile.as_str(), ParserConfig::new());
+    let _ = xml::parse(sch.clone(), schemafile.as_str(), None);
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_err());

--- a/tests/conformance/relaxng/mod.rs
+++ b/tests/conformance/relaxng/mod.rs
@@ -22,10 +22,10 @@ fn rngtestone(){
 ";
 
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), d, ParserConfig::new());
+    let _ = xml::parse(doc.clone(), d, None);
 
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), s, ParserConfig::new());
+    let _ = xml::parse(sch.clone(), s, None);
 
 
     let result = validate_relaxng(&doc, &sch);

--- a/tests/conformance/relaxng/mod.rs
+++ b/tests/conformance/relaxng/mod.rs
@@ -1,14 +1,15 @@
 mod jamesclark;
 
-/*
+
 use std::fs;
 use std::rc::Rc;
 use xrust::Node;
-use xrust::parser::xml;
+use xrust::parser::{ParserConfig, xml};
 use xrust::trees::smite::{Node as SmiteNode};
 use xrust::validators::relaxng::validate_relaxng;
 
 #[test]
+#[ignore]
 fn rngtestone(){
 
     let s = "<?xml version=\"1.0\" encoding=\"utf-8\"?>
@@ -21,13 +22,13 @@ fn rngtestone(){
 ";
 
     let doc = Rc::new(SmiteNode::new());
-    let _ = xml::parse(doc.clone(), d, None, None);
+    let _ = xml::parse(doc.clone(), d, ParserConfig::new());
 
     let sch = Rc::new(SmiteNode::new());
-    let _ = xml::parse(sch.clone(), s, None, None);
+    let _ = xml::parse(sch.clone(), s, ParserConfig::new());
 
 
     let result = validate_relaxng(&doc, &sch);
     assert!(result.is_ok());
 }
- */
+

--- a/tests/conformance/xml/xmltest_valid_sa_canonicalonly.rs
+++ b/tests/conformance/xml/xmltest_valid_sa_canonicalonly.rs
@@ -8,7 +8,9 @@ James Clark XMLTEST cases - Standalone
 
 use std::convert::TryFrom;
 use std::fs;
-use xrust::Document;
+use std::rc::Rc;
+use xrust::parser::xml;
+use xrust::trees::smite::Node;
 
 #[test]
 fn validsa001() {
@@ -18,14 +20,13 @@ fn validsa001() {
         Spec Sections:3.2.2 [51]
         Description:Test demonstrates an Element Type Declaration with Mixed Content.
     */
-
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/001.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/001.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -37,13 +38,13 @@ fn validsa002() {
         Description:Test demonstrates that whitespace is permitted after the tag name in a Start-tag.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/002.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/002.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -55,13 +56,13 @@ fn validsa003() {
         Description:Test demonstrates that whitespace is permitted after the tag name in an End-tag.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/003.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/003.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -73,13 +74,13 @@ fn validsa004() {
         Description:Test demonstrates a valid attribute specification within a Start-tag.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/004.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/004.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -91,13 +92,13 @@ fn validsa005() {
         Description:Test demonstrates a valid attribute specification within a Start-tag thatcontains whitespace on both sides of the equal sign.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/005.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/005.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -109,13 +110,13 @@ fn validsa006() {
         Description:Test demonstrates that the AttValue within a Start-tag can use a single quote as a delimter.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/006.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/006.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -127,13 +128,13 @@ fn validsa007() {
         Description:Test demonstrates numeric character references can be used for element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/007.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/007.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -145,13 +146,13 @@ fn validsa008() {
         Description:Test demonstrates character references can be used for element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/008.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/008.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -163,13 +164,13 @@ fn validsa009() {
         Description:Test demonstrates that PubidChar can be used for element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/009.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/009.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -181,13 +182,13 @@ fn validsa010() {
         Description:Test demonstrates that whitespace is valid after the Attribute in a Start-tag.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/010.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/010.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -199,16 +200,16 @@ fn validsa011() {
         Description:Test demonstrates mutliple Attibutes within the Start-tag.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/011.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/011.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
-/*
+
 #[test]
 #[ignore]
 fn validsa012() {
@@ -223,14 +224,15 @@ fn validsa012() {
         Description:Uses a legal XML 1.0 name consisting of a single colon character (disallowed by the latest XML Namespaces draft).
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/012.xml").unwrap(),
-        None,None
-    ));
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/012.xml").unwrap().as_str(),
+        None,
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
- */
+
 
 #[test]
 fn validsa013() {
@@ -241,13 +243,13 @@ fn validsa013() {
         Description:Test demonstrates that the Attribute in a Start-tag can consist of numerals along with special characters.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/013.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/013.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -259,13 +261,13 @@ fn validsa014() {
         Description:Test demonstrates that all lower case letters are valid for the Attribute in a Start-tag.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/014.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/014.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -277,13 +279,13 @@ fn validsa015() {
         Description:Test demonstrates that all upper case letters are valid for the Attribute in a Start-tag.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/015.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/015.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -295,13 +297,13 @@ fn validsa016() {
         Description:Test demonstrates that Processing Instructions are valid element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/016.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/016.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -313,13 +315,13 @@ fn validsa017() {
         Description:Test demonstrates that Processing Instructions are valid element content and there can be more than one.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/017.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/017.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -331,13 +333,13 @@ fn validsa018() {
         Description:Test demonstrates that CDATA sections are valid element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/018.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/018.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -349,13 +351,13 @@ fn validsa019() {
         Description:Test demonstrates that CDATA sections are valid element content and thatampersands may occur in their literal form.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/019.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/019.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -367,13 +369,13 @@ fn validsa020() {
         Description:Test demonstractes that CDATA sections are valid element content and thateveryting between the CDStart and CDEnd is recognized as character data not markup.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/020.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/020.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -385,13 +387,13 @@ fn validsa021() {
         Description:Test demonstrates that comments are valid element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/021.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/021.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -403,13 +405,13 @@ fn validsa022() {
         Description:Test demonstrates that comments are valid element content and that all characters before the double-hypen right angle combination are considered part of thecomment.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/022.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/022.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -421,13 +423,13 @@ fn validsa023() {
         Description:Test demonstrates that Entity References are valid element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/023.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/023.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -439,13 +441,13 @@ fn validsa024() {
         Description:Test demonstrates that Entity References are valid element content and also demonstrates a valid Entity Declaration.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/024.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/024.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -457,13 +459,13 @@ fn validsa025() {
         Description:Test demonstrates an Element Type Declaration and that the contentspec can be of mixed content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/025.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/025.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -475,13 +477,13 @@ fn validsa026() {
         Description:Test demonstrates an Element Type Declaration and that EMPTY is a valid contentspec.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/026.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/026.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -493,13 +495,13 @@ fn validsa027() {
         Description:Test demonstrates an Element Type Declaration and that ANY is a valid contenspec.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/027.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/027.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -511,13 +513,13 @@ fn validsa028() {
         Description:Test demonstrates a valid prolog that uses double quotes as delimeters around the VersionNum.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/028.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/028.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -529,13 +531,13 @@ fn validsa029() {
         Description:Test demonstrates a valid prolog that uses single quotes as delimters around the VersionNum.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/029.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/029.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -547,13 +549,13 @@ fn validsa030() {
         Description:Test demonstrates a valid prolog that contains whitespace on both sides of the equal sign in the VersionInfo.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/030.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/030.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -565,13 +567,13 @@ fn validsa031() {
         Description:Test demonstrates a valid EncodingDecl within the prolog.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/031.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/031.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -583,13 +585,13 @@ fn validsa032() {
         Description:Test demonstrates a valid SDDecl within the prolog.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/032.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/032.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -601,13 +603,13 @@ fn validsa033() {
         Description:Test demonstrates that both a EncodingDecl and SDDecl are valid within the prolog.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/033.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/033.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -619,13 +621,13 @@ fn validsa034() {
         Description:Test demonstrates the correct syntax for an Empty element tag.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/034.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/034.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -637,13 +639,13 @@ fn validsa035() {
         Description:Test demonstrates that whitespace is permissible after the name in an Empty element tag.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/035.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/035.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -655,13 +657,13 @@ fn validsa036() {
         Description:Test demonstrates a valid processing instruction.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/036.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/036.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -673,13 +675,13 @@ fn validsa017a() {
         Description:Test demonstrates that two apparently wrong Processing Instructions make aright one, with very odd content "some data ? > <?".
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/017a.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/017a.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -691,13 +693,13 @@ fn validsa037() {
         Description:Test demonstrates a valid comment and that it may appear anywhere in the document including at the end.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/037.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/037.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -709,13 +711,13 @@ fn validsa038() {
         Description:Test demonstrates a valid comment and that it may appear anywhere in the document including the beginning.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/038.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/038.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -727,13 +729,13 @@ fn validsa039() {
         Description:Test demonstrates a valid processing instruction and that it may appear at the beginning of the document.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/039.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/039.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -745,13 +747,13 @@ fn validsa040() {
         Description:Test demonstrates an Attribute List declaration that uses a StringType as the AttType.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/040.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/040.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -763,13 +765,13 @@ fn validsa041() {
         Description:Test demonstrates an Attribute List declaration that uses a StringType as the AttType and also expands the CDATA attribute with a character reference.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/041.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/041.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -781,13 +783,13 @@ fn validsa042() {
         Description:Test demonstrates an Attribute List declaration that uses a StringType as the AttType and also expands the CDATA attribute with a character reference. The test also shows that the leading zeros in the character reference are ignored.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/042.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/042.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -799,13 +801,13 @@ fn validsa043() {
         Description:An element's attributes may be declared before its content model; and attribute values may contain newlines.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/043.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/043.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -817,13 +819,13 @@ fn validsa044() {
         Description:Test demonstrates that the empty-element tag must be use for an elements that are declared EMPTY.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/044.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/044.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -835,13 +837,13 @@ fn validsa045() {
         Description:Tests whether more than one definition can be provided for the same attribute of a given element type with the first declaration being binding.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/045.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/045.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -853,13 +855,13 @@ fn validsa046() {
         Description:Test demonstrates that when more than one AttlistDecl is provided for a given element type, the contents of all those provided are merged.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/046.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/046.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -871,13 +873,13 @@ fn validsa047() {
         Description:Test demonstrates that extra whitespace is normalized into single space character.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/047.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/047.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -889,13 +891,13 @@ fn validsa048() {
         Description:Test demonstrates that character data is valid element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/048.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/048.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -907,13 +909,13 @@ fn validsa049() {
         Description:Test demonstrates that characters outside of normal ascii range can be used as element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/049.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/049.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -925,13 +927,13 @@ fn validsa050() {
         Description:Test demonstrates that characters outside of normal ascii range can be used as element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/050.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/050.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -943,13 +945,13 @@ fn validsa051() {
         Description:The document is encoded in UTF-16 and uses some name characters well outside of the normal ASCII range.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/051.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/051.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -961,13 +963,13 @@ fn validsa052() {
         Description:The document is encoded in UTF-8 and the text inside the root element uses two non-ASCII characters, encoded in UTF-8 and each of which expands to a Unicode surrogate pair.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/052.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/052.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -979,13 +981,13 @@ fn validsa053() {
         Description:Tests inclusion of a well-formed internal entity, which holds an element required by the content model.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/053.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/053.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -997,13 +999,13 @@ fn validsa054() {
         Description:Test demonstrates that extra whitespace within Start-tags and End-tags are nomalized into single spaces.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/054.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/054.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1015,13 +1017,13 @@ fn validsa055() {
         Description:Test demonstrates that extra whitespace within a processing instruction willnormalized into s single space character.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/055.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/055.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1033,13 +1035,13 @@ fn validsa056() {
         Description:Test demonstrates an Attribute List declaration that uses a StringType as the AttType and also expands the CDATA attribute with a character reference. The test also shows that the leading zeros in the character reference are ignored.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/056.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/056.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1051,13 +1053,13 @@ fn validsa057() {
         Description:Test demonstrates an element content model whose element can occur zero or more times.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/057.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/057.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1069,13 +1071,13 @@ fn validsa058() {
         Description:Test demonstrates that extra whitespace be normalized into a single space character in an attribute of type NMTOKENS.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/058.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/058.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1087,13 +1089,13 @@ fn validsa059() {
         Description:Test demonstrates an Element Type Declaration that uses the contentspec of EMPTY. The element cannot have any contents and must always appear as an empty element in the document. The test also shows an Attribute-list declaration with multiple AttDef's.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/059.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/059.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1105,13 +1107,13 @@ fn validsa060() {
         Description:Test demonstrates the use of decimal Character References within element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/060.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/060.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1123,13 +1125,13 @@ fn validsa061() {
         Description:Test demonstrates the use of decimal Character References within element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/061.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/061.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1141,13 +1143,13 @@ fn validsa062() {
         Description:Test demonstrates the use of hexadecimal Character References within element.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/062.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/062.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1159,13 +1161,13 @@ fn validsa063() {
         Description:The document is encoded in UTF-8 and the name of the root element type uses non-ASCII characters.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/063.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/063.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1177,13 +1179,13 @@ fn validsa064() {
         Description:Tests in-line handling of two legal character references, which each expand to a Unicode surrogate pair.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/064.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/064.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1195,13 +1197,13 @@ fn validsa065() {
         Description:Tests ability to define an internal entity which can't legally be expanded (contains an unquoted <).
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/065.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/065.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1213,13 +1215,13 @@ fn validsa066() {
         Description:Expands a CDATA attribute with a character reference.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/066.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/066.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1231,13 +1233,13 @@ fn validsa067() {
         Description:Test demonstrates the use of decimal character references within element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/067.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/067.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1249,13 +1251,13 @@ fn validsa068() {
         Description:Tests definition of an internal entity holding a carriage return character reference, which must not be normalized before reporting to the application. Line break normalization only occurs when parsing external parsed entities.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/068.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/068.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1267,13 +1269,13 @@ fn validsa069() {
         Description:Verifies that an XML parser will parse a NOTATION declaration; the output phase of this test ensures that it's reported to the application.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/069.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/069.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1285,13 +1287,13 @@ fn validsa070() {
         Description:Verifies that internal parameter entities are correctly expanded within the internal subset.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/070.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/070.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1303,13 +1305,13 @@ fn validsa071() {
         Description:Test demonstrates that an AttlistDecl can use ID as the TokenizedType within the Attribute type. The test also shows that IMPLIED is a valid DefaultDecl.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/071.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/071.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1321,13 +1323,13 @@ fn validsa072() {
         Description:Test demonstrates that an AttlistDecl can use IDREF as the TokenizedType within the Attribute type. The test also shows that IMPLIED is a valid DefaultDecl.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/072.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/072.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1339,13 +1341,13 @@ fn validsa073() {
         Description:Test demonstrates that an AttlistDecl can use IDREFS as the TokenizedType within the Attribute type. The test also shows that IMPLIED is a valid DefaultDecl.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/073.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/073.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1357,13 +1359,13 @@ fn validsa074() {
         Description:Test demonstrates that an AttlistDecl can use ENTITY as the TokenizedType within the Attribute type. The test also shows that IMPLIED is a valid DefaultDecl.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/074.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/074.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1375,13 +1377,13 @@ fn validsa075() {
         Description:Test demonstrates that an AttlistDecl can use ENTITIES as the TokenizedType within the Attribute type. The test also shows that IMPLIED is a valid DefaultDecl.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/075.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/075.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1393,13 +1395,13 @@ fn validsa076() {
         Description:Verifies that an XML parser will parse a NOTATION attribute; the output phase of this test ensures that both notations are reported to the application.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/076.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/076.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1411,13 +1413,13 @@ fn validsa077() {
         Description:Test demonstrates that an AttlistDecl can use an EnumeratedType within the Attribute type. The test also shows that IMPLIED is a valid DefaultDecl.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/077.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/077.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1429,13 +1431,13 @@ fn validsa078() {
         Description:Test demonstrates that an AttlistDecl can use an StringType of CDATA within the Attribute type. The test also shows that REQUIRED is a valid DefaultDecl.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/078.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/078.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1447,13 +1449,13 @@ fn validsa079() {
         Description:Test demonstrates that an AttlistDecl can use an StringType of CDATA within the Attribute type. The test also shows that FIXED is a valid DefaultDecl and that a value can be given to the attribute in the Start-tag as well as the AttListDecl.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/079.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/079.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1465,13 +1467,13 @@ fn validsa080() {
         Description:Test demonstrates that an AttlistDecl can use an StringType of CDATA within the Attribute type. The test also shows that FIXED is a valid DefaultDecl and that an value can be given to the attribute.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/080.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/080.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1483,13 +1485,13 @@ fn validsa081() {
         Description:Test demonstrates the use of the optional character following a name or list to govern the number of times an element or content particles in the list occur.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/081.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/081.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1501,13 +1503,13 @@ fn validsa082() {
         Description:Tests that an external PE may be defined (but not referenced).
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/082.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/082.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1519,13 +1521,13 @@ fn validsa083() {
         Description:Tests that an external PE may be defined (but not referenced).
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/083.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/083.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1537,13 +1539,13 @@ fn validsa084() {
         Description:Test demonstrates that although whitespace can be used to set apart markup for greater readability it is not necessary.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/084.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/084.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1555,13 +1557,13 @@ fn validsa085() {
         Description:Parameter and General entities use different namespaces, so there can be an entity of each type with a given name.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/085.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/085.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1573,13 +1575,13 @@ fn validsa086() {
         Description:Tests whether entities may be declared more than once, with the first declaration being the binding one.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/086.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/086.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1591,13 +1593,13 @@ fn validsa087() {
         Description:Tests whether character references in internal entities are expanded early enough, by relying on correct handling to make the entity be well formed.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/087.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/087.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1609,13 +1611,13 @@ fn validsa088() {
         Description:Tests whether entity references in internal entities are expanded late enough, by relying on correct handling to make the expanded text be valid. (If it's expanded too early, the entity will parse as an element that's not valid in that context.)
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/088.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/088.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1627,13 +1629,13 @@ fn validsa089() {
         Description:Tests entity expansion of three legal character references, which each expand to a Unicode surrogate pair.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/089.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/089.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1645,13 +1647,13 @@ fn validsa090() {
         Description:Verifies that an XML parser will parse a NOTATION attribute; the output phase of this test ensures that the notation is reported to the application.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/090.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/090.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1663,13 +1665,13 @@ fn validsa091() {
         Description:Verifies that an XML parser will parse an ENTITY attribute; the output phase of this test ensures that the notation is reported to the application, and for validating parsers it further tests that the entity is so reported.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/091.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/091.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1681,13 +1683,13 @@ fn validsa092() {
         Description:Test demostrates that extra whitespace is normalized into a single space character.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/092.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/092.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1699,13 +1701,13 @@ fn validsa093() {
         Description:Test demonstrates that extra whitespace is not intended for inclusion in the delivered version of the document.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/093.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/093.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1717,13 +1719,13 @@ fn validsa094() {
         Description:Attribute defaults with a DTD have special parsing rules, different from other strings. That means that characters found there may look like an undefined parameter entity reference "within a markup declaration", but they aren't ... so they can't be violating the PEs in Internal Subset WFC.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/094.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/094.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1735,13 +1737,13 @@ fn validsa095() {
         Description:Basically an output test, this requires extra whitespace to be normalized into a single space character in an attribute of type NMTOKENS.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/095.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/095.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1753,13 +1755,13 @@ fn validsa096() {
         Description:Test demonstrates that extra whitespace is normalized into a single space character in an attribute of type NMTOKENS.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/096.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/096.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1771,13 +1773,13 @@ fn validsa097() {
         Description:Basically an output test, this tests whether an externally defined attribute declaration (with a default) takes proper precedence over a subsequent internal declaration.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/097.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/097.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1789,13 +1791,13 @@ fn validsa098() {
         Description:Test demonstrates that extra whitespace within a processing instruction is converted into a single space character.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/098.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/098.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1807,13 +1809,13 @@ fn validsa099() {
         Description:Test demonstrates the name of the encoding can be composed of lowercase characters.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/099.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/099.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1825,13 +1827,13 @@ fn validsa100() {
         Description:Makes sure that PUBLIC identifiers may have some strange characters. NOTE: The XML editors have said that the XML specification errata will specify that parameter entity expansion does not occur in PUBLIC identifiers, so that the '%' character will not flag a malformed parameter entity reference.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/100.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/100.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1843,13 +1845,13 @@ fn validsa101() {
         Description:This tests whether entity expansion is (incorrectly) done while processing entity declarations; if it is, the entity value literal will terminate prematurely.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/101.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/101.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1861,13 +1863,13 @@ fn validsa102() {
         Description:Test demonstrates that a CDATA attribute can pass a double quote as its value.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/102.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/102.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1879,13 +1881,13 @@ fn validsa103() {
         Description:Test demonstrates that an attribute can pass a less than sign as its value.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/103.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/103.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1897,13 +1899,13 @@ fn validsa104() {
         Description:Test demonstrates that extra whitespace within an Attribute of a Start-tag is normalized to a single space character.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/104.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/104.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1915,13 +1917,13 @@ fn validsa105() {
         Description:Basically an output test, this requires a CDATA attribute with a tab character to be passed through as one space.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/105.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/105.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1933,13 +1935,13 @@ fn validsa106() {
         Description:Basically an output test, this requires a CDATA attribute with a newline character to be passed through as one space.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/106.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/106.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1951,13 +1953,13 @@ fn validsa107() {
         Description:Basically an output test, this requires a CDATA attribute with a return character to be passed through as one space.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/107.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/107.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1969,13 +1971,13 @@ fn validsa108() {
         Description:This tests normalization of end-of-line characters (CRLF) within entities to LF, primarily as an output test.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/108.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/108.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -1987,13 +1989,13 @@ fn validsa109() {
         Description:Test demonstrates that an attribute can have a null value.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/109.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/109.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -2005,13 +2007,13 @@ fn validsa110() {
         Description:Basically an output test, this requires that a CDATA attribute with a CRLF be normalized to one space.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/110.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/110.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -2023,13 +2025,13 @@ fn validsa111() {
         Description:Character references expanding to spaces doesn't affect treatment of attributes.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/111.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/111.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -2041,13 +2043,13 @@ fn validsa112() {
         Description:Test demonstrates shows the use of content particles within the element content.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/112.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/112.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -2059,13 +2061,13 @@ fn validsa113() {
         Description:Test demonstrates that it is not an error to have attributes declared for an element not itself declared.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/113.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/113.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -2077,13 +2079,13 @@ fn validsa114() {
         Description:Test demonstrates that all text within a valid CDATA section is considered text and not recognized as markup.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/114.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/114.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -2095,13 +2097,13 @@ fn validsa115() {
         Description:Test demonstrates that an entity reference is processed by recursively processing the replacement text of the entity.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/115.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/115.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -2113,13 +2115,13 @@ fn validsa116() {
         Description:Test demonstrates that a line break within CDATA will be normalized.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/116.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/116.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -2131,13 +2133,13 @@ fn validsa117() {
         Description:Test demonstrates that entity expansion is done while processing entity declarations.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/117.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/117.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -2149,13 +2151,13 @@ fn validsa118() {
         Description:Test demonstrates that entity expansion is done while processing entity declarations.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/118.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/118.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }
 
 #[test]
@@ -2167,11 +2169,11 @@ fn validsa119() {
         Description:Comments may contain any legal XML characters; only the string "--" is disallowed.
     */
 
-    let testxml = Document::try_from((
-        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/119.xml").unwrap(),
+    let testxml = Rc::new(Node::new());
+    let parseresult = xml::parse(testxml, 
+        fs::read_to_string("tests/conformance/xml/xmlconf/xmltest/valid/sa/out/119.xml").unwrap().as_str(),
         None,
-        None,
-    ));
+    );
 
-    assert!(testxml.is_ok());
+    assert!(parseresult.is_ok());
 }

--- a/tests/smite.rs
+++ b/tests/smite.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use xrust::item::{Node, NodeType};
 use xrust::item_node_tests;
 use xrust::item_value_tests;
+use xrust::parser::ParserConfig;
 use xrust::parser::xml::{parse as xmlparse, parse_with_ns};
 use xrust::pattern_tests;
 use xrust::qname::QualifiedName;
@@ -37,7 +38,7 @@ fn make_sd_raw() -> RNode {
     let doc = Rc::new(SmiteNode::new());
     xmlparse(doc.clone(),
              "<a id='a1'><b id='b1'><a id='a2'><b id='b2'/><b id='b3'/></a><a id='a3'><b id='b4'/><b id='b5'/></a></b><b id='b6'><a id='a4'><b id='b7'/><b id='b8'/></a><a id='a5'><b id='b9'/><b id='b10'/></a></b></a>",
-             None, None).expect("unable to parse XML");
+             ParserConfig::new()).expect("unable to parse XML");
     doc
 }
 fn make_sd_cooked() -> Result<RNode, Error> {
@@ -49,13 +50,13 @@ fn make_sd() -> Item<RNode> {
 
 fn make_from_str(s: &str) -> Result<RNode, Error> {
     let doc = Rc::new(SmiteNode::new());
-    xmlparse(doc.clone(), s, None, None)?;
+    xmlparse(doc.clone(), s, ParserConfig::new())?;
     Ok(doc)
 }
 
 fn make_from_str_with_ns(s: &str) -> Result<(RNode, Vec<HashMap<String, String>>), Error> {
     let doc = Rc::new(SmiteNode::new());
-    let r = parse_with_ns(doc.clone(), s, None, None)?;
+    let r = parse_with_ns(doc.clone(), s, ParserConfig::new())?;
     Ok(r)
 }
 

--- a/tests/smite.rs
+++ b/tests/smite.rs
@@ -38,7 +38,7 @@ fn make_sd_raw() -> RNode {
     let doc = Rc::new(SmiteNode::new());
     xmlparse(doc.clone(),
              "<a id='a1'><b id='b1'><a id='a2'><b id='b2'/><b id='b3'/></a><a id='a3'><b id='b4'/><b id='b5'/></a></b><b id='b6'><a id='a4'><b id='b7'/><b id='b8'/></a><a id='a5'><b id='b9'/><b id='b10'/></a></b></a>",
-             ParserConfig::new()).expect("unable to parse XML");
+             None).expect("unable to parse XML");
     doc
 }
 fn make_sd_cooked() -> Result<RNode, Error> {
@@ -50,13 +50,13 @@ fn make_sd() -> Item<RNode> {
 
 fn make_from_str(s: &str) -> Result<RNode, Error> {
     let doc = Rc::new(SmiteNode::new());
-    xmlparse(doc.clone(), s, ParserConfig::new())?;
+    xmlparse(doc.clone(), s, None)?;
     Ok(doc)
 }
 
 fn make_from_str_with_ns(s: &str) -> Result<(RNode, Vec<HashMap<String, String>>), Error> {
     let doc = Rc::new(SmiteNode::new());
-    let r = parse_with_ns(doc.clone(), s, ParserConfig::new())?;
+    let r = parse_with_ns(doc.clone(), s, None)?;
     Ok(r)
 }
 


### PR DESCRIPTION
Hi Steve,

Started removing some of the uses of intmuttree on the parser tests.

Have also replaced a bunch of the parameters on the parse function with a single "parserconfig" struct, to allow us an easier time when we extend the parser later.

However, I am hitting some roadblocks around the Canonical XML feature, specifically for those tests that compare a file against its canonical representation... I can't seem to figure out how to get equality checks against two smite trees.

    error[E0369]: binary operation `==` cannot be applied to type `Rc<xrust::trees::smite::Node>`
       --> tests\conformance\xml\xmltest_valid_sa.rs:293:46
        |
    293 |     assert!(testxml.get_canonical().unwrap() == canonicalxml);
        |             -------------------------------- ^^ ------------ Rc<xrust::trees::smite::Node>
        |             |
        |             Rc<xrust::trees::smite::Node>

Mind taking a look? The other changes here should be fine to push in, if we can figure out the document comparison then I should be able to swap over the rest easily enough.