### PR TITLE
First crack at custom xpath functions

### DIFF
--- a/src/parser/xpath/functions.rs
+++ b/src/parser/xpath/functions.rs
@@ -475,10 +475,7 @@ pub(crate) fn function_call<'a, N: Node + 'a>(
                         String::from("wrong number of arguments"),
                     ),
                 },
-                _ => Transform::Error(
-                    ErrorKind::ParseError,
-                    format!("undefined function \"{}\"", qn),
-                ), // TODO: user-defined functions
+                _ => Transform::Extension(localpart.to_string(), a)
             },
             NodeTest::Name(NameTest {
                 name: Some(WildcardOrName::Name(localpart)),

--- a/src/transform/functions.rs
+++ b/src/transform/functions.rs
@@ -256,6 +256,21 @@ pub fn document<
     }
 }
 
+pub fn ext_function<N: Node>(
+    ctxt: &Context<N>,
+    func_name: String,
+    arguments: &Vec<Transform<N>>,
+) -> Result<Sequence<N>, Error> {
+    let func = match ctxt.x_path_ext_functions.get(&func_name) {
+        Some(func) => func,
+        None =>  return Err(Error::new(
+            ErrorKind::Unknown,
+            "function not found".to_string(),
+        )),
+    };
+    func(arguments)
+}
+
 pub(crate) fn tr_error<N: Node>(
     _ctxt: &Context<N>,
     kind: &ErrorKind,

--- a/src/transform/functions.rs
+++ b/src/transform/functions.rs
@@ -264,8 +264,8 @@ pub fn ext_function<N: Node>(
     let func = match ctxt.x_path_ext_functions.get(&func_name) {
         Some(func) => func,
         None =>  return Err(Error::new(
-            ErrorKind::Unknown,
-            "function not found".to_string(),
+            ErrorKind::ParseError,
+            format!("undefined function \"{}\"", &func_name),
         )),
     };
     func(arguments)

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -239,6 +239,10 @@ pub enum Transform<N: Node> {
         Box<Transform<N>>,
         Option<Box<Transform<N>>>,
     ),
+    Extension(
+        String,
+        Vec<Transform<N>>
+    ),
     /// Convert a number to a string.
     /// This is one half of the functionality of xsl:number, as well as format-integer().
     /// See XSLT 12.4.
@@ -386,6 +390,7 @@ impl<N: Node> Debug for Transform<N> {
             Transform::Message(_, _, _, _) => write!(f, "message"),
             Transform::NotImplemented(s) => write!(f, "Not implemented: \"{}\"", s),
             Transform::Error(k, s) => write!(f, "Error: {} \"{}\"", k, s),
+            Transform::Extension(n, p) => write!(f, "Extension: \"{}\"", n),
         }
     }
 }


### PR DESCRIPTION
I am rather new to Rust and the XRust library so i apologize for my blunders in advance haha. This seems to do what my team needs. I tested with the following snippet.

```

    fn make_from_str(s: &str) -> Result<RNode, Error> {
        let doc = Rc::new_document();
        let e = parse(doc.clone(), s, None)?;
        Ok(doc)
    }
    
    // The source document (a tree)
    let src = Item::Node(
        make_from_str("<Example><Title>XSLT in Rust</Title><Paragraph>A simple document.</Paragraph></Example>")
        .expect("unable to parse XML")
    );
    
    // The XSL stylesheet
    let style = make_from_str("<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
      <xsl:template match='child::Example'><html><xsl:value-of select=\"custom()\"/><xsl:apply-templates/></html></xsl:template>
      <xsl:template match='child::Title'><head><title><xsl:apply-templates/></title></head></xsl:template>
      <xsl:template match='child::Paragraph'><body><p><xsl:apply-templates/></p></body></xsl:template>
    </xsl:stylesheet>")
        .expect("unable to parse stylesheet");
    
    // Create a static context (with dummy callbacks)
    let mut static_context = StaticContextBuilder::new()
        .message(|_| Ok(()))
        .fetcher(|_| Err(Error::new(ErrorKind::NotImplemented, "not implemented")))
        .parser(|_| Err(Error::new(ErrorKind::NotImplemented, "not implemented")))
        .build();
    
    // Compile the stylesheet
    let mut ctxt = from_document(
        style,
        None,
        make_from_str,
        |_| Ok(String::new())
    ).expect("failed to compile stylesheet");

    // register custom function
    fn custom<N: Node>(args: &Vec<Transform<N>>) -> Result<Sequence<N>, Error> {
        println!("in custom");
        // random return value used to test
        Ok(vec![Item::Value(Rc::new(Value::Boolean(true)))])
    }
    
    // Set the source document as the context item
    ctxt.context(vec![src], 0);
    ctxt.register_ext_function("custom".to_string(), custom);
    // Make an empty result document
    ctxt.result_document(Rc::new_document());
    
    // Let 'er rip!
    // Evaluate the transformation
    let seq = ctxt.evaluate(&mut static_context)
        .expect("evaluation failed");
    fs::write("test.xml", seq.to_xml()).expect("Unable to write file");
```