### PR TITLE
Implmented PartialEq for Node

### DIFF
--- a/src/qname.rs
+++ b/src/qname.rs
@@ -5,6 +5,7 @@ use crate::parser::ParserState;
 use crate::trees::nullo::Nullo;
 use crate::xdmerror::{Error, ErrorKind};
 use core::hash::{Hash, Hasher};
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Debug;
@@ -116,6 +117,29 @@ impl PartialEq for QualifiedName {
                 )
             },
         )
+    }
+}
+
+/// A partial ordering for QualifiedNames. Unprefixed names are considered to come before prefixed names.
+impl PartialOrd for QualifiedName {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (&self.nsuri, &other.nsuri) {
+            (None, None) => self.localname.partial_cmp(&other.localname),
+            (Some(_), None) => Some(Ordering::Greater),
+            (None, Some(_)) => Some(Ordering::Less),
+            (Some(n), Some(m)) => {
+                if n == m {
+                    self.localname.partial_cmp(&other.localname)
+                } else {
+                    n.partial_cmp(&m)
+                }
+            }
+        }
+    }
+}
+impl Ord for QualifiedName {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
     }
 }
 impl Eq for QualifiedName {}

--- a/src/testutils/item_node.rs
+++ b/src/testutils/item_node.rs
@@ -456,5 +456,96 @@ macro_rules! item_node_tests (
 		let b6: Vec<RNode> = sd.descend_iter().filter(|n| n.get_attribute(&QualifiedName::new(None, None, String::from("id"))).to_string() == String::from("b6")).collect();
 		assert_eq!(b10[0].cmp_document_order(&b6[0]), Ordering::Greater)
 	}
+
+	#[test]
+	fn item_node_partialeq_1_pos() {
+	    let mut sd = $x();
+	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
+		.expect("unable to create element");
+	    sd.push(t.clone())
+		.expect("unable to append child");
+	    let a1 = sd.new_attribute(
+		QualifiedName::new(None, None, String::from("role")),
+		Rc::new(Value::from("testing"))
+	    ).expect("unable to create attribute");
+	    t.add_attribute(a1)
+		.expect("unable to add attribute");
+	    let a2 = sd.new_attribute(
+		QualifiedName::new(None, None, String::from("phase")),
+		Rc::new(Value::from("one"))
+	    ).expect("unable to create element");
+	    t.add_attribute(a2)
+		.expect("unable to add attribute");
+		t.push(sd.new_text(Rc::new(Value::from("my test document"))).expect("unable to create text node"))
+		.expect("unable to add text node");
+
+		// The same document as above, but with attributes in a different order
+	    let mut od = $x();
+	    let mut u = od.new_element(QualifiedName::new(None, None, String::from("Test")))
+		.expect("unable to create element");
+	    od.push(u.clone())
+		.expect("unable to append child");
+	    let b1 = od.new_attribute(
+		QualifiedName::new(None, None, String::from("role")),
+		Rc::new(Value::from("testing"))
+	    ).expect("unable to create attribute");
+	    let b2 = od.new_attribute(
+		QualifiedName::new(None, None, String::from("phase")),
+		Rc::new(Value::from("one"))
+	    ).expect("unable to create element");
+	    u.add_attribute(b2)
+		.expect("unable to add attribute");
+		u.push(od.new_text(Rc::new(Value::from("my test document"))).expect("unable to create text node"))
+		.expect("unable to add text node");
+	    u.add_attribute(b1)
+		.expect("unable to add attribute");
+
+	    assert_eq!(sd == od, true)
+	}
+	#[test]
+	fn item_node_partialeq_1_neg() {
+	    let mut sd = $x();
+	    let mut t = sd.new_element(QualifiedName::new(None, None, String::from("Test")))
+		.expect("unable to create element");
+	    sd.push(t.clone())
+		.expect("unable to append child");
+	    let a1 = sd.new_attribute(
+		QualifiedName::new(None, None, String::from("role")),
+		Rc::new(Value::from("testing"))
+	    ).expect("unable to create attribute");
+	    t.add_attribute(a1)
+		.expect("unable to add attribute");
+	    let a2 = sd.new_attribute(
+		QualifiedName::new(None, None, String::from("phase")),
+		Rc::new(Value::from("one"))
+	    ).expect("unable to create element");
+	    t.add_attribute(a2)
+		.expect("unable to add attribute");
+		t.push(sd.new_text(Rc::new(Value::from("my test document"))).expect("unable to create text node"))
+		.expect("unable to add text node");
+
+		// The same document as above, but with attributes in a different order
+	    let mut od = $x();
+	    let mut u = od.new_element(QualifiedName::new(None, None, String::from("Test")))
+		.expect("unable to create element");
+	    od.push(u.clone())
+		.expect("unable to append child");
+	    let b1 = od.new_attribute(
+		QualifiedName::new(None, None, String::from("role")),
+		Rc::new(Value::from("testing"))
+	    ).expect("unable to create attribute");
+	    let b2 = od.new_attribute(
+		QualifiedName::new(None, None, String::from("phase")),
+		Rc::new(Value::from("one"))
+	    ).expect("unable to create element");
+	    u.add_attribute(b2)
+		.expect("unable to add attribute");
+		u.push(od.new_text(Rc::new(Value::from("not the same document"))).expect("unable to create text node"))
+		.expect("unable to add text node");
+	    u.add_attribute(b1)
+		.expect("unable to add attribute");
+
+	    assert_eq!(sd == od, false)
+	}
     }
 );

--- a/src/trees/nullo.rs
+++ b/src/trees/nullo.rs
@@ -187,3 +187,9 @@ impl fmt::Debug for Nullo {
         write!(f, "Nullo node")
     }
 }
+
+impl PartialEq for Nullo {
+    fn eq(&self, other: &Self) -> bool {
+        Node::eq(self, other)
+    }
+}


### PR DESCRIPTION
Implements the PartialEq trait for trees.

What is actually happening is that PartialEq is a supertrait of item::Node. The Node trait then defines an 'eq' method and provides a default implementation that utilises the generic methods to navigate both trees.

Smite can't use the default implementation, so it gets its own 'eq' method for the smite::Node type.

Already reviewed as part of PR 84