### PR TITLE
XML DTD ID/ID REF support for attributes.

### DIFF
--- a/examples/ixml.rs
+++ b/examples/ixml.rs
@@ -62,6 +62,8 @@ fn to_rnode_aux(arena: &Arena<Content>, n: NodeId, mut t: RNode) {
                             .new_attribute(
                                 Rc::new(QualifiedName::new(None, None, attr_name.clone())),
                                 Rc::new(Value::from(attr_value.clone())),
+                                false,
+                                false
                             )
                             .expect("unable to create attribute node");
                         t.add_attribute(new_attr).expect("unable to append node");
@@ -76,6 +78,8 @@ fn to_rnode_aux(arena: &Arena<Content>, n: NodeId, mut t: RNode) {
                     .new_attribute(
                         Rc::new(QualifiedName::new(None, None, name.clone())),
                         Rc::new(Value::from(value.clone())),
+                        false,
+                        false
                     )
                     .expect("unable to create attribute node");
                 t.add_attribute(new).expect("unable to append node");

--- a/src/item.rs
+++ b/src/item.rs
@@ -431,6 +431,10 @@ pub trait Node: Clone + PartialEq + fmt::Debug {
     fn is_element(&self) -> bool {
         self.node_type() == NodeType::Element
     }
+    /// Check if a node is an XML ID
+    fn is_id(&self) -> bool;
+    /// Check if a node is an  XML IDREF or IDREFS
+    fn is_idrefs(&self) -> bool;
 
     /// An iterator over the children of the node
     fn child_iter(&self) -> Self::NodeIterator;
@@ -470,7 +474,7 @@ pub trait Node: Clone + PartialEq + fmt::Debug {
     /// Create a new text-type node in the same document tree. The new node is not attached to the tree.
     fn new_text(&self, v: Rc<Value>) -> Result<Self, Error>;
     /// Create a new attribute-type node in the same document tree. The new node is not attached to the tree.
-    fn new_attribute(&self, qn: Rc<QualifiedName>, v: Rc<Value>) -> Result<Self, Error>;
+    fn new_attribute(&self, qn: Rc<QualifiedName>, v: Rc<Value>, is_id: bool, is_idrefs: bool) -> Result<Self, Error>;
     /// Create a new comment-type node in the same document tree. The new node is not attached to the tree.
     fn new_comment(&self, v: Rc<Value>) -> Result<Self, Error>;
     /// Create a new processing-instruction-type node in the same document tree. The new node is not attached to the tree.

--- a/src/parser/xml/attribute.rs
+++ b/src/parser/xml/attribute.rs
@@ -25,7 +25,7 @@ use crate::{Error, ErrorKind};
 pub(crate) fn attributes<N: Node>() -> impl Fn(
     ParseInput<N>,
 ) -> Result<
-    (ParseInput<N>, (Vec<N>, Vec<N>)),
+    (ParseInput<N>, (Vec<(QualifiedName, Rc<Value>)>, Vec<N>)),
     ParseError,
 > {
     move |input| match many0(attribute())(input) {
@@ -209,10 +209,11 @@ pub(crate) fn attributes<N: Node>() -> impl Fn(
                             }
                         }
                     }
-                    let newatt = doc
-                        .new_attribute(Rc::new(qn.clone()), attrval)
-                        .expect("unable to create attribute");
-                    resnodes.push(newatt);
+                    /*
+                        We don't return fully completed attributes here because we need to do some
+                        DTD checking on the element to assign properties such as IS_ID to the attribute
+                    */
+                    resnodes.push((qn.clone(), attrval));
 
                     /* Why not just use resnodes.contains()  ? I don't know how to do partial matching */
                     if resnodenames.contains(&(qn.namespace_uri(), qn.localname())) {

--- a/src/parser/xml/element.rs
+++ b/src/parser/xml/element.rs
@@ -17,18 +17,14 @@ use crate::parser::xml::qname::qualname;
 use crate::parser::xml::reference::reference;
 use crate::parser::{ParseError, ParseInput};
 use crate::qname::QualifiedName;
-use crate::xmldecl::DefaultDecl;
+use crate::xmldecl::{AttType, DefaultDecl};
 
 // Element ::= EmptyElemTag | STag content ETag
 pub(crate) fn element<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), ParseError>
 {
-    move |input| alt2(emptyelem(), taggedelem())(input)
-}
-
-// EmptyElemTag ::= '<' Name (Attribute)* '/>'
-fn emptyelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), ParseError> {
-    move |input| {
-        match tuple5(
+    move |input| match alt2(
+        //Empty element
+        map(tuple5(
             tag("<"),
             wellformed(qualname(), |qn| {
                 qn.prefix_to_string() != Some("xmlns".to_string())
@@ -36,85 +32,11 @@ fn emptyelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), 
             attributes(), //many0(attribute),
             whitespace0(),
             tag("/>"),
-        )(input)
-        {
-            Ok(((input1, state1), (_, mut n, (av, namespaces), _, _))) => {
-                if n.resolve(|p| state1.namespace.get(&p).map_or(
-                    Err(Error::new(ErrorKind::DynamicAbsent, "no namespace for prefix")),
-                    |r| Ok(r.clone())
-                )).is_err() {
-                    return Err(ParseError::MissingNameSpace);
-                }
-                let elementname = state1.get_qualified_name(n.namespace_uri(), n.prefix(), n.localname());
-                if state1.xmlversion=="1.1"
-                    && elementname.namespace_uri_to_string() == Some("".to_string())
-                    && elementname.prefix_to_string().is_some(){
-                    return Err(ParseError::MissingNameSpace);
-                }
-                let d = state1
-                    .doc
-                    .clone()
-                    .unwrap();
-                let e = d
-                    .new_element(elementname)
-                    .expect("unable to create element");
-
-                //Looking up the DTD, seeing if there are any attributes we should populate
-                //Remember, DTDs don't have namespaces, you need to lookup based on prefix and local name!
-                if state1.attr_defaults {
-                    match state1.dtd.attlists.get(&QualifiedName::new_from_values(None, n.prefix(), n.localname())){
-                        None => {
-
-                        }
-                        Some(atts) => {
-                            for (attname, (_, defdecl, _)) in atts.iter(){
-                                match defdecl {
-                                    DefaultDecl::Default(s) | DefaultDecl::FIXED(s) => {
-                                        let mut at = attname.clone();
-                                        match at.prefix() {
-                                            None => {}
-                                            Some(_) => {
-                                                if at.resolve(|p| state1.namespace.get(&p).map_or(
-                                                    Err(Error::new(ErrorKind::DynamicAbsent, "no namespace for prefix")),
-                                                    |r| Ok(r.clone())
-                                                )).is_err() {
-                                                    return Err(ParseError::MissingNameSpace);
-                                                }
-                                            }
-                                        }
-                                        let newattr = d.new_attribute(
-                                            Rc::new(at),
-                                            Rc::new(Value::String(s.clone()))
-                                        ).expect("unable to create attlist attribute");
-                                        e.add_attribute(newattr)
-                                            .expect("unable to add attlist attribute");
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
-                    }
-                }
-
-                //This will overwrite any attributes added above
-                //TODO merge into a single set of attributes before creating.
-                av.iter()
-                    .for_each(|b| e.add_attribute(b.clone()).expect("unable to add attribute"));
-                namespaces.iter().for_each(|nn| e.add_namespace(nn.clone()).expect("unable to add namespace node"));
-
-                Ok(((input1, state1.clone()), e))
-            }
-            Err(err) => Err(err),
-        }
-    }
-}
-
-// STag ::= '<' Name (Attribute)* '>'
-// ETag ::= '</' Name '>'
-// TODO: Check that names match and throw meaningful error
-fn taggedelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), ParseError> {
-    move |input| {
-        match wellformed(
+        ),|(_, n, (at, ns), _, _)|{
+            ((), n.clone(), (at, ns), (), (), vec![], (), n, (), ())
+        }),
+        //tagged element
+        wellformed(
             tuple10(
                 tag("<"),
                 wellformed(qualname(), |qn| {
@@ -132,77 +54,157 @@ fn taggedelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N),
                 tag(">"),
             ),
             |(_, n, _a, _, _, _c, _, e, _, _)| n.to_string() == e.to_string(),
-        )(input)
-        {
-            Ok(((input1, state1), (_, mut n, (av, namespaces), _, _, c, _, _, _, _))) => {
-                if n.resolve(|p| state1.namespace.get(&p).map_or(
-                    Err(Error::new(ErrorKind::DynamicAbsent, "no namespace for prefix")),
-                    |r| Ok(r.clone())
-                )).is_err() {
-                    return Err(ParseError::MissingNameSpace);
+        ))(input){
+        Err(err) => Err(err),
+        Ok(((input1, mut state1), (_, mut n, (av, namespaces), _, _, c, _, _, _, _))) => {
+            if n.resolve(|p| state1.namespace.get(&p).map_or(
+                Err(Error::new(ErrorKind::DynamicAbsent, "no namespace for prefix")),
+                |r| Ok(r.clone())
+            )).is_err() {
+                return Err(ParseError::MissingNameSpace);
+            }
+            let elementname = state1.get_qualified_name(n.namespace_uri(), n.prefix(), n.localname());
+            if state1.xmlversion=="1.1"
+                && elementname.namespace_uri_to_string() == Some("".to_string())
+                && elementname.prefix_to_string().is_some(){
+                return Err(ParseError::MissingNameSpace);
+            }
+            let d = state1.doc.clone().unwrap();
+            let mut e = d
+                .new_element(elementname)
+                .expect("unable to create element");
+
+            //Looking up the DTD, seeing if there are any attributes we should populate
+            //Remember, DTDs don't have namespaces, you need to lookup based on prefix and local name!
+            // We generate the attributes in two sweeps:
+            // Once for attributes declared on the element and once for the DTD default attribute values.
+
+            let attlist = state1.dtd.attlists.get(&QualifiedName::new_from_values(None, n.prefix(), n.localname()));
+
+            match attlist {
+                None => {
+                    //No Attribute DTD, just insert all elements.
+                    for (attname, attval) in av.into_iter(){
+                        let a = d.new_attribute(
+                            Rc::new(attname),
+                            attval,
+                            false,
+                            false
+                        ).expect("unable to create attribute");
+                        e.add_attribute(a).expect("unable to add attribute")
+                    }
                 }
-                let d = state1.doc.clone().unwrap();
+                Some(atts) => {
+                    if state1.attr_defaults {
+                        for (attname, (atttype, defdecl, _)) in atts.iter(){
 
-                let elementname = state1.get_qualified_name(n.namespace_uri(), n.prefix(), n.localname());
-                if state1.xmlversion=="1.1"
-                    && elementname.namespace_uri_to_string() == Some("".to_string())
-                    && elementname.prefix_to_string().is_some(){
-                    return Err(ParseError::MissingNameSpace);
-                }
-                let mut e = d
-                    .new_element(elementname)
-                    .expect("unable to create element");
-
-                //Looking up the DTD, seeing if there are any attributes we should populate
-                //Remember, DTDs don't have namespaces, you need to lookup based on prefix and local name!
-                if state1.attr_defaults {
-                    match state1.dtd.attlists.get(&QualifiedName::new_from_values(None, n.prefix(), n.localname())){
-                        None => {
-
-                        }
-                        Some(atts) => {
-                            for (attname, (_, defdecl, _)) in atts.iter(){
-                                match defdecl {
-                                    DefaultDecl::Default(s) | DefaultDecl::FIXED(s) => {
-                                        let mut at = attname.clone();
-                                        match at.prefix() {
-                                            None => {}
-                                            Some(_) => {
-                                                if at.resolve(|p| state1.namespace.get(&p).map_or(
-                                                    Err(Error::new(ErrorKind::DynamicAbsent, "no namespace for prefix")),
-                                                    |r| Ok(r.clone())
-                                                )).is_err() {
-                                                    return Err(ParseError::MissingNameSpace);
-                                                }
+                            match defdecl {
+                                DefaultDecl::Default(s) | DefaultDecl::FIXED(s) => {
+                                    let mut at = attname.clone();
+                                    match at.prefix() {
+                                        None => {}
+                                        Some(_) => {
+                                            if at.resolve(|p| state1.namespace.get(&p).map_or(
+                                                Err(Error::new(ErrorKind::DynamicAbsent, "no namespace for prefix")),
+                                                |r| Ok(r.clone())
+                                            )).is_err() {
+                                                return Err(ParseError::MissingNameSpace);
                                             }
                                         }
-                                        let newattr = d.new_attribute(
-                                            Rc::new(at),
-                                            Rc::new(Value::String(s.clone()))
-                                        ).expect("unable to create attlist attribute");
-                                        e.add_attribute(newattr)
-                                            .expect("unable to add attlist attribute");
                                     }
-                                    _ => {}
+                                    //Assign IDs only if we are tracking.
+                                    let (attr_is_id, attr_is_idref) = match (atttype, state1.id_tracking) {
+                                        (_, false) => (false, false),
+                                        (AttType::ID, true) => (true, false),
+                                        (AttType::IDREF, true) => (false, true),
+                                        (AttType::IDREFS, true) => (false, true),
+                                        (_, _) => (false, false),
+                                    };
+                                    let a = d.new_attribute(
+                                        Rc::new(at),
+                                        Rc::new(Value::String(s.clone())),
+                                        attr_is_id,
+                                        attr_is_idref
+                                    ).expect("unable to create attribute");
+                                    e.add_attribute(a).expect("unable to add attribute")
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+
+                    for (attname, attval) in av.into_iter() {
+                        match atts.get(&QualifiedName::new(None, attname.prefix_to_string(), attname.localname_to_string())) {
+                            None => {
+                                let a = d.new_attribute(
+                                    Rc::new(attname),
+                                    attval,
+                                    false,
+                                    false
+                                ).expect("unable to create attribute");
+                                e.add_attribute(a).expect("unable to add attribute")
+                            }
+                            Some((atttype, _, _)) => {
+
+                                //Assign IDs only if we are tracking.
+                                let (attr_is_id, attr_is_idref) = match (atttype, state1.id_tracking) {
+                                    (_, false) => (false, false),
+                                    (AttType::ID, true) => (true, false),
+                                    (AttType::IDREF, true) => (false, true),
+                                    (AttType::IDREFS, true) => (false, true),
+                                    (_, _) => (false, false),
+                                };
+                                let a = d.new_attribute(
+                                    Rc::new(attname),
+                                    attval,
+                                    attr_is_id,
+                                    attr_is_idref
+                                ).expect("unable to create attribute");
+                                e.add_attribute(a).expect("unable to add attribute")
+                            }
+                        }
+                    }
+                }
+            }
+
+            //we've added the IDs and IDRefs, but we need to track all that.
+            if state1.id_tracking {
+                for attribute in e.attribute_iter() {
+                    if attribute.is_id(){
+                        match state1.ids_read.insert(attribute.value().clone()){
+                            true => {}
+                            false => {
+                                //Value already existed!
+                                return Err(ParseError::IDError(String::from("Diplicate ID found")))
+                            }
+                        }
+                    }
+                    if attribute.is_idrefs(){
+                        /*
+                        If the IDRef matches a previously loaded ID, we're all good. If not, that ID
+                        may exist further along, we'll make a note of it to check when we
+                        have completely parsed the document.
+                        */
+                        for idref in attribute.value().to_string().split_whitespace(){
+                            let idref_new = Rc::new(Value::String(idref.to_string()));
+                            match state1.ids_read.get(&idref_new){
+                                Some(_) => {}
+                                None => {
+                                    state1.ids_pending.insert(idref_new);
                                 }
                             }
                         }
                     }
                 }
-
-                //This will overwrite any attributes added above
-                //TODO merge into a single set of attributes before creating.
-                av.iter()
-                    .for_each(|b| e.add_attribute(b.clone()).expect("unable to add attribute"));
-                namespaces.iter()
-                    .for_each(|b| e.add_namespace(b.clone()).expect("unable to add namespace"));
-                // Add child nodes
-                c.iter().for_each(|d| {
-                    e.push(d.clone()).expect("unable to add node");
-                });
-                Ok(((input1, state1.clone()), e))
             }
-            Err(err) => Err(err),
+
+            namespaces.iter()
+                .for_each(|b| e.add_namespace(b.clone()).expect("unable to add namespace"));
+            // Add child nodes
+            c.iter().for_each(|d| {
+                e.push(d.clone()).expect("unable to add node");
+            });
+            Ok(((input1, state1.clone()), e))
         }
     }
 }

--- a/src/parser/xml/mod.rs
+++ b/src/parser/xml/mod.rs
@@ -97,6 +97,22 @@ fn document<N: Node>(input: ParseInput<N>) -> Result<(ParseInput<N>, N), ParseEr
         Ok(((input1, state1), (_, p, e, m))) => {
             //Check nothing remaining in iterator, nothing after the end of the root node.
             if input1.is_empty() {
+
+                /*
+                    We were check XML IDRefs as we parsed, but sometimes an ID comes after the IDREF,
+                    we now check those cases to ensure that all IDs needed were reported.
+                 */
+                if state1.id_tracking {
+                    for idref in state1.ids_pending.iter() {
+                        match state1.ids_read.get(idref){
+                            None => {
+                                return Err(ParseError::IDError(String::from("ID missing")))
+                            }
+                            Some(_) => {}
+                        }
+                    }
+                }
+
                 let pr = p.unwrap_or((None, vec![]));
 
                 pr.1.iter().for_each(|n| {

--- a/src/testutils/item_node.rs
+++ b/src/testutils/item_node.rs
@@ -395,13 +395,17 @@ macro_rules! item_node_tests (
 		.expect("unable to append child");
 	    let a1 = sd.new_attribute(
 		Rc::new(QualifiedName::new(None, None, String::from("role"))),
-		Rc::new(Value::from("testing"))
+		Rc::new(Value::from("testing")),
+		false,
+		false
 	    ).expect("unable to create attribute");
 	    t.add_attribute(a1)
 		.expect("unable to add attribute");
 	    let a2 = sd.new_attribute(
 		Rc::new(QualifiedName::new(None, None, String::from("phase"))),
-		Rc::new(Value::from("one"))
+		Rc::new(Value::from("one")),
+		false,
+		false
 	    ).expect("unable to create element");
 	    t.add_attribute(a2)
 		.expect("unable to add attribute");
@@ -466,13 +470,17 @@ macro_rules! item_node_tests (
 		.expect("unable to append child");
 	    let a1 = sd.new_attribute(
 		Rc::new(QualifiedName::new(None, None, String::from("role"))),
-		Rc::new(Value::from("testing"))
+		Rc::new(Value::from("testing")),
+		false,
+		false
 	    ).expect("unable to create attribute");
 	    t.add_attribute(a1)
 		.expect("unable to add attribute");
 	    let a2 = sd.new_attribute(
 		Rc::new(QualifiedName::new(None, None, String::from("phase"))),
-		Rc::new(Value::from("one"))
+		Rc::new(Value::from("one")),
+		false,
+		false
 	    ).expect("unable to create element");
 	    t.add_attribute(a2)
 		.expect("unable to add attribute");
@@ -487,11 +495,15 @@ macro_rules! item_node_tests (
 		.expect("unable to append child");
 	    let b1 = od.new_attribute(
 		Rc::new(QualifiedName::new(None, None, String::from("role"))),
-		Rc::new(Value::from("testing"))
+		Rc::new(Value::from("testing")),
+		false,
+		false
 	    ).expect("unable to create attribute");
 	    let b2 = od.new_attribute(
 		Rc::new(QualifiedName::new(None, None, String::from("phase"))),
-		Rc::new(Value::from("one"))
+		Rc::new(Value::from("one")),
+		false,
+		false
 	    ).expect("unable to create element");
 	    u.add_attribute(b2)
 		.expect("unable to add attribute");
@@ -511,13 +523,17 @@ macro_rules! item_node_tests (
 		.expect("unable to append child");
 	    let a1 = sd.new_attribute(
 		Rc::new(QualifiedName::new(None, None, String::from("role"))),
-		Rc::new(Value::from("testing"))
+		Rc::new(Value::from("testing")),
+		false,
+		false
 	    ).expect("unable to create attribute");
 	    t.add_attribute(a1)
 		.expect("unable to add attribute");
 	    let a2 = sd.new_attribute(
 		Rc::new(QualifiedName::new(None, None, String::from("phase"))),
-		Rc::new(Value::from("one"))
+		Rc::new(Value::from("one")),
+		false,
+		false
 	    ).expect("unable to create element");
 	    t.add_attribute(a2)
 		.expect("unable to add attribute");
@@ -532,11 +548,15 @@ macro_rules! item_node_tests (
 		.expect("unable to append child");
 	    let b1 = od.new_attribute(
 		Rc::new(QualifiedName::new(None, None, String::from("role"))),
-		Rc::new(Value::from("testing"))
+		Rc::new(Value::from("testing")),
+		false,
+		false
 	    ).expect("unable to create attribute");
 	    let b2 = od.new_attribute(
 		Rc::new(QualifiedName::new(None, None, String::from("phase"))),
-		Rc::new(Value::from("one"))
+		Rc::new(Value::from("one")),
+		false,
+		false
 	    ).expect("unable to create element");
 	    u.add_attribute(b2)
 		.expect("unable to add attribute");

--- a/src/transform/construct.rs
+++ b/src/transform/construct.rs
@@ -178,6 +178,8 @@ pub(crate) fn literal_attribute<
     let a = ctxt.rd.clone().unwrap().new_attribute(
         qn.clone(),
         Rc::new(Value::from(ctxt.dispatch(stctxt, t)?.to_string())),
+        false, // is_id
+        false
     )?;
     Ok(vec![Item::Node(a)])
 }
@@ -266,12 +268,14 @@ pub(crate) fn set_attribute<
                 if attval.len() == 1 {
                     match attval.first() {
                         Some(Item::Value(av)) => {
-                            n.add_attribute(od.new_attribute(atname.clone(), av.clone())?)?;
+                            n.add_attribute(od.new_attribute(atname.clone(), av.clone(), false, false)?)?;
                         }
                         _ => {
                             n.add_attribute(od.new_attribute(
                                 atname.clone(),
                                 Rc::new(Value::from(attval.to_string())),
+                                false,
+                                false
                             )?)?;
                         }
                     }
@@ -279,6 +283,8 @@ pub(crate) fn set_attribute<
                     n.add_attribute(od.new_attribute(
                         atname.clone(),
                         Rc::new(Value::from(attval.to_string())),
+                        false,
+                        false
                     )?)?;
                 }
             }

--- a/src/trees/nullo.rs
+++ b/src/trees/nullo.rs
@@ -106,7 +106,7 @@ impl Node for Nullo {
             String::from("not implemented"),
         ))
     }
-    fn new_attribute(&self, _: Rc<QualifiedName>, _: Rc<Value>) -> Result<Self, Error> {
+    fn new_attribute(&self, _: Rc<QualifiedName>, _: Rc<Value>, _: bool, _:bool) -> Result<Self, Error> {
         Err(Error::new(
             ErrorKind::NotImplemented,
             String::from("not implemented"),
@@ -178,6 +178,14 @@ impl Node for Nullo {
             ErrorKind::NotImplemented,
             String::from("not implemented"),
         ))
+    }
+
+    fn is_id(&self) -> bool {
+        false
+    }
+
+    fn is_idrefs(&self) -> bool {
+        false
     }
 }
 

--- a/src/xslt.rs
+++ b/src/xslt.rs
@@ -291,6 +291,8 @@ where
                             String::from("import"),
                         )),
                         Rc::new(Value::from(1)),
+                        false,
+                        false
                     )?;
                     newnode.add_attribute(newat)?;
                     c.insert_before(newnode)?;

--- a/tests/conformance/xml/eduni_errata3e_invalid.rs
+++ b/tests/conformance/xml/eduni_errata3e_invalid.rs
@@ -10,7 +10,6 @@ use xrust::item::Node;
 use xrust::trees::smite::RNode;
 
 #[test]
-#[ignore]
 fn rmte3e06a() {
     /*
         Test ID:rmt-e3e-06a
@@ -27,7 +26,6 @@ fn rmte3e06a() {
             .as_str(),
         None,
     );
-
     assert!(parseresult.is_err());
 }
 
@@ -53,7 +51,6 @@ fn rmte3e06b() {
 }
 
 #[test]
-#[ignore]
 fn rmte3e06c() {
     /*
         Test ID:rmt-e3e-06c

--- a/tests/conformance/xml/ibm_invalid.rs
+++ b/tests/conformance/xml/ibm_invalid.rs
@@ -444,7 +444,6 @@ fn ibminvalid_p56ibm56i06xml() {
 }
 
 #[test]
-#[ignore]
 fn ibminvalid_p56ibm56i07xml() {
     /*
         Test ID:ibm-invalid-P56-ibm56i07.xml
@@ -466,7 +465,6 @@ fn ibminvalid_p56ibm56i07xml() {
 }
 
 #[test]
-#[ignore]
 fn ibminvalid_p56ibm56i08xml() {
     /*
         Test ID:ibm-invalid-P56-ibm56i08.xml
@@ -488,7 +486,6 @@ fn ibminvalid_p56ibm56i08xml() {
 }
 
 #[test]
-#[ignore]
 fn ibminvalid_p56ibm56i09xml() {
     /*
         Test ID:ibm-invalid-P56-ibm56i09.xml
@@ -510,7 +507,6 @@ fn ibminvalid_p56ibm56i09xml() {
 }
 
 #[test]
-#[ignore]
 fn ibminvalid_p56ibm56i10xml() {
     /*
         Test ID:ibm-invalid-P56-ibm56i10.xml

--- a/tests/conformance/xml/sun_invalid.rs
+++ b/tests/conformance/xml/sun_invalid.rs
@@ -362,7 +362,6 @@ fn id07() {
 }
 
 #[test]
-#[ignore]
 fn id08() {
     /*
         Test ID:id08
@@ -379,12 +378,10 @@ fn id08() {
             .as_str(),
         None,
     );
-
     assert!(parseresult.is_err());
 }
 
 #[test]
-#[ignore]
 fn id09() {
     /*
         Test ID:id09

--- a/tests/node/mod.rs
+++ b/tests/node/mod.rs
@@ -16,11 +16,15 @@ where
     let a1 = sd.new_attribute(
         Rc::new(QualifiedName::new(None, None, String::from("role"))),
         Rc::new(Value::from("testing")),
+        false,
+        false
     )?;
     t.add_attribute(a1)?;
     let a2 = sd.new_attribute(
         Rc::new(QualifiedName::new(None, None, String::from("phase"))),
         Rc::new(Value::from("one")),
+        false,
+        false
     )?;
     t.add_attribute(a2)?;
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -101,3 +101,167 @@ fn parser_issue_94() {
 
     assert!(parseresult.is_ok())
 }
+
+#[test]
+fn parser_config_id_1() {
+
+    /*
+        Conformance tests will determine if the XML IDs are properly tracked by the parser,
+        this tests only that it can be disabled.
+    */
+
+    let doc = r#"<!DOCTYPE root [
+    <!ELEMENT doc ANY>
+    <!ELEMENT element1 EMPTY>
+    <!ATTLIST element1
+	id	ID	#IMPLIED
+	idref	IDREF	#IMPLIED
+	>
+]>
+<doc>
+    <element1 id="a1"/>
+    <element1 id="a1"/>
+</doc>
+"#;
+
+
+    let pc = ParserConfig::new();
+
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(testxml, doc, Some(pc));
+
+    assert!(parseresult.is_err());
+
+    let mut pc2 = ParserConfig::new();
+    pc2.id_tracking = false;
+
+    let testxml2 = RNode::new_document();
+    let parseresult2 = xml::parse(testxml2, doc, Some(pc2));
+
+    assert!(parseresult2.is_ok());
+}
+
+#[test]
+fn parser_config_id_2() {
+
+    /*
+        Conformance tests will determine if the XML IDs are properly tracked by the parser,
+        this tests only that it can be disabled.
+    */
+
+    let doc = r#"<!DOCTYPE root [
+    <!ELEMENT doc ANY>
+    <!ELEMENT element1 EMPTY>
+    <!ATTLIST element1
+	id	ID	#IMPLIED
+	idref	IDREF	#IMPLIED
+	>
+]>
+<doc>
+    <element1 idref="a1"/>
+</doc>
+"#;
+
+
+    let pc = ParserConfig::new();
+
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(testxml, doc, Some(pc));
+
+    assert!(parseresult.is_err());
+
+    let mut pc2 = ParserConfig::new();
+    pc2.id_tracking = false;
+
+    let testxml2 = RNode::new_document();
+    let parseresult2 = xml::parse(testxml2, doc, Some(pc2));
+
+    assert!(parseresult2.is_ok());
+}
+
+#[test]
+fn parser_config_id_3() {
+
+    /*
+        Conformance tests will determine if the XML IDs are properly tracked by the parser,
+        this tests only that it can be disabled.
+
+        When we disable XML ID tracking, the is-id and is-idrefs properties will not populate.
+    */
+
+    let doc = r#"<!DOCTYPE root [
+    <!ELEMENT doc ANY>
+    <!ATTLIST doc
+	id	ID	#IMPLIED
+	idref	IDREF	#IMPLIED
+	>
+]>
+<doc id="a1"/>
+"#;
+
+
+    let pc = ParserConfig::new();
+
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(testxml, doc, Some(pc));
+
+    assert!(parseresult.is_ok());
+    println!("{:?}",parseresult.clone().unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_id());
+    assert_eq!(parseresult.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_id(), true);
+
+    let mut pc2 = ParserConfig::new();
+    pc2.id_tracking = false;
+
+    let testxml2 = RNode::new_document();
+    let parseresult2 = xml::parse(testxml2, doc, Some(pc2));
+
+    assert!(parseresult2.is_ok());
+    println!("{:?}",parseresult2.clone().unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_id());
+    assert_eq!(parseresult2.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_id(), false);
+
+}
+
+#[test]
+fn parser_config_id_4() {
+
+    /*
+        Conformance tests will determine if the XML IDs are properly tracked by the parser,
+        this tests only that it can be disabled.
+
+        When we disable XML ID tracking, the is-id and is-idrefs properties will not populate.
+    */
+
+    let doc = r#"<!DOCTYPE root [
+    <!ELEMENT doc ANY>
+    <!ATTLIST doc
+	idref	IDREF	#IMPLIED
+	>
+	<!ELEMENT element1 EMPTY>
+    <!ATTLIST element1
+	id	ID	#IMPLIED
+	>
+]>
+<doc idref="a1">
+    <element1 id="a1"/>
+</doc>
+"#;
+
+
+    let pc = ParserConfig::new();
+
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(testxml, doc, Some(pc));
+
+    assert!(parseresult.is_ok());
+    assert_eq!(parseresult.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_idrefs(), true);
+
+    let mut pc2 = ParserConfig::new();
+    pc2.id_tracking = false;
+
+    let testxml2 = RNode::new_document();
+    let parseresult2 = xml::parse(testxml2, doc, Some(pc2));
+
+    assert!(parseresult2.is_ok());
+    assert_eq!(parseresult2.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_idrefs(), false);
+
+}

--- a/tests/transformgeneric/mod.rs
+++ b/tests/transformgeneric/mod.rs
@@ -1901,6 +1901,8 @@ where
         .new_attribute(
             Rc::new(QualifiedName::new(None, None, String::from("name"))),
             Rc::new(Value::from("first")),
+            false,
+            false
         )
         .expect("unable to create attribute node");
     l1_1.add_attribute(a1)
@@ -1917,6 +1919,8 @@ where
         .new_attribute(
             Rc::new(QualifiedName::new(None, None, String::from("name"))),
             Rc::new(Value::from("second")),
+            false,
+            false
         )
         .expect("unable to create attribute node");
     l1_2.add_attribute(a2)
@@ -1967,6 +1971,8 @@ where
         .new_attribute(
             Rc::new(QualifiedName::new(None, None, String::from("name"))),
             Rc::new(Value::from("first")),
+            false,
+            false
         )
         .expect("unable to create attribute node");
     l1_1.add_attribute(a1)
@@ -1983,6 +1989,8 @@ where
         .new_attribute(
             Rc::new(QualifiedName::new(None, None, String::from("name"))),
             Rc::new(Value::from("second")),
+            false,
+            false
         )
         .expect("unable to create attribute node");
     l1_2.add_attribute(a2.clone())
@@ -2033,6 +2041,8 @@ where
         .new_attribute(
             Rc::new(QualifiedName::new(None, None, String::from("name"))),
             Rc::new(Value::from("first")),
+            false,
+            false
         )
         .expect("unable to create attribute node");
     l1_1.add_attribute(a1)
@@ -2049,6 +2059,8 @@ where
         .new_attribute(
             Rc::new(QualifiedName::new(None, None, String::from("name"))),
             Rc::new(Value::from("second")),
+            false,
+            false
         )
         .expect("unable to create attribute node");
     l1_2.add_attribute(a2.clone())


### PR DESCRIPTION
Hi Steve,

Started work on support for XML IDs.

- Smite has been slightly tweaked to have the is_id and is_idrefs properties
- The taggedelem and emptyelem have been merged into a single "element" function, as they were mostly the same.
- Attribute creation is now done in the new elem function, as the ATTList DTD declarations have to be checked before creation.
- Have adjusted the parser to check for duplicate XML IDs as well as missing IDs for IDREFs
- The ParserConfig has been updated to enable/disable this feature. It is on by default
- The transformation steps have not yet been updated to handle these new capabilities, just setting is_id and is_idrefs to false when creating attributes. Will need to research some more about what needs to happen here.
- Elements do not yet have IDs, will need to add that at a later stage.
- xml:ID is not part of this pull request, I need to do a bit of reading on those.

