### PR TITLE
Namespace node iter

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -571,5 +571,8 @@ pub trait Node: Clone + PartialEq + fmt::Debug {
             _ => self.node_type() == other.node_type(), // Other types of node do not affect the equality
         }
     }
+    /// An iterator over the namespace nodes of an element. Note: These nodes are calculated
+    /// at the time the iterator is called, it is not guaranteed that the namespace nodes returned
+    /// will specify the current element node as their parent.
     fn namespace_iter(&self) -> Self::NodeIterator;
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -51,13 +51,13 @@ fn parser_config_namespace_nodes_1() {
         .next()
         .unwrap();
 
-    assert_eq!(doc.namespace_iter().count(), 6);
-    assert_eq!(element1.namespace_iter().count(), 0);
-    assert_eq!(element2.namespace_iter().count(), 1);
-    assert_eq!(element3.namespace_iter().count(), 1);
-    assert_eq!(element4.namespace_iter().count(), 1);
-    assert_eq!(element5.namespace_iter().count(), 0);
-    assert_eq!(element6.namespace_iter().count(), 0);
+    assert_eq!(doc.namespace_iter().count(), 7);
+    assert_eq!(element1.namespace_iter().count(), 7);
+    assert_eq!(element2.namespace_iter().count(), 7);
+    assert_eq!(element3.namespace_iter().count(), 8);
+    assert_eq!(element4.namespace_iter().count(), 8);
+    assert_eq!(element5.namespace_iter().count(), 7);
+    assert_eq!(element6.namespace_iter().count(), 7);
 }
 
 #[test]
@@ -156,6 +156,6 @@ fn parser_config_namespace_nodes_3() {
     assert_eq!(element2.namespace_iter().count(), 7);
     assert_eq!(element3.namespace_iter().count(), 8);
     assert_eq!(element4.namespace_iter().count(), 8);
-    assert_eq!(element5.namespace_iter().count(), 6);
-    assert_eq!(element6.namespace_iter().count(), 6);
+    assert_eq!(element5.namespace_iter().count(), 7);
+    assert_eq!(element6.namespace_iter().count(), 7);
 }


### PR DESCRIPTION
Hi Steve,

A first attempt at something that could solve the namespace issue. Basically its an iter that once called will recursively check the parent node for namespaces then return a complete set with the most recent version of each prefix.

It does not handle the links to parent nodes on the namespaces, I can look at editing those if needed, nor have I made any changes to the namespace lookup for the custom functions in the transformation context, but if this looks ok we could look to modify that in a subsequent pull request.

This also will make the "namespace_nodes" flag on the parser unnecessary, so I'll also remove that if this is accepted.

Let me know what you think, if we go this route I think we'll also have to make it fairly explicit we won't be supporting the namespace axis unless we are given a very compelling reason to.