### PR TITLE
Added abbreviated syntax to Pattern parser

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -127,10 +127,10 @@ pub struct ParserState<N: Node> {
 
     dtd: DTD,
     /*
-        The namespaces are tracked in a vector of hashmaps, added and removed as you go up and down
-        paths in the document.
-        NOTE: the "None" key in this hashmap is used to track the namespace when no alias is declared.
-     */
+       The namespaces are tracked in a vector of hashmaps, added and removed as you go up and down
+       paths in the document.
+       NOTE: the "None" key in this hashmap is used to track the namespace when no alias is declared.
+    */
     namespace: Vec<HashMap<Option<String>, String>>,
     /* Do we add the parents namespace nodes to an element? */
     namespace_nodes: bool,

--- a/src/parser/xml/mod.rs
+++ b/src/parser/xml/mod.rs
@@ -11,6 +11,7 @@ mod xmldecl;
 use crate::item::Node;
 use crate::parser::combinators::map::map;
 use crate::parser::combinators::opt::opt;
+use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::tuple::tuple4;
 use crate::parser::xml::dtd::doctypedecl;
 use crate::parser::xml::element::element;
@@ -20,7 +21,6 @@ use crate::parser::{ParseError, ParseInput, ParserConfig, ParserState};
 use crate::xdmerror::{Error, ErrorKind};
 use crate::xmldecl::XMLDecl;
 use std::collections::HashMap;
-use crate::parser::combinators::tag::tag;
 
 pub fn parse<N: Node>(doc: N, input: &str, config: Option<ParserConfig>) -> Result<N, Error> {
     let (xmldoc, _) = parse_with_ns(doc, input, config)?;
@@ -149,7 +149,6 @@ fn prolog<N: Node>(
     )
 }
 
-fn utf8bom<N: Node>(
-) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError>{
+fn utf8bom<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     tag("\u{feff}")
 }

--- a/src/transform/numbers.rs
+++ b/src/transform/numbers.rs
@@ -8,7 +8,7 @@ use formato::Formato;
 use italian_numbers::roman_converter;
 
 use crate::item::{Item, Node, NodeType, Sequence, SequenceTrait};
-use crate::pattern::{PathBuilder, Pattern};
+use crate::pattern::{Pattern, Step};
 use crate::qname::QualifiedName;
 use crate::transform::context::{Context, StaticContext};
 use crate::transform::{
@@ -66,35 +66,30 @@ pub fn generate_integers<
     if n.len() == 1 {
         if let Item::Node(m) = &n[0] {
             // Determine the count pattern
-            let count_pat =
-                (num.count)
-                    .clone()
-                    .unwrap_or(Pattern::Selection(match m.node_type() {
-                        NodeType::Element => PathBuilder::new()
-                            .step(
-                                Axis::SelfAxis,
-                                Axis::SelfAxis,
-                                NodeTest::Name(NameTest::new(
-                                    m.name().get_nsuri().map(WildcardOrName::Name),
-                                    None,
-                                    Some(WildcardOrName::Name(m.name().get_localname())),
-                                )),
-                            )
-                            .build(),
-                        NodeType::Text => PathBuilder::new()
-                            .step(
-                                Axis::SelfAxis,
-                                Axis::SelfAxis,
-                                NodeTest::Kind(KindTest::Text),
-                            )
-                            .build(),
-                        _ => {
-                            return Err(Error::new(
-                                ErrorKind::TypeError,
-                                "cannot match this type of node",
-                            ))
-                        }
-                    }));
+            let count_pat = (num.count)
+                .clone()
+                .unwrap_or(Pattern::Selection(vec![match m.node_type() {
+                    NodeType::Element => Step::new(
+                        Axis::SelfAxis,
+                        Axis::SelfAxis,
+                        NodeTest::Name(NameTest::new(
+                            m.name().get_nsuri().map(WildcardOrName::Name),
+                            None,
+                            Some(WildcardOrName::Name(m.name().get_localname())),
+                        )),
+                    ),
+                    NodeType::Text => Step::new(
+                        Axis::SelfAxis,
+                        Axis::SelfAxis,
+                        NodeTest::Kind(KindTest::Text),
+                    ),
+                    _ => {
+                        return Err(Error::new(
+                            ErrorKind::TypeError,
+                            "cannot match this type of node",
+                        ))
+                    }
+                }]));
 
             // let a = $S/ancestor-or-self::node()[matches-count(.)][1]
             // TODO: Don't Panic

--- a/src/trees/smite.rs
+++ b/src/trees/smite.rs
@@ -218,12 +218,10 @@ impl ItemNode for RNode {
                 let r: QualifiedName = (*qn.clone()).clone();
                 r
             }
-            NodeInner::Namespace(_,p,_) => {
-                match p {
-                    None => QualifiedName::new(None, None, String::from("")),
-                    Some(pf) => {QualifiedName::new(None, None, String::from(pf))}
-                }
-            }
+            NodeInner::Namespace(_, p, _) => match p {
+                None => QualifiedName::new(None, None, String::from("")),
+                Some(pf) => QualifiedName::new(None, None, String::from(pf)),
+            },
             _ => QualifiedName::new(None, None, String::from("")),
         }
     }
@@ -1257,21 +1255,20 @@ pub struct NamespaceNodes {
 impl NamespaceNodes {
     fn new(n: &RNode) -> Self {
         if let NodeInner::Element(_, _, _, _, namespaces) = &n.0 {
-
-            let parent_nsnodes = match n.parent(){
-                Some(p) => {
-                    p.namespace_iter()
-                }
-                None => {
-                    Box::new(NamespaceNodes { ns: vec![], cur: 0 }) }
+            let parent_nsnodes = match n.parent() {
+                Some(p) => p.namespace_iter(),
+                None => Box::new(NamespaceNodes { ns: vec![], cur: 0 }),
             };
 
-            let xns = n.new_namespace("http://www.w3.org/XML/1998/namespace".to_string(),Some("xml".to_string()))
+            let xns = n
+                .new_namespace(
+                    "http://www.w3.org/XML/1998/namespace".to_string(),
+                    Some("xml".to_string()),
+                )
                 .expect("Unable to generate xml namespace");
 
             let mut nshm = HashMap::new();
             nshm.insert(Some("xml".to_string()), xns);
-
 
             for node in parent_nsnodes {
                 if node.name().get_localname().is_empty() {

--- a/src/xslt.rs
+++ b/src/xslt.rs
@@ -363,7 +363,19 @@ where
         })
         .try_for_each(|c| {
             let m = c.get_attribute(&QualifiedName::new(None, None, "match"));
-            let pat = Pattern::try_from(m.to_string())?;
+            let pat = Pattern::try_from(m.to_string()).map_err(|e| {
+                Error::new(
+                    e.kind,
+                    format!(
+                        "Error parsing match pattern \"{}\": {}",
+                        m.to_string(),
+                        e.message
+                    ),
+                )
+            })?;
+            if pat.is_err() {
+                return Err(pat.get_err().unwrap());
+            }
             let mut body = vec![];
             let mode = c.get_attribute_node(&QualifiedName::new(None, None, "mode"));
             c.child_iter().try_for_each(|d| {
@@ -384,7 +396,7 @@ where
                             _ => 1.0,
                         },
                         Pattern::Selection(s) => {
-                            let ((t, nt), q) = s.clone().t.unwrap();
+                            let (t, nt, q) = s[0].get_ref();
                             // If "/" then -0.5
                             match (t, nt) {
                                 (Axis::SelfAttribute, _) => -0.5,

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -160,7 +160,6 @@ fn parser_config_namespace_nodes_3() {
     assert_eq!(element6.namespace_iter().count(), 7);
 }
 
-
 #[test]
 fn parser_issue_94() {
     /*
@@ -175,5 +174,4 @@ fn parser_issue_94() {
     let parseresult = xml::parse(source.clone(), &data, None);
 
     assert!(parseresult.is_ok())
-
 }

--- a/tests/patterngeneric/mod.rs
+++ b/tests/patterngeneric/mod.rs
@@ -352,6 +352,172 @@ where
     Ok(())
 }
 
+pub fn pattern_abbrev_1_pos<N: Node, G>(make_empty_doc: G) -> Result<(), Error>
+where
+    G: Fn() -> N,
+{
+    let p: Pattern<N> = Pattern::try_from("a").expect("unable to parse \"a\"");
+
+    // Setup a source document
+    let mut sd = make_empty_doc();
+    let mut t = sd
+        .new_element(QualifiedName::new(None, None, String::from("Test")))
+        .expect("unable to create element");
+    sd.push(t.clone()).expect("unable to append child");
+    let mut a = sd
+        .new_element(QualifiedName::new(None, None, String::from("a")))
+        .expect("unable to create element");
+    t.push(a.clone()).expect("unable to append child");
+    let t_a = sd
+        .new_text(Rc::new(Value::from("first")))
+        .expect("unable to create text node");
+    a.push(t_a).expect("unable to append text node");
+    let mut b = sd
+        .new_element(QualifiedName::new(None, None, String::from("b")))
+        .expect("unable to create element");
+    t.push(b.clone()).expect("unable to append child");
+    let t_b = sd
+        .new_text(Rc::new(Value::from("second")))
+        .expect("unable to create text node");
+    b.push(t_b).expect("unable to append text node");
+
+    let mut stctxt = StaticContextBuilder::new()
+        .message(|_| Ok(()))
+        .fetcher(|_| Err(Error::new(ErrorKind::NotImplemented, "not implemented")))
+        .parser(|_| Err(Error::new(ErrorKind::NotImplemented, "not implemented")))
+        .build();
+
+    assert_eq!(
+        p.matches(&Context::new(), &mut stctxt, &Rc::new(Item::Node(a))),
+        true
+    );
+    Ok(())
+}
+pub fn pattern_abbrev_1_neg<N: Node, G>(make_empty_doc: G) -> Result<(), Error>
+where
+    G: Fn() -> N,
+{
+    let p: Pattern<N> = Pattern::try_from("a").expect("unable to parse \"a\"");
+
+    // Setup a source document
+    let mut sd = make_empty_doc();
+    let mut t = sd
+        .new_element(QualifiedName::new(None, None, String::from("Test")))
+        .expect("unable to create element");
+    sd.push(t.clone()).expect("unable to append child");
+    let mut a = sd
+        .new_element(QualifiedName::new(None, None, String::from("a")))
+        .expect("unable to create element");
+    t.push(a.clone()).expect("unable to append child");
+    let t_a = sd
+        .new_text(Rc::new(Value::from("first")))
+        .expect("unable to create text node");
+    a.push(t_a).expect("unable to append text node");
+    let mut b = sd
+        .new_element(QualifiedName::new(None, None, String::from("b")))
+        .expect("unable to create element");
+    t.push(b.clone()).expect("unable to append child");
+    let t_b = sd
+        .new_text(Rc::new(Value::from("second")))
+        .expect("unable to create text node");
+    b.push(t_b).expect("unable to append text node");
+
+    let mut stctxt = StaticContextBuilder::new()
+        .message(|_| Ok(()))
+        .fetcher(|_| Err(Error::new(ErrorKind::NotImplemented, "not implemented")))
+        .parser(|_| Err(Error::new(ErrorKind::NotImplemented, "not implemented")))
+        .build();
+
+    assert_eq!(
+        p.matches(&Context::new(), &mut stctxt, &Rc::new(Item::Node(b))),
+        false
+    );
+    Ok(())
+}
+
+pub fn pattern_abbrev_2_pos<N: Node, G>(make_empty_doc: G) -> Result<(), Error>
+where
+    G: Fn() -> N,
+{
+    let p: Pattern<N> = Pattern::try_from("/Test/a").expect("unable to parse \"/Test/a\"");
+
+    // Setup a source document
+    let mut sd = make_empty_doc();
+    let mut t = sd
+        .new_element(QualifiedName::new(None, None, String::from("Test")))
+        .expect("unable to create element");
+    sd.push(t.clone()).expect("unable to append child");
+    let mut a = sd
+        .new_element(QualifiedName::new(None, None, String::from("a")))
+        .expect("unable to create element");
+    t.push(a.clone()).expect("unable to append child");
+    let t_a = sd
+        .new_text(Rc::new(Value::from("first")))
+        .expect("unable to create text node");
+    a.push(t_a).expect("unable to append text node");
+    let mut b = sd
+        .new_element(QualifiedName::new(None, None, String::from("b")))
+        .expect("unable to create element");
+    t.push(b.clone()).expect("unable to append child");
+    let t_b = sd
+        .new_text(Rc::new(Value::from("second")))
+        .expect("unable to create text node");
+    b.push(t_b).expect("unable to append text node");
+
+    let mut stctxt = StaticContextBuilder::new()
+        .message(|_| Ok(()))
+        .fetcher(|_| Err(Error::new(ErrorKind::NotImplemented, "not implemented")))
+        .parser(|_| Err(Error::new(ErrorKind::NotImplemented, "not implemented")))
+        .build();
+
+    assert_eq!(
+        p.matches(&Context::new(), &mut stctxt, &Rc::new(Item::Node(a))),
+        true
+    );
+    Ok(())
+}
+pub fn pattern_abbrev_2_neg<N: Node, G>(make_empty_doc: G) -> Result<(), Error>
+where
+    G: Fn() -> N,
+{
+    let p: Pattern<N> = Pattern::try_from("/a/b").expect("unable to parse \"/a/b\"");
+
+    // Setup a source document
+    let mut sd = make_empty_doc();
+    let mut t = sd
+        .new_element(QualifiedName::new(None, None, String::from("Test")))
+        .expect("unable to create element");
+    sd.push(t.clone()).expect("unable to append child");
+    let mut a = sd
+        .new_element(QualifiedName::new(None, None, String::from("a")))
+        .expect("unable to create element");
+    t.push(a.clone()).expect("unable to append child");
+    let t_a = sd
+        .new_text(Rc::new(Value::from("first")))
+        .expect("unable to create text node");
+    a.push(t_a).expect("unable to append text node");
+    let mut b = sd
+        .new_element(QualifiedName::new(None, None, String::from("b")))
+        .expect("unable to create element");
+    t.push(b.clone()).expect("unable to append child");
+    let t_b = sd
+        .new_text(Rc::new(Value::from("second")))
+        .expect("unable to create text node");
+    b.push(t_b).expect("unable to append text node");
+
+    let mut stctxt = StaticContextBuilder::new()
+        .message(|_| Ok(()))
+        .fetcher(|_| Err(Error::new(ErrorKind::NotImplemented, "not implemented")))
+        .parser(|_| Err(Error::new(ErrorKind::NotImplemented, "not implemented")))
+        .build();
+
+    assert_eq!(
+        p.matches(&Context::new(), &mut stctxt, &Rc::new(Item::Node(b))),
+        false
+    );
+    Ok(())
+}
+
 pub fn pattern_sel_text_kind_1_pos<N: Node, G>(make_empty_doc: G) -> Result<(), Error>
 where
     G: Fn() -> N,

--- a/tests/smite-pattern.rs
+++ b/tests/smite-pattern.rs
@@ -43,6 +43,22 @@ fn pattern_sel_2_neg() {
     patterngeneric::pattern_sel_2_neg::<RNode, _>(smite::make_empty_doc).expect("test failed")
 }
 #[test]
+fn pattern_abbrev_1_pos() {
+    patterngeneric::pattern_abbrev_1_pos::<RNode, _>(smite::make_empty_doc).expect("test failed")
+}
+#[test]
+fn pattern_abbrev_1_neg() {
+    patterngeneric::pattern_abbrev_1_neg::<RNode, _>(smite::make_empty_doc).expect("test failed")
+}
+#[test]
+fn pattern_abbrev_2_pos() {
+    patterngeneric::pattern_abbrev_2_pos::<RNode, _>(smite::make_empty_doc).expect("test failed")
+}
+#[test]
+fn pattern_abbrev_2_neg() {
+    patterngeneric::pattern_abbrev_2_neg::<RNode, _>(smite::make_empty_doc).expect("test failed")
+}
+#[test]
 fn pattern_sel_text_kind_1_pos() {
     patterngeneric::pattern_sel_text_kind_1_pos::<RNode, _>(smite::make_empty_doc)
         .expect("test failed")

--- a/tests/smite-xslt.rs
+++ b/tests/smite-xslt.rs
@@ -229,3 +229,30 @@ fn xslt_attr_set_3() {
     )
     .expect("test failed")
 }
+#[test]
+fn xslt_issue_96_abs() {
+    xsltgeneric::issue_96_abs(
+        smite::make_from_str,
+        smite::make_from_str_with_ns,
+        smite::make_sd_cooked,
+    )
+    .expect("test failed")
+}
+#[test]
+fn xslt_issue_96_rel() {
+    xsltgeneric::issue_96_rel(
+        smite::make_from_str,
+        smite::make_from_str_with_ns,
+        smite::make_sd_cooked,
+    )
+    .expect("test failed")
+}
+#[test]
+fn xslt_issue_96_mixed() {
+    xsltgeneric::issue_96_mixed(
+        smite::make_from_str,
+        smite::make_from_str_with_ns,
+        smite::make_sd_cooked,
+    )
+    .expect("test failed")
+}


### PR DESCRIPTION
This PR fixes issue 96. It does so by adding support for abbreviated syntax to the XPath Pattern parser.