### PR TITLE
ATTLIST default declaration support.

### DIFF
--- a/src/parser/combinators/wellformed.rs
+++ b/src/parser/combinators/wellformed.rs
@@ -32,7 +32,7 @@ where
 {
     /*
        Some well formed constraints (specifically character checks) are dependant on XML versions.
-       This just selects the constrain based on the version in the state.
+       This just selects the constraint based on the version in the state.
     */
     move |input| match parser(input) {
         Ok(((input2, state2), result)) => {

--- a/src/parser/xml/dtd/attlistdecl.rs
+++ b/src/parser/xml/dtd/attlistdecl.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use crate::item::Node;
-use crate::parser::combinators::alt::{alt2, alt3, alt4, alt7};
+use crate::parser::combinators::alt::{alt2, alt3, alt9};
 use crate::parser::combinators::delimited::delimited;
 use crate::parser::combinators::many::many0;
 use crate::parser::combinators::map::map;
@@ -11,11 +12,12 @@ use crate::parser::combinators::value::value;
 use crate::parser::combinators::whitespace::{whitespace0, whitespace1};
 use crate::parser::xml::chardata::chardata_unicode_codepoint;
 use crate::parser::xml::dtd::enumerated::enumeratedtype;
-use crate::parser::xml::dtd::pereference::petextreference;
 use crate::parser::xml::qname::{name, qualname};
 use crate::parser::xml::reference::textreference;
 use crate::parser::{ParseError, ParseInput};
-use crate::xmldecl::DTDDecl;
+use crate::parser::common::{is_ncnamechar, is_ncnamestartchar};
+use crate::qname::QualifiedName;
+use crate::xmldecl::{AttType, DefaultDecl};
 
 //AttlistDecl ::= '<!ATTLIST' S Name AttDef* S? '>'
 pub(crate) fn attlistdecl<N: Node>(
@@ -29,19 +31,205 @@ pub(crate) fn attlistdecl<N: Node>(
         tag(">"),
     )((input, state))
     {
-        Ok(((input2, mut state2), (_, _, n, _, _, _))) => {
+        Ok(((input2, mut state2), (_, _, n, ats, _, _))) => {
+            /*
+
+            "3.3 Attribute-List Declarations
+            When more than one AttlistDecl is provided for a given element type, the contents of all those provided are merged.
+            When more than one definition is provided for the same attribute of a given element type, the first declaration
+            is binding and later declarations are ignored."
+
+            So we're going to do some checks for existing ATTLIST declarations, but each one has a boolean flag to confirm
+            if it was created by an external or internal DTD. If its external we can happily overwrite, but not for internal.
+
+             */
+            /* Entities should always bind to the first value */
+            let replaceable = state2.currentlyexternal;
+
+            let mut atts = HashMap::new();
+
+            let mut count_id_attrs = 0;
+            for (qn, att, dfd) in ats {
+                match &dfd {
+                    //We need to make sure that the default is valid, even if its not used.
+                    DefaultDecl::FIXED(s) | DefaultDecl::Default(s)=> {
+                        match att {
+                            AttType::ID => {
+                                count_id_attrs += 1;
+                                let mut ch = s.chars();
+                                match ch.next(){
+                                    None => {}
+                                    Some(c) => {
+                                        if is_ncnamestartchar(&c){
+                                            for cha in ch {
+                                                if !is_ncnamechar(&cha){
+                                                    return Err(ParseError::NotWellFormed(String::from(
+                                                        "DTD Attvalue default is invalid",
+                                                    )));
+                                                }
+                                            }
+                                        } else {
+                                            return Err(ParseError::NotWellFormed(String::from(
+                                                "DTD Attvalue default is invalid",
+                                            )));
+                                        }
+                                    }
+                                }
+                            }
+                            AttType::IDREF => {
+                                let mut ch = s.chars();
+                                match ch.next(){
+                                    None => {}
+                                    Some(c) => {
+                                        if is_ncnamestartchar(&c){
+                                            for cha in ch {
+                                                if !is_ncnamechar(&cha){
+                                                    return Err(ParseError::NotWellFormed(String::from(
+                                                        "DTD Attvalue default is invalid",
+                                                    )));
+                                                }
+                                            }
+                                        } else {
+                                            return Err(ParseError::NotWellFormed(String::from(
+                                                "DTD Attvalue default is invalid",
+                                            )));
+                                        }
+                                    }
+                                }
+                            }
+                            AttType::IDREFS => {
+                                let names = s.split(" ");
+                                for name in names{
+                                    let mut ch = name.chars();
+                                    match ch.next(){
+                                        None => {}
+                                        Some(c) => {
+                                            if is_ncnamestartchar(&c){
+                                                for cha in ch {
+                                                    if !is_ncnamechar(&cha){
+                                                        return Err(ParseError::NotWellFormed(String::from(
+                                                            "DTD Attvalue default is invalid",
+                                                        )));
+                                                    }
+                                                }
+                                            } else {
+                                                return Err(ParseError::NotWellFormed(String::from(
+                                                    "DTD Attvalue default is invalid",
+                                                )));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            AttType::ENTITY => {
+                                let mut ch = s.chars();
+                                match ch.next(){
+                                    None => {}
+                                    Some(c) => {
+                                        if is_ncnamestartchar(&c){
+                                            for cha in ch {
+                                                if !is_ncnamechar(&cha){
+                                                    return Err(ParseError::NotWellFormed(String::from(
+                                                        "DTD Attvalue default is invalid",
+                                                    )));
+                                                }
+                                            }
+                                        } else {
+                                            return Err(ParseError::NotWellFormed(String::from(
+                                                "DTD Attvalue default is invalid",
+                                            )));
+                                        }
+                                    }
+                                }
+                            }
+                            AttType::ENTITIES => {
+                                let entities = s.split(" ");
+                                for entity in entities{
+                                    let mut ch = entity.chars();
+                                    match ch.next(){
+                                        None => {}
+                                        Some(c) => {
+                                            if is_ncnamestartchar(&c){
+                                                for cha in ch {
+                                                    if !is_ncnamechar(&cha){
+                                                        return Err(ParseError::NotWellFormed(String::from(
+                                                        "DTD Attvalue default is invalid",
+                                                        )));
+                                                    }
+                                                }
+                                            } else {
+                                                return Err(ParseError::NotWellFormed(String::from(
+                                                "DTD Attvalue default is invalid",
+                                                )));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            _ => {/*TODO complete the rest of these */}
+                        }
+                    },
+                    //else do nothing
+                    _ => {}
+                }
+                atts.insert(qn, (att, dfd, replaceable));
+            }
+            if count_id_attrs > 1 {
+                return Err(ParseError::NotWellFormed(String::from(
+                    "Duplicate ID attribute declarations",
+                )));
+            }
+
+            match state2.dtd.attlists.get(&n) {
+                None => {
+                    state2
+                        .dtd
+                        .attlists
+                        .insert(n, atts);
+                    Ok(((input2, state2), ()))
+                }
+                Some(al) => {
+                    let mut newal = al.clone();
+                    for (attname, (atttype, defaultdecl, is_editable)) in atts.iter(){
+                        match newal.get(attname){
+                            None => {
+                                newal.insert(
+                                    attname.clone(), (atttype.clone(), defaultdecl.clone(), *is_editable)
+                                );
+                            }
+                            Some((_, _, existing_is_editable)) => {
+                                if *existing_is_editable {
+                                    newal.insert(
+                                        attname.clone(), (atttype.clone(), defaultdecl.clone(), *is_editable)
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    state2
+                        .dtd
+                        .attlists
+                        .insert(n, newal);
+                    Ok(((input2, state2), ()))
+                }
+            }
+
+
+    /*
             state2
                 .dtd
                 .attlists
-                .insert(n.to_string(), DTDDecl::Attlist(n, "".to_string()));
+                .insert(n, atts);
             Ok(((input2, state2), ()))
+
+     */
         }
         Err(err) => Err(err),
     }
 }
 
 //AttDef ::= S Name S AttType S DefaultDecl
-fn attdef<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
+fn attdef<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (QualifiedName, AttType, DefaultDecl)), ParseError> {
     map(
         tuple6(
             whitespace1(),
@@ -51,53 +239,55 @@ fn attdef<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String)
             whitespace1(),
             defaultdecl(),
         ),
-        |_x| "".to_string(),
+        |(_,an,_,at,_,dd)| {
+            let qn = if an.contains(':'){
+                let mut attnamesplit = an.split(":");
+                let prefix = Some(attnamesplit.next().unwrap().to_string());
+                let local = attnamesplit.collect::<String>();
+                QualifiedName::new(None, prefix, local)
+            } else {
+                QualifiedName::new(None, None, an)
+            };
+            (qn, at, dd)
+        },
     )
 }
 
 //AttType ::= StringType | TokenizedType | EnumeratedType
-fn atttype<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
-    alt4(
-        map(petextreference(), |_| {}), //TODO
-        tag("CDATA"),                   //Stringtype
-        alt7(
-            //tokenizedtype
-            tag("IDREFS"),
-            tag("IDREF"),
-            tag("ID"),
-            tag("ENTITY"),
-            tag("ENTITIES"),
-            tag("NMTOKENS"),
-            tag("NMTOKEN"),
-        ),
+fn atttype<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, AttType), ParseError> {
+    alt9(
+        //map(petextreference(), |_| {}), //TODO
+        value(tag("CDATA"), AttType::CDATA), //Stringtype
+        //tokenizedtype
+        value(tag("IDREFS"), AttType::IDREFS),
+        value(tag("IDREF"), AttType::IDREF),
+        value(tag("ID"), AttType::ID),
+        value(tag("ENTITY"), AttType::ENTITY),
+        value(tag("ENTITIES"), AttType::ENTITIES),
+        value(tag("NMTOKENS"), AttType::NMTOKENS),
+        value(tag("NMTOKEN"), AttType::NMTOKEN),
         enumeratedtype(),
     )
 }
 
 //DefaultDecl ::= '#REQUIRED' | '#IMPLIED' | (('#FIXED' S)? AttValue)
-fn defaultdecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
-    map(
-        alt3(
-            value(tag("#REQUIRED"), "#REQUIRED".to_string()),
-            value(tag("#IMPLIED"), "#IMPLIED".to_string()),
-            map(
-                tuple2(
-                    opt(tuple2(
-                        value(tag("#FIXED"), "#FIXED".to_string()),
-                        whitespace1(),
-                    )),
-                    attvalue(),
-                ),
-                |(x, y)| match x {
-                    None => y,
-                    Some((mut f, _)) => {
-                        f.push_str(&y);
-                        f
-                    }
-                },
+fn defaultdecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, DefaultDecl), ParseError> {
+    alt3(
+        value(tag("#REQUIRED"), DefaultDecl::Required),
+        value(tag("#IMPLIED"), DefaultDecl::Implied),
+        map(
+            tuple2(
+                opt(tuple2(
+                    value(tag("#FIXED"), "#FIXED".to_string()),
+                    whitespace1(),
+                )),
+                attvalue(),
             ),
-        ),
-        |_x| (),
+            |(x, y)| match x {
+                None => DefaultDecl::Default(y),
+                Some(_) => DefaultDecl::FIXED(y)
+            },
+        )
     )
 }
 

--- a/src/parser/xml/dtd/extsubset.rs
+++ b/src/parser/xml/dtd/extsubset.rs
@@ -9,7 +9,7 @@ use crate::parser::xml::dtd::attlistdecl::attlistdecl;
 use crate::parser::xml::dtd::conditionals::conditionalsect;
 use crate::parser::xml::dtd::elementdecl::elementdecl;
 use crate::parser::xml::dtd::gedecl::gedecl;
-use crate::parser::xml::dtd::notation::ndatadecl;
+use crate::parser::xml::dtd::notation::NotationDecl;
 use crate::parser::xml::dtd::pedecl::pedecl;
 use crate::parser::xml::dtd::pereference::pereference;
 use crate::parser::xml::dtd::textdecl::textdecl;
@@ -46,7 +46,7 @@ pub(crate) fn extsubsetdecl<N: Node>(
         attlistdecl(),
         pedecl(),
         gedecl(),
-        ndatadecl(),
+        NotationDecl(),
         whitespace1(),
         map(comment(), |_| ()),
         map(processing_instruction(), |_| ()),

--- a/src/parser/xml/dtd/intsubset.rs
+++ b/src/parser/xml/dtd/intsubset.rs
@@ -6,7 +6,7 @@ use crate::parser::combinators::whitespace::whitespace1;
 use crate::parser::xml::dtd::attlistdecl::attlistdecl;
 use crate::parser::xml::dtd::elementdecl::elementdecl;
 use crate::parser::xml::dtd::gedecl::gedecl;
-use crate::parser::xml::dtd::notation::ndatadecl;
+use crate::parser::xml::dtd::notation::NotationDecl;
 use crate::parser::xml::dtd::pedecl::pedecl;
 use crate::parser::xml::dtd::pereference::pereference;
 use crate::parser::xml::misc::comment;
@@ -20,7 +20,7 @@ pub(crate) fn intsubset<N: Node>(
         attlistdecl(),
         pedecl(),
         gedecl(),
-        ndatadecl(),
+        NotationDecl(),
         whitespace1(),
         map(comment(), |_| ()),
         map(processing_instruction(), |_| ()),

--- a/src/parser/xml/dtd/misc.rs
+++ b/src/parser/xml/dtd/misc.rs
@@ -13,9 +13,9 @@ use crate::parser::xml::dtd::pereference::petextreference;
 use crate::parser::xml::qname::name;
 use crate::parser::{ParseError, ParseInput};
 
-pub(crate) fn nmtoken<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError>
+pub(crate) fn nmtoken<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError>
 {
-    map(many1(take_while(|c| is_namechar(&c))), |_x| ())
+    map(many1(take_while(|c| is_namechar(&c))), |x| x.join(""))
 }
 
 pub(crate) fn contentspec<N: Node>(

--- a/src/parser/xml/dtd/notation.rs
+++ b/src/parser/xml/dtd/notation.rs
@@ -11,11 +11,11 @@ use crate::parser::combinators::whitespace::{whitespace0, whitespace1};
 use crate::parser::common::{is_pubid_char, is_pubid_charwithapos};
 use crate::parser::xml::qname::{name, qualname};
 use crate::parser::{ParseError, ParseInput};
-use crate::xmldecl::DTDDecl;
+use crate::xmldecl::{AttType, DTDDecl};
 
 //NotationType ::= 'NOTATION' S '(' S? Name (S? '|' S? Name)* S? ')'
 pub(crate) fn notationtype<N: Node>(
-) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, AttType), ParseError> {
     map(
         tuple8(
             tag("NOTATION"),
@@ -23,11 +23,19 @@ pub(crate) fn notationtype<N: Node>(
             tag("("),
             whitespace0(),
             name(),
-            many0(tuple4(whitespace0(), tag("|"), whitespace0(), name())),
+            many0(
+                map(
+                    tuple4(whitespace0(), tag("|"), whitespace0(), name()),
+                    |(_,_,_,n)| n
+                )
+            ),
             whitespace0(),
             tag(")"),
         ),
-        |_x| (),
+        |(_,_,_,_,nm, mut nms,_,_)| {
+            nms.push(nm);
+            AttType::NOTATION(nms)
+        },
     )
 }
 
@@ -37,7 +45,7 @@ pub(crate) fn notationpublicid<N: Node>(
         map(
             tuple3(
                 tag("SYSTEM"),
-                whitespace0(),
+                whitespace1(),
                 alt2(
                     delimited(tag("'"), take_until("'"), tag("'")),
                     delimited(tag("\""), take_until("\""), tag("\"")),
@@ -48,7 +56,7 @@ pub(crate) fn notationpublicid<N: Node>(
         map(
             tuple5(
                 tag("PUBLIC"),
-                whitespace0(),
+                whitespace1(),
                 alt2(
                     delimited(tag("'"), take_while(|c| is_pubid_char(&c)), tag("'")),
                     delimited(
@@ -68,7 +76,7 @@ pub(crate) fn notationpublicid<N: Node>(
         map(
             tuple3(
                 tag("PUBLIC"),
-                whitespace0(),
+                whitespace1(),
                 alt2(
                     delimited(tag("'"), take_while(|c| is_pubid_char(&c)), tag("'")),
                     delimited(
@@ -83,7 +91,7 @@ pub(crate) fn notationpublicid<N: Node>(
     )
 }
 
-pub(crate) fn ndatadecl<N: Node>(
+pub(crate) fn NotationDecl<N: Node>(
 ) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |input| match tuple7(
         tag("<!NOTATION"),
@@ -105,4 +113,20 @@ pub(crate) fn ndatadecl<N: Node>(
         }
         Err(err) => Err(err),
     }
+}
+
+pub(crate) fn ndatadecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError>
+{
+    map(
+        tuple4(
+            whitespace1(),
+            tag("NDATA"),
+            whitespace1(),
+            name()
+        ),
+        |(_,_,_,notation)|{
+            println!("notation");
+            notation
+        }
+    )
 }

--- a/src/xmldecl.rs
+++ b/src/xmldecl.rs
@@ -99,10 +99,10 @@ impl XMLDeclBuilder {
 #[derive(Clone, PartialEq)]
 pub struct DTD {
     pub(crate) elements: HashMap<String, DTDDecl>,
-    pub(crate) attlists: HashMap<String, DTDDecl>,
+    pub(crate) attlists: HashMap<QualifiedName, HashMap<QualifiedName, (AttType, DefaultDecl, bool)>>,// Boolean for is_editable;
     pub(crate) notations: HashMap<String, DTDDecl>,
     pub(crate) generalentities: HashMap<String, (String, bool)>, // Boolean for is_editable;
-    pub(crate) paramentities: HashMap<String, (String, bool)>,
+    pub(crate) paramentities: HashMap<String, (String, bool)>,// Boolean for is_editable;
     publicid: Option<String>,
     systemid: Option<String>,
     name: Option<String>,
@@ -139,8 +139,29 @@ impl Default for DTD {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DTDDecl {
     Element(QualifiedName, String),
-    Attlist(QualifiedName, String),
     Notation(QualifiedName, String),
     GeneralEntity(QualifiedName, String),
     ParamEntity(QualifiedName, String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum AttType {
+    CDATA,
+    ID,
+    IDREF,
+    IDREFS,
+    ENTITY,
+    ENTITIES,
+    NMTOKEN,
+    NMTOKENS,
+    NOTATION(Vec<String>),
+    ENUMERATION(Vec<String>)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum DefaultDecl {
+    Required,
+    Implied,
+    FIXED(String),
+    Default(String)
 }

--- a/tests/conformance/xml/xmltest_valid_ext_sa.rs
+++ b/tests/conformance/xml/xmltest_valid_ext_sa.rs
@@ -18,7 +18,7 @@ fn validextsa001() {
         Test ID:valid-ext-sa-001
         Test URI:valid/ext-sa/001.xml
         Spec Sections:2.11
-        Description:A combination of carriage return line feed in an external entity mustbe normalized to a single newline.
+        Description:A combination of carriage return line feed in an external entity must be normalized to a single newline.
     */
 
     let mut pc = ParserConfig::new();

--- a/tests/conformance/xml/xmltest_valid_sa.rs
+++ b/tests/conformance/xml/xmltest_valid_sa.rs
@@ -1508,7 +1508,6 @@ fn validsa043() {
 }
 
 #[test]
-#[ignore]
 fn validsa044() {
     /*
         Test ID:valid-sa-044
@@ -1543,7 +1542,6 @@ fn validsa044() {
 }
 
 #[test]
-#[ignore]
 fn validsa045() {
     /*
         Test ID:valid-sa-045
@@ -1578,7 +1576,6 @@ fn validsa045() {
 }
 
 #[test]
-#[ignore]
 fn validsa046() {
     /*
         Test ID:valid-sa-046
@@ -2732,7 +2729,6 @@ fn validsa079() {
 }
 
 #[test]
-#[ignore]
 fn validsa080() {
     /*
         Test ID:valid-sa-080
@@ -3144,7 +3140,6 @@ fn validsa091() {
 }
 
 #[test]
-#[ignore]
 fn validsa092() {
     /*
         Test ID:valid-sa-092
@@ -3213,7 +3208,6 @@ fn validsa093() {
 }
 
 #[test]
-#[ignore]
 fn validsa094() {
     /*
         Test ID:valid-sa-094
@@ -3283,7 +3277,6 @@ fn validsa095() {
 }
 
 #[test]
-#[ignore]
 fn validsa096() {
     /*
         Test ID:valid-sa-096

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -27,7 +27,6 @@ fn parser_config_namespace_nodes_1() {
              </doc>"#;
 
     let mut pc = ParserConfig::new();
-    pc.namespace_nodes = false;
 
     let testxml = RNode::new_document();
     let parseresult = xml::parse(testxml, doc, Some(pc));
@@ -59,103 +58,32 @@ fn parser_config_namespace_nodes_1() {
 }
 
 #[test]
-fn parser_config_namespace_nodes_2() {
-    let doc = r#"<doc xmlns="namespace"
-                  xmlns:a="namespace1"
-                  xmlns:b="namespace2"
-                  xmlns:c="namespace3"
-                  xmlns:d="namespace4"
-                  xmlns:e="namespace5"
-             >
-                 <element1/>
-                 <element2 xmlns="namespace6"/>
-                 <element3 xmlns:f="namespace7"/>
-                 <element4 xmlns:f="namespace8"/>
-                 <element5>
-                     <element6/>
-                 </element5>
-             </doc>"#;
+fn parser_config_default_attrs_1() {
+    /*
+        Conformance tests will determine if the ATTLIST functions are working,
+        this tests only that it can be disabled.
+     */
+    let doc = r#"<!DOCTYPE doc [
+        <!ELEMENT doc EMPTY>
+        <!ATTLIST doc a CDATA "a" b CDATA "b" c CDATA #IMPLIED>
+    ]>
+    <doc/>"#;
 
-    let mut pc = ParserConfig::new();
-    pc.namespace_nodes = true;
+    let mut pc1 = ParserConfig::new();
+    let testxml1 = RNode::new_document();
+    let parseresult1 = xml::parse(testxml1, doc, Some(pc1));
 
-    let testxml = RNode::new_document();
-    let parseresult = xml::parse(testxml, doc, Some(pc));
+    let mut pc2 = ParserConfig::new();
+    pc2.attr_defaults = false;
+    let testxml2 = RNode::new_document();
+    let parseresult2 = xml::parse(testxml2, doc, Some(pc2));
 
-    assert!(parseresult.is_ok());
+    assert!(parseresult1.is_ok());
+    assert!(parseresult2.is_ok());
 
-    let doc = parseresult.clone().unwrap().first_child().unwrap();
-    let mut docchildren = doc
-        .child_iter()
-        .filter(|n| n.node_type() == NodeType::Element);
-    let element1 = docchildren.next().unwrap();
-    let element2 = docchildren.next().unwrap();
-    let element3 = docchildren.next().unwrap();
-    let element4 = docchildren.next().unwrap();
-    let element5 = docchildren.next().unwrap();
-    let element6 = element5
-        .child_iter()
-        .filter(|n| n.node_type() == NodeType::Element)
-        .next()
-        .unwrap();
+    assert_eq!(parseresult1.clone().unwrap().first_child().unwrap().attribute_iter().count(),2);
+    assert_eq!(parseresult2.clone().unwrap().first_child().unwrap().attribute_iter().count(),0);
 
-    assert_eq!(doc.namespace_iter().count(), 7);
-    assert_eq!(element1.namespace_iter().count(), 7);
-    assert_eq!(element2.namespace_iter().count(), 7);
-    assert_eq!(element3.namespace_iter().count(), 8);
-    assert_eq!(element4.namespace_iter().count(), 8);
-    assert_eq!(element5.namespace_iter().count(), 7);
-    assert_eq!(element6.namespace_iter().count(), 7);
-}
-
-#[test]
-fn parser_config_namespace_nodes_3() {
-    let doc = r#"<doc xmlns="namespace"
-                  xmlns:a="namespace1"
-                  xmlns:b="namespace2"
-                  xmlns:c="namespace3"
-                  xmlns:d="namespace4"
-                  xmlns:e="namespace5"
-             >
-                 <element1/>
-                 <element2 xmlns="namespace6"/>
-                 <element3 xmlns:f="namespace7"/>
-                 <element4 xmlns:f="namespace8"/>
-                 <element5 xmlns="">
-                     <element6/>
-                 </element5>
-             </doc>"#;
-
-    let mut pc = ParserConfig::new();
-    pc.namespace_nodes = true;
-
-    let testxml = RNode::new_document();
-    let parseresult = xml::parse(testxml, doc, Some(pc));
-
-    assert!(parseresult.is_ok());
-
-    let doc = parseresult.clone().unwrap().first_child().unwrap();
-    let mut docchildren = doc
-        .child_iter()
-        .filter(|n| n.node_type() == NodeType::Element);
-    let element1 = docchildren.next().unwrap();
-    let element2 = docchildren.next().unwrap();
-    let element3 = docchildren.next().unwrap();
-    let element4 = docchildren.next().unwrap();
-    let element5 = docchildren.next().unwrap();
-    let element6 = element5
-        .child_iter()
-        .filter(|n| n.node_type() == NodeType::Element)
-        .next()
-        .unwrap();
-
-    assert_eq!(doc.namespace_iter().count(), 7);
-    assert_eq!(element1.namespace_iter().count(), 7);
-    assert_eq!(element2.namespace_iter().count(), 7);
-    assert_eq!(element3.namespace_iter().count(), 8);
-    assert_eq!(element4.namespace_iter().count(), 8);
-    assert_eq!(element5.namespace_iter().count(), 7);
-    assert_eq!(element6.namespace_iter().count(), 7);
 }
 
 #[test]


### PR DESCRIPTION
Hi Steve,

Some updates for the parser, we now populate default and FIXED attribute values as specified in the DTD. Its enabled by default but can be switched off as a parser config setting.

Have removed the namespace_nodes flag on the parser config as it does nothing in the aftermath of the namespace node redesign.