### PR TITLE
Change in storage of Attributes and Namespaces on Smite

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,5 +97,5 @@ pub use transform::Transform;
 pub mod trees;
 
 pub mod testutils;
-pub mod validators;
+//pub mod validators;
 pub mod namespace;

--- a/src/parser/combinators/alt.rs
+++ b/src/parser/combinators/alt.rs
@@ -171,6 +171,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn alt7<P1, P2, P3, P4, P5, P6, P7, A, N: Node>(
     parser1: P1,
     parser2: P2,

--- a/src/parser/xml/dtd/extsubset.rs
+++ b/src/parser/xml/dtd/extsubset.rs
@@ -9,7 +9,7 @@ use crate::parser::xml::dtd::attlistdecl::attlistdecl;
 use crate::parser::xml::dtd::conditionals::conditionalsect;
 use crate::parser::xml::dtd::elementdecl::elementdecl;
 use crate::parser::xml::dtd::gedecl::gedecl;
-use crate::parser::xml::dtd::notation::NotationDecl;
+use crate::parser::xml::dtd::notation::notation_decl;
 use crate::parser::xml::dtd::pedecl::pedecl;
 use crate::parser::xml::dtd::pereference::pereference;
 use crate::parser::xml::dtd::textdecl::textdecl;
@@ -46,7 +46,7 @@ pub(crate) fn extsubsetdecl<N: Node>(
         attlistdecl(),
         pedecl(),
         gedecl(),
-        NotationDecl(),
+        notation_decl(),
         whitespace1(),
         map(comment(), |_| ()),
         map(processing_instruction(), |_| ()),

--- a/src/parser/xml/dtd/intsubset.rs
+++ b/src/parser/xml/dtd/intsubset.rs
@@ -6,7 +6,7 @@ use crate::parser::combinators::whitespace::whitespace1;
 use crate::parser::xml::dtd::attlistdecl::attlistdecl;
 use crate::parser::xml::dtd::elementdecl::elementdecl;
 use crate::parser::xml::dtd::gedecl::gedecl;
-use crate::parser::xml::dtd::notation::NotationDecl;
+use crate::parser::xml::dtd::notation::notation_decl;
 use crate::parser::xml::dtd::pedecl::pedecl;
 use crate::parser::xml::dtd::pereference::pereference;
 use crate::parser::xml::misc::comment;
@@ -20,7 +20,7 @@ pub(crate) fn intsubset<N: Node>(
         attlistdecl(),
         pedecl(),
         gedecl(),
-        NotationDecl(),
+        notation_decl(),
         whitespace1(),
         map(comment(), |_| ()),
         map(processing_instruction(), |_| ()),

--- a/src/parser/xml/dtd/notation.rs
+++ b/src/parser/xml/dtd/notation.rs
@@ -91,7 +91,7 @@ pub(crate) fn notationpublicid<N: Node>(
     )
 }
 
-pub(crate) fn NotationDecl<N: Node>(
+pub(crate) fn notation_decl<N: Node>(
 ) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
     move |input| match tuple7(
         tag("<!NOTATION"),
@@ -115,6 +115,7 @@ pub(crate) fn NotationDecl<N: Node>(
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn ndatadecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError>
 {
     map(

--- a/src/parser/xml/element.rs
+++ b/src/parser/xml/element.rs
@@ -67,7 +67,7 @@ fn emptyelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), 
 
                         }
                         Some(atts) => {
-                            for (mut attname, (_, defdecl, _)) in atts.iter(){
+                            for (attname, (_, defdecl, _)) in atts.iter(){
                                 match defdecl {
                                     DefaultDecl::Default(s) | DefaultDecl::FIXED(s) => {
                                         let mut at = attname.clone();
@@ -161,7 +161,7 @@ fn taggedelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N),
 
                         }
                         Some(atts) => {
-                            for (mut attname, (_, defdecl, _)) in atts.iter(){
+                            for (attname, (_, defdecl, _)) in atts.iter(){
                                 match defdecl {
                                     DefaultDecl::Default(s) | DefaultDecl::FIXED(s) => {
                                         let mut at = attname.clone();

--- a/src/value.rs
+++ b/src/value.rs
@@ -424,6 +424,35 @@ impl PartialOrd for Value {
     }
 }
 
+//This is ONLY being used for namespace node sorting for the purposes of serializing
+//Feel free to change it.
+//We can change between versions, so long as each execution on that version is consistent.
+impl Ord for Value {
+    fn cmp(&self, other: &Value) -> Ordering {
+        match self {
+            Value::String(s) => {
+                let o: String = other.to_string();
+                s.cmp(&o)
+            }
+            Value::Boolean(_) => Ordering::Equal,
+            Value::Decimal(d) => match other {
+                Value::Decimal(e) => d.cmp(e),
+                _ => Ordering::Equal, // type error?
+            },
+            Value::Integer(d) => match other {
+                Value::Integer(e) => d.cmp(e),
+                _ => Ordering::Equal, // type error?
+            },
+            Value::Double(d) => match other {
+                Value::Double(e) => d.partial_cmp(e).unwrap_or_else(|| Ordering::Equal),
+                _ => Ordering::Equal, // type error?
+            },
+            _ => Ordering::Equal,
+        }
+    }
+}
+
+
 impl From<String> for Value {
     fn from(s: String) -> Self {
         Value::String(s)

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -26,7 +26,7 @@ fn parser_config_namespace_nodes_1() {
                  </element5>
              </doc>"#;
 
-    let mut pc = ParserConfig::new();
+    let pc = ParserConfig::new();
 
     let testxml = RNode::new_document();
     let parseresult = xml::parse(testxml, doc, Some(pc));
@@ -69,7 +69,7 @@ fn parser_config_default_attrs_1() {
     ]>
     <doc/>"#;
 
-    let mut pc1 = ParserConfig::new();
+    let  pc1 = ParserConfig::new();
     let testxml1 = RNode::new_document();
     let parseresult1 = xml::parse(testxml1, doc, Some(pc1));
 

--- a/tests/serializer.rs
+++ b/tests/serializer.rs
@@ -1,0 +1,150 @@
+use std::fs;
+use std::rc::Rc;
+use xrust::Node;
+use xrust::parser::xml;
+use xrust::trees::smite::{Node as SmiteNode, RNode};
+
+#[test]
+fn serializer_issue_98() {
+    /*
+        Github issue number 98
+        We wish to have XML documents output attributes in some stable order for test purposes.
+        IMPORTANT NOTE: We will be stable for a particular version, but XML itself does not care
+        about attribute order. We may switch the ordering between versions if we find a technical
+        reason to do so.
+    */
+
+    let data = fs::read_to_string("tests/xml/issue-98.xml").unwrap();
+    let mut prev_xml_output = None;
+
+    for iteration in 0..100 {
+        let doc = xml::parse(RNode::new_document(), data.clone().as_str(), None).unwrap();
+        let xml_output = doc.to_xml();
+        if let Some(prev_xml_output) = &prev_xml_output {
+            assert_eq!(
+                &xml_output,
+                prev_xml_output,
+                "Failed on run {}", iteration
+            );
+        }
+        prev_xml_output = Some(xml_output);
+    }
+
+}
+
+#[test]
+fn serializer_1() {
+    /*
+        Testing the XML output, simple document.
+    */
+
+    let data = "<doc><child/></doc>";
+
+    let doc = xml::parse(RNode::new_document(), data, None).unwrap();
+    let xml_output = doc.to_xml();
+
+    /*
+        Note, xRust currently does not output self closing tags, if it does you'll need to update
+        this test with
+
+        assert_eq!(xml_output, "<doc><child/></doc>");
+     */
+    assert_eq!(xml_output, "<doc><child></child></doc>");
+
+}
+
+
+#[test]
+fn serializer_2() {
+    /*
+        Testing the XML output, with some namespaces.
+    */
+
+    let data = "<doc xmlns='ns1'><child xmlns='ns2'/></doc>";
+
+    let doc = xml::parse(RNode::new_document(), data, None).unwrap();
+    let xml_output = doc.to_xml();
+
+    /*
+        Note, xRust currently does not output self closing tags, if it does you'll need to update
+        this test with
+
+        assert_eq!(xml_output, "<doc xmlns='ns1'><child xmlns='ns2'/></doc>");
+     */
+    assert_eq!(xml_output, "<doc xmlns='ns1'><child xmlns='ns2'></child></doc>");
+
+}
+
+#[test]
+fn serializer_3() {
+    /*
+        Testing the XML output, with some namespace aliases.
+    */
+
+    let data = "<a:doc xmlns:a='ns1'><a:child xmlns:a='ns2'/></a:doc>";
+
+    let doc = xml::parse(RNode::new_document(), data, None).unwrap();
+    let xml_output = doc.to_xml();
+
+    /*
+        Note, xRust currently does not output self closing tags, if it does you'll need to update
+        this test with
+
+        assert_eq!(xml_output, "<a:doc xmlns:a='ns1'><a:child xmlns:a='ns2'/></a:doc>");
+     */
+    assert_eq!(xml_output, "<a:doc xmlns:a='ns1'><a:child xmlns:a='ns2'></a:child></a:doc>");
+
+}
+
+#[test]
+fn serializer_4() {
+    /*
+        Testing the XML output, mixed content
+    */
+
+    let data = r#"<content att1='val1' xmlns:a='someothernamespace' att2='val2' xmlns='somenamespace' a:att4='val4' someatt='val5' other='valx'>
+    <content2>text</content2>
+    <content3/>
+    <content4 xmlns='thirdnamespace' a:something='test'>text3</content4>
+    <content05 xmlns:a='fourthnamespace' a:somethingelse='test2'>text4</content05>
+</content>"#;
+
+    let doc = xml::parse(RNode::new_document(), data, None).unwrap();
+    let xml_output = doc.to_xml();
+
+    /*
+        Note, xRust currently does not output self closing tags, if it does you'll need to update
+        this test with
+
+    assert_eq!(xml_output, "<content xmlns='somenamespace' xmlns:a='someothernamespace' att1='val1' att2='val2' other='valx' someatt='val5' a:att4='val4'>
+    <content2>text</content2>
+    <content3/>
+    <content4 xmlns='thirdnamespace' a:something='test'>text3</content4>
+    <content05 xmlns:a='fourthnamespace' a:somethingelse='test2'>text4</content05>
+</content>");
+
+     */
+    assert_eq!(xml_output, "<content xmlns='somenamespace' xmlns:a='someothernamespace' att1='val1' att2='val2' other='valx' someatt='val5' a:att4='val4'>
+    <content2>text</content2>
+    <content3></content3>
+    <content4 xmlns='thirdnamespace' a:something='test'>text3</content4>
+    <content05 xmlns:a='fourthnamespace' a:somethingelse='test2'>text4</content05>
+</content>");
+
+}
+
+#[test]
+#[ignore]
+fn serializer_5() {
+    /*
+        Testing the XML output, characters to be escaped
+    */
+
+    let data = "<doc attr='&apos;'>XML escape test: &lt; &gt; &amp; &apos; &quot;</doc>";
+
+    let doc = xml::parse(RNode::new_document(), data, None).unwrap();
+    let xml_output = doc.to_xml();
+
+    assert_eq!(xml_output, "<doc attr='&apos;'>XML escape test: &lt; &gt; &amp; &apos; &quot;</doc>");
+
+}

--- a/tests/serializer.rs
+++ b/tests/serializer.rs
@@ -1,8 +1,7 @@
 use std::fs;
-use std::rc::Rc;
 use xrust::Node;
 use xrust::parser::xml;
-use xrust::trees::smite::{Node as SmiteNode, RNode};
+use xrust::trees::smite::RNode;
 
 #[test]
 fn serializer_issue_98() {

--- a/tests/xml/issue-98.xml
+++ b/tests/xml/issue-98.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<content att1="val1" xmlns:a="someothernamespace" att2="val2" xmlns="somenamespace" a:att4="val4" someatt="val5" other="valx">
+    <content2>text</content2>
+    <content3>text2</content3>
+    <content4 xmlns="thirdnamespace" a:something="test">text3</content4>
+    <content05 xmlns:a="fourthnamespace" a:somethingelse="test2">text4</content05>
+</content>


### PR DESCRIPTION
Hi Steve,

A small-ish change from using Hashmaps on attributes and namespaces in smite to instead using BTrees. Shouldn't see much if any change in speed, but BTrees will store the values in order allowing for stable serialization of documents for issue #98