### PR TITLE
XML ID support

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -434,6 +434,11 @@ pub trait Node: Clone + PartialEq + fmt::Debug {
         self.node_type() == NodeType::Element
     }
 
+    /// Check if a node is an XML ID
+    fn is_id(&self) -> bool;
+    /// Check if a node is an  XML IDREF or IDREFS
+    fn is_idrefs(&self) -> bool;
+
     /// An iterator over the children of the node
     fn child_iter(&self) -> Self::NodeIterator;
     /// Get the first child of the node, if there is one

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -49,7 +49,7 @@ pub enum ParseError {
     Unbalanced,
     Notimplemented,
     ExtDTDLoadError,
-    IDError(String)
+    IDError(String),
 }
 
 pub struct ParserConfig {
@@ -66,7 +66,7 @@ pub struct ParserConfig {
     /// Set to true by default.
     pub attr_defaults: bool,
     /// Track and assign XML IDs based on the DTDs.
-    pub id_tracking: bool
+    pub id_tracking: bool,
 }
 
 impl Default for ParserConfig {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -150,7 +150,7 @@ pub struct ParserState<N: Node> {
 
 impl<N: Node> ParserState<N> {
     pub fn new(doc: Option<N>, cur: Option<N>, parser_config: Option<ParserConfig>) -> Self {
-        let pc = if let Some(..) = parser_config {
+        let pc = if parser_config.is_some() {
             parser_config.unwrap()
         } else {
             ParserConfig::new()

--- a/src/parser/xml/attribute.rs
+++ b/src/parser/xml/attribute.rs
@@ -15,19 +15,15 @@ use crate::parser::xml::qname::qualname;
 use crate::parser::xml::reference::textreference;
 use crate::parser::{ParseError, ParseInput};
 use crate::qname::QualifiedName;
-use crate::value::Value;
 use crate::{Error, ErrorKind};
 use std::collections::HashSet;
 use std::rc::Rc;
 
 /// Parse all of the attributes in an element's start tag.
 /// Returns (attribute nodes, namespace declaration nodes).
-pub(crate) fn attributes<N: Node>() -> impl Fn(
-    ParseInput<N>,
-) -> Result<
-    (ParseInput<N>, (Vec<(QualifiedName, String)>, Vec<N>)),
-    ParseError,
-> {
+pub(crate) fn attributes<N: Node>(
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (Vec<(QualifiedName, String)>, Vec<N>)), ParseError>
+{
     move |input| match many0(attribute())(input) {
         Ok(((input1, mut state1), nodes)) => {
             let doc = state1.doc.clone().unwrap().clone();
@@ -105,7 +101,10 @@ pub(crate) fn attributes<N: Node>() -> impl Fn(
                 }
 
                 if qn_prefix_str == "xmlns" {
-                    new_namespaces.push(doc.new_namespace(state1.get_value(val), Some(qn.localname())).expect("unable to create namespace node"));
+                    new_namespaces.push(
+                        doc.new_namespace(state1.get_value(val), Some(qn.localname()))
+                            .expect("unable to create namespace node"),
+                    );
                     match new_namespace_prefixes.insert(Some(qn.localname())) {
                         true => {}
                         false => {
@@ -117,7 +116,10 @@ pub(crate) fn attributes<N: Node>() -> impl Fn(
                     //namespaces.insert(Some(qn.get_localname()), val.to_string());
                     //resnsnodes.insert(Some(qn.get_localname()), val.to_string());
                 } else if qn_localname == "xmlns" && !val_str.is_empty() {
-                    new_namespaces.push(doc.new_namespace(state1.get_value(val), None).expect("unable to create default namespace node"));
+                    new_namespaces.push(
+                        doc.new_namespace(state1.get_value(val), None)
+                            .expect("unable to create default namespace node"),
+                    );
                     match new_namespace_prefixes.insert(None) {
                         true => {}
                         false => {
@@ -239,9 +241,7 @@ fn attribute<N: Node>(
         attribute_value(),
     )((input, state))
     {
-        Ok(((input1, state1), (_, n, _, _, _, s))) => {
-            Ok(((input1, state1.clone()), (n, s)))
-        }
+        Ok(((input1, state1), (_, n, _, _, _, s))) => Ok(((input1, state1.clone()), (n, s))),
         Err(e) => Err(e),
     }
 }

--- a/src/parser/xml/attribute.rs
+++ b/src/parser/xml/attribute.rs
@@ -22,19 +22,15 @@ use std::rc::Rc;
 
 /// Parse all of the attributes in an element's start tag.
 /// Returns (attribute nodes, namespace declaration nodes).
-pub(crate) fn attributes<N: Node>(
-) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (Vec<N>, Vec<N>)), ParseError> {
+pub(crate) fn attributes<N: Node>() -> impl Fn(
+    ParseInput<N>,
+) -> Result<
+    (ParseInput<N>, (Vec<(QualifiedName, String)>, Vec<N>)),
+    ParseError,
+> {
     move |input| match many0(attribute())(input) {
         Ok(((input1, mut state1), nodes)) => {
             let doc = state1.doc.clone().unwrap().clone();
-
-            //let n: HashMap<Option<String>, String> = HashMap::new();
-            //let mut namespaces = state1.namespace.last().unwrap_or(&n).clone();
-            //            let mut resnsnodes = if state1.namespace_nodes {
-            //                state1.namespace.last().unwrap_or(&n).clone()
-            //            } else {
-            //                HashMap::new()
-            //            };
 
             // If new namespaces are declared, then construct a new namespace hashmap
             // with the old entries overlaid with the new entries.
@@ -109,10 +105,7 @@ pub(crate) fn attributes<N: Node>(
                 }
 
                 if qn_prefix_str == "xmlns" {
-                    new_namespaces.push(
-                        doc.new_namespace(val.clone(), Some(qn.localname()))
-                            .expect("unable to create namespace node"),
-                    );
+                    new_namespaces.push(doc.new_namespace(state1.get_value(val), Some(qn.localname())).expect("unable to create namespace node"));
                     match new_namespace_prefixes.insert(Some(qn.localname())) {
                         true => {}
                         false => {
@@ -123,12 +116,8 @@ pub(crate) fn attributes<N: Node>(
                     }
                     //namespaces.insert(Some(qn.get_localname()), val.to_string());
                     //resnsnodes.insert(Some(qn.get_localname()), val.to_string());
-                };
-                if qn_localname == "xmlns" && !val_str.is_empty() {
-                    new_namespaces.push(
-                        doc.new_namespace(val.clone(), None)
-                            .expect("unable to create default namespace node"),
-                    );
+                } else if qn_localname == "xmlns" && !val_str.is_empty() {
+                    new_namespaces.push(doc.new_namespace(state1.get_value(val), None).expect("unable to create default namespace node"));
                     match new_namespace_prefixes.insert(None) {
                         true => {}
                         false => {
@@ -217,10 +206,11 @@ pub(crate) fn attributes<N: Node>(
                             }
                         }
                     }
-                    let newatt = doc
-                        .new_attribute(Rc::new(qn.clone()), attrval)
-                        .expect("unable to create attribute");
-                    resnodes.push(newatt);
+                    /*
+                        We don't return fully completed attributes here because we need to do some
+                        DTD checking on the element to manage IDs.
+                    */
+                    resnodes.push((qn.clone(), attrval));
 
                     /* Why not just use resnodes.contains()  ? I don't know how to do partial matching */
                     if resnodenames.contains(&(qn.namespace_uri(), qn.localname())) {
@@ -239,7 +229,7 @@ pub(crate) fn attributes<N: Node>(
 }
 // Attribute ::= Name '=' AttValue
 fn attribute<N: Node>(
-) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (QualifiedName, Rc<Value>)), ParseError> {
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, (QualifiedName, String)), ParseError> {
     move |(input, state)| match tuple6(
         whitespace1(),
         qualname(),
@@ -250,7 +240,7 @@ fn attribute<N: Node>(
     )((input, state))
     {
         Ok(((input1, state1), (_, n, _, _, _, s))) => {
-            Ok(((input1, state1.clone()), (n, state1.get_value(s))))
+            Ok(((input1, state1.clone()), (n, s)))
         }
         Err(e) => Err(e),
     }

--- a/src/parser/xml/dtd/attlistdecl.rs
+++ b/src/parser/xml/dtd/attlistdecl.rs
@@ -184,8 +184,11 @@ pub(crate) fn attlistdecl<N: Node>(
                 }
                 //xml:id datatype checking
                 if &qn == &QualifiedName::new(None, Some("xml".to_string()), "id".to_string())
-                    && att != AttType::ID {
-                    return Err(ParseError::IDError("xml:id declaration in the DTD does not have type ID".to_string()))
+                    && att != AttType::ID
+                {
+                    return Err(ParseError::IDError(
+                        "xml:id declaration in the DTD does not have type ID".to_string(),
+                    ));
                 }
                 atts.insert(qn, (att, dfd, replaceable));
             }

--- a/src/parser/xml/dtd/attlistdecl.rs
+++ b/src/parser/xml/dtd/attlistdecl.rs
@@ -182,6 +182,11 @@ pub(crate) fn attlistdecl<N: Node>(
                     //else do nothing
                     _ => {}
                 }
+                //xml:id datatype checking
+                if &qn == &QualifiedName::new(None, Some("xml".to_string()), "id".to_string())
+                    && att != AttType::ID {
+                    return Err(ParseError::IDError("xml:id declaration in the DTD does not have type ID".to_string()))
+                }
                 atts.insert(qn, (att, dfd, replaceable));
             }
             if count_id_attrs > 1 {

--- a/src/parser/xml/dtd/attlistdecl.rs
+++ b/src/parser/xml/dtd/attlistdecl.rs
@@ -102,7 +102,7 @@ pub(crate) fn attlistdecl<N: Node>(
                                 }
                             }
                             AttType::IDREFS => {
-                                let names = s.split(" ");
+                                let names = s.split(' ');
                                 for name in names {
                                     let mut ch = name.chars();
                                     match ch.next() {
@@ -151,7 +151,7 @@ pub(crate) fn attlistdecl<N: Node>(
                                 }
                             }
                             AttType::ENTITIES => {
-                                let entities = s.split(" ");
+                                let entities = s.split(' ');
                                 for entity in entities {
                                     let mut ch = entity.chars();
                                     match ch.next() {
@@ -183,7 +183,7 @@ pub(crate) fn attlistdecl<N: Node>(
                     _ => {}
                 }
                 //xml:id datatype checking
-                if &qn == &QualifiedName::new(None, Some("xml".to_string()), "id".to_string())
+                if qn == QualifiedName::new(None, Some("xml".to_string()), "id".to_string())
                     && att != AttType::ID
                 {
                     return Err(ParseError::IDError(
@@ -256,7 +256,7 @@ fn attdef<N: Node>(
         ),
         |(_, an, _, at, _, dd)| {
             let qn = if an.contains(':') {
-                let mut attnamesplit = an.split(":");
+                let mut attnamesplit = an.split(':');
                 let prefix = Some(attnamesplit.next().unwrap().to_string());
                 let local = attnamesplit.collect::<String>();
                 QualifiedName::new(None, prefix, local)

--- a/src/parser/xml/dtd/notation.rs
+++ b/src/parser/xml/dtd/notation.rs
@@ -119,7 +119,6 @@ pub(crate) fn ndatadecl<N: Node>(
     map(
         tuple4(whitespace1(), tag("NDATA"), whitespace1(), name()),
         |(_, _, _, notation)| {
-            println!("notation");
             notation
         },
     )

--- a/src/parser/xml/dtd/notation.rs
+++ b/src/parser/xml/dtd/notation.rs
@@ -118,8 +118,6 @@ pub(crate) fn ndatadecl<N: Node>(
 ) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
     map(
         tuple4(whitespace1(), tag("NDATA"), whitespace1(), name()),
-        |(_, _, _, notation)| {
-            notation
-        },
+        |(_, _, _, notation)| notation,
     )
 }

--- a/src/parser/xml/element.rs
+++ b/src/parser/xml/element.rs
@@ -192,7 +192,7 @@ pub(crate) fn element<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput
                                     (AttType::ID, true) => Rc::new(Value::ID(av)),
                                     (AttType::IDREF, true) => Rc::new(Value::IDREF(av)),
                                     (AttType::IDREFS, true) => Rc::new(Value::IDREFS(
-                                        av.split(" ").map(|s| s.to_string()).collect(),
+                                        av.split(' ').map(|s| s.to_string()).collect(),
                                     )),
                                     (_, _) => state1.get_value(av),
                                 };

--- a/src/parser/xml/element.rs
+++ b/src/parser/xml/element.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+use crate::{Error, ErrorKind, Value};
 use crate::item::{Node, NodeType};
 use crate::parser::combinators::alt::{alt2, alt4};
 use crate::parser::combinators::many::many0nsreset;
@@ -14,21 +16,14 @@ use crate::parser::xml::qname::qualname;
 use crate::parser::xml::reference::reference;
 use crate::parser::{ParseError, ParseInput};
 use crate::qname::QualifiedName;
-use crate::value::Value;
-use crate::xdmerror::{Error, ErrorKind};
-use crate::xmldecl::DefaultDecl;
-use std::rc::Rc;
+use crate::xmldecl::{AttType, DefaultDecl};
 
 // Element ::= EmptyElemTag | STag content ETag
 pub(crate) fn element<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), ParseError>
 {
-    move |input| alt2(emptyelem(), taggedelem())(input)
-}
-
-// EmptyElemTag ::= '<' Name (Attribute)* '/>'
-fn emptyelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), ParseError> {
-    move |input| {
-        match tuple5(
+    move |input| match alt2(
+        //Empty element
+        map(tuple5(
             tag("<"),
             wellformed(qualname(), |qn| {
                 qn.prefix_to_string() != Some("xmlns".to_string())
@@ -36,106 +31,11 @@ fn emptyelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), 
             attributes(), //many0(attribute),
             whitespace0(),
             tag("/>"),
-        )(input)
-        {
-            Ok(((input1, state1), (_, mut n, (av, namespaces), _, _))) => {
-                if n.resolve(|p| {
-                    state1.namespace.get(&p).map_or(
-                        Err(Error::new(
-                            ErrorKind::DynamicAbsent,
-                            "no namespace for prefix",
-                        )),
-                        |r| Ok(r.clone()),
-                    )
-                })
-                .is_err()
-                {
-                    return Err(ParseError::MissingNameSpace);
-                }
-                let elementname =
-                    state1.get_qualified_name(n.namespace_uri(), n.prefix(), n.localname());
-                if state1.xmlversion == "1.1"
-                    && elementname.namespace_uri_to_string() == Some("".to_string())
-                    && elementname.prefix_to_string().is_some()
-                {
-                    return Err(ParseError::MissingNameSpace);
-                }
-                let d = state1.doc.clone().unwrap();
-                let e = d
-                    .new_element(elementname)
-                    .expect("unable to create element");
-
-                //Looking up the DTD, seeing if there are any attributes we should populate
-                //Remember, DTDs don't have namespaces, you need to lookup based on prefix and local name!
-                if state1.attr_defaults {
-                    match state1.dtd.attlists.get(&QualifiedName::new_from_values(
-                        None,
-                        n.prefix(),
-                        n.localname(),
-                    )) {
-                        None => {}
-                        Some(atts) => {
-                            for (attname, (_, defdecl, _)) in atts.iter() {
-                                match defdecl {
-                                    DefaultDecl::Default(s) | DefaultDecl::FIXED(s) => {
-                                        let mut at = attname.clone();
-                                        match at.prefix() {
-                                            None => {}
-                                            Some(_) => {
-                                                if at
-                                                    .resolve(|p| {
-                                                        state1.namespace.get(&p).map_or(
-                                                            Err(Error::new(
-                                                                ErrorKind::DynamicAbsent,
-                                                                "no namespace for prefix",
-                                                            )),
-                                                            |r| Ok(r.clone()),
-                                                        )
-                                                    })
-                                                    .is_err()
-                                                {
-                                                    return Err(ParseError::MissingNameSpace);
-                                                }
-                                            }
-                                        }
-                                        let newattr = d
-                                            .new_attribute(
-                                                Rc::new(at),
-                                                Rc::new(Value::String(s.clone())),
-                                            )
-                                            .expect("unable to create attlist attribute");
-                                        e.add_attribute(newattr)
-                                            .expect("unable to add attlist attribute");
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
-                    }
-                }
-
-                //This will overwrite any attributes added above
-                //TODO merge into a single set of attributes before creating.
-                av.iter()
-                    .for_each(|b| e.add_attribute(b.clone()).expect("unable to add attribute"));
-                namespaces.iter().for_each(|nn| {
-                    e.add_namespace(nn.clone())
-                        .expect("unable to add namespace node")
-                });
-
-                Ok(((input1, state1.clone()), e))
-            }
-            Err(err) => Err(err),
-        }
-    }
-}
-
-// STag ::= '<' Name (Attribute)* '>'
-// ETag ::= '</' Name '>'
-// TODO: Check that names match and throw meaningful error
-fn taggedelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), ParseError> {
-    move |input| {
-        match wellformed(
+        ),|(_, n, (at, ns), _, _)|{
+            ((), n.clone(), (at, ns), (), (), vec![], (), n, (), ())
+        }),
+        //tagged element
+        wellformed(
             tuple10(
                 tag("<"),
                 wellformed(qualname(), |qn| {
@@ -153,99 +53,173 @@ fn taggedelem<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N),
                 tag(">"),
             ),
             |(_, n, _a, _, _, _c, _, e, _, _)| n.to_string() == e.to_string(),
-        )(input)
-        {
-            Ok(((input1, state1), (_, mut n, (av, namespaces), _, _, c, _, _, _, _))) => {
-                if n.resolve(|p| {
-                    state1.namespace.get(&p).map_or(
-                        Err(Error::new(
-                            ErrorKind::DynamicAbsent,
-                            "no namespace for prefix",
-                        )),
-                        |r| Ok(r.clone()),
-                    )
-                })
-                .is_err()
-                {
-                    return Err(ParseError::MissingNameSpace);
-                }
-                let d = state1.doc.clone().unwrap();
+        ))(input){
+        Err(err) => Err(err),
+        Ok(((input1, mut state1), (_, mut n, (av, namespaces), _, _, c, _, _, _, _))) => {
+            if n.resolve(|p| state1.namespace.get(&p).map_or(
+                Err(Error::new(ErrorKind::DynamicAbsent, "no namespace for prefix")),
+                |r| Ok(r.clone())
+            )).is_err() {
+                return Err(ParseError::MissingNameSpace);
+            }
+            let elementname = state1.get_qualified_name(n.namespace_uri(), n.prefix(), n.localname());
+            if state1.xmlversion=="1.1"
+                && elementname.namespace_uri_to_string() == Some("".to_string())
+                && elementname.prefix_to_string().is_some(){
+                return Err(ParseError::MissingNameSpace);
+            }
+            let d = state1.doc.clone().unwrap();
+            let mut e = d
+                .new_element(elementname)
+                .expect("unable to create element");
 
-                let elementname =
-                    state1.get_qualified_name(n.namespace_uri(), n.prefix(), n.localname());
-                if state1.xmlversion == "1.1"
-                    && elementname.namespace_uri_to_string() == Some("".to_string())
-                    && elementname.prefix_to_string().is_some()
-                {
-                    return Err(ParseError::MissingNameSpace);
-                }
-                let mut e = d
-                    .new_element(elementname)
-                    .expect("unable to create element");
+            //Looking up the DTD, seeing if there are any attributes we should populate
+            //Remember, DTDs don't have namespaces, you need to lookup based on prefix and local name!
+            // We generate the attributes in two sweeps:
+            // Once for attributes declared on the element and once for the DTD default attribute values.
 
-                //Looking up the DTD, seeing if there are any attributes we should populate
-                //Remember, DTDs don't have namespaces, you need to lookup based on prefix and local name!
-                if state1.attr_defaults {
-                    match state1.dtd.attlists.get(&QualifiedName::new_from_values(
-                        None,
-                        n.prefix(),
-                        n.localname(),
-                    )) {
-                        None => {}
-                        Some(atts) => {
-                            for (attname, (_, defdecl, _)) in atts.iter() {
-                                match defdecl {
-                                    DefaultDecl::Default(s) | DefaultDecl::FIXED(s) => {
-                                        let mut at = attname.clone();
-                                        match at.prefix() {
-                                            None => {}
-                                            Some(_) => {
-                                                if at
-                                                    .resolve(|p| {
-                                                        state1.namespace.get(&p).map_or(
-                                                            Err(Error::new(
-                                                                ErrorKind::DynamicAbsent,
-                                                                "no namespace for prefix",
-                                                            )),
-                                                            |r| Ok(r.clone()),
-                                                        )
-                                                    })
-                                                    .is_err()
-                                                {
-                                                    return Err(ParseError::MissingNameSpace);
-                                                }
+            let attlist = state1.dtd.attlists.get(&QualifiedName::new_from_values(None, n.prefix(), n.localname()));
+
+            match attlist {
+                None => {
+                    //No Attribute DTD, just insert all attributes.
+                    for (attname, attval) in av.into_iter(){
+                                //Ordinarily, you'll just treat attributes as CDATA and not normalize, however we need to check xml:id
+                                let av: String;
+                                let a: N;
+                                if attname.prefix_to_string() == Some("xml".to_string())  && attname.localname_to_string() == "id" {
+                                    av = attval.trim().replace("  ", " ");
+                                    a = d.new_attribute(
+                                        Rc::new(attname),
+                                        Rc::new(Value::ID(av))
+                                    ).expect("unable to create attribute");
+                                } else {
+                                    av = attval;
+                                    a = d.new_attribute(
+                                        Rc::new(attname),
+                                        state1.get_value(av),
+                                    ).expect("unable to create attribute");
+                                };
+
+
+                                e.add_attribute(a).expect("unable to add attribute")
+                    }
+                }
+                Some(atts) => {
+                    if state1.attr_defaults {
+                        for (attname, (atttype, defdecl, _)) in atts.iter(){
+
+                            match defdecl {
+                                DefaultDecl::Default(s) | DefaultDecl::FIXED(s) => {
+                                    let mut at = attname.clone();
+                                    match at.prefix() {
+                                        None => {}
+                                        Some(_) => {
+                                            if at.resolve(|p| state1.namespace.get(&p).map_or(
+                                                Err(Error::new(ErrorKind::DynamicAbsent, "no namespace for prefix")),
+                                                |r| Ok(r.clone())
+                                            )).is_err() {
+                                                return Err(ParseError::MissingNameSpace);
                                             }
                                         }
-                                        let newattr = d
-                                            .new_attribute(
-                                                Rc::new(at),
-                                                Rc::new(Value::String(s.clone())),
-                                            )
-                                            .expect("unable to create attlist attribute");
-                                        e.add_attribute(newattr)
-                                            .expect("unable to add attlist attribute");
                                     }
-                                    _ => {}
+                                    //https://www.w3.org/TR/xml11/#AVNormalize
+                                    let attval = match atttype {
+                                        AttType::CDATA => { s.clone() }
+                                        _ => {
+                                            s.trim().replace("  ", " ")
+                                        }
+                                    };
+                                    let a = d.new_attribute(
+                                        Rc::new(at),
+                                        state1.get_value(attval),
+                                    ).expect("unable to create attribute");
+                                    e.add_attribute(a).expect("unable to add attribute")
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+
+                    for (attname, attval) in av.into_iter() {
+                        match atts.get(&QualifiedName::new(None, attname.prefix_to_string(), attname.localname_to_string())) {
+                            //No DTD found, we just create the value
+                            None => {
+                                //Ordinarily, you'll just treat attributes as CDATA and not normalize, however we need to check xml:id
+                                let av = if attname.prefix_to_string() == Some("xml".to_string())  && attname.localname_to_string() == "id" {
+                                    attval.trim().replace("  ", " ")
+                                } else {
+                                    attval
+                                };
+                                let a = d.new_attribute(
+                                    Rc::new(attname),
+                                    state1.get_value(av),
+                                ).expect("unable to create attribute");
+                                e.add_attribute(a).expect("unable to add attribute")
+                            }
+                            Some((atttype, _, _)) => {
+                                //https://www.w3.org/TR/xml11/#AVNormalize
+                                let av = match atttype {
+                                    AttType::CDATA => { attval }
+                                    _ => {
+                                        attval.trim().replace("  ", " ")
+                                    }
+                                };
+                                //Assign IDs only if we are tracking.
+                                let v = match (atttype, state1.id_tracking) {
+                                    (AttType::ID, true) => Rc::new(Value::ID(av)),
+                                    (AttType::IDREF, true) => Rc::new(Value::IDREF(av)),
+                                    (AttType::IDREFS, true) => Rc::new(Value::IDREFS(av.split(" ").map(|s| s.to_string()).collect())),
+                                    (_, _) => state1.get_value(av),
+                                };
+                                let a = d.new_attribute(
+                                    Rc::new(attname),
+                                    v
+                                ).expect("unable to create attribute");
+                                e.add_attribute(a).expect("unable to add attribute")
+                            }
+                        }
+                    }
+                }
+            }
+
+            //we've added the IDs and IDRefs, but we need to track all that.
+            if state1.id_tracking {
+                for attribute in e.attribute_iter() {
+                    if attribute.is_id(){
+                        match state1.ids_read.insert(attribute.to_string()){
+                            true => {}
+                            false => {
+                                //Value already existed!
+                                return Err(ParseError::IDError(String::from("Diplicate ID found")))
+                            }
+                        }
+                    }
+                    if attribute.is_idrefs(){
+                        /*
+                        If the IDRef matches a previously loaded ID, we're all good. If not, that ID
+                        may exist further along, we'll make a note of it to check when we
+                        have completely parsed the document.
+                        */
+                        for idref in attribute.value().to_string().split_whitespace(){
+                            match state1.ids_read.get(idref){
+                                Some(_) => {}
+                                None => {
+                                    state1.ids_pending.insert(idref.to_string());
                                 }
                             }
                         }
                     }
                 }
-
-                //This will overwrite any attributes added above
-                //TODO merge into a single set of attributes before creating.
-                av.iter()
-                    .for_each(|b| e.add_attribute(b.clone()).expect("unable to add attribute"));
-                namespaces
-                    .iter()
-                    .for_each(|b| e.add_namespace(b.clone()).expect("unable to add namespace"));
-                // Add child nodes
-                c.iter().for_each(|d| {
-                    e.push(d.clone()).expect("unable to add node");
-                });
-                Ok(((input1, state1.clone()), e))
             }
-            Err(err) => Err(err),
+
+            namespaces.iter()
+                .for_each(|b| e.add_namespace(b.clone()).expect("unable to add namespace"));
+            // Add child nodes
+            c.iter().for_each(|d| {
+                e.push(d.clone()).expect("unable to add node");
+            });
+            Ok(((input1, state1.clone()), e))
         }
     }
 }

--- a/src/parser/xml/element.rs
+++ b/src/parser/xml/element.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-use crate::{Error, ErrorKind, Value};
 use crate::item::{Node, NodeType};
 use crate::parser::combinators::alt::{alt2, alt4};
 use crate::parser::combinators::many::many0nsreset;
@@ -17,23 +15,26 @@ use crate::parser::xml::reference::reference;
 use crate::parser::{ParseError, ParseInput};
 use crate::qname::QualifiedName;
 use crate::xmldecl::{AttType, DefaultDecl};
+use crate::{Error, ErrorKind, Value};
+use std::rc::Rc;
 
 // Element ::= EmptyElemTag | STag content ETag
 pub(crate) fn element<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, N), ParseError>
 {
     move |input| match alt2(
         //Empty element
-        map(tuple5(
-            tag("<"),
-            wellformed(qualname(), |qn| {
-                qn.prefix_to_string() != Some("xmlns".to_string())
-            }),
-            attributes(), //many0(attribute),
-            whitespace0(),
-            tag("/>"),
-        ),|(_, n, (at, ns), _, _)|{
-            ((), n.clone(), (at, ns), (), (), vec![], (), n, (), ())
-        }),
+        map(
+            tuple5(
+                tag("<"),
+                wellformed(qualname(), |qn| {
+                    qn.prefix_to_string() != Some("xmlns".to_string())
+                }),
+                attributes(), //many0(attribute),
+                whitespace0(),
+                tag("/>"),
+            ),
+            |(_, n, (at, ns), _, _)| ((), n.clone(), (at, ns), (), (), vec![], (), n, (), ()),
+        ),
         //tagged element
         wellformed(
             tuple10(
@@ -53,19 +54,30 @@ pub(crate) fn element<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput
                 tag(">"),
             ),
             |(_, n, _a, _, _, _c, _, e, _, _)| n.to_string() == e.to_string(),
-        ))(input){
+        ),
+    )(input)
+    {
         Err(err) => Err(err),
         Ok(((input1, mut state1), (_, mut n, (av, namespaces), _, _, c, _, _, _, _))) => {
-            if n.resolve(|p| state1.namespace.get(&p).map_or(
-                Err(Error::new(ErrorKind::DynamicAbsent, "no namespace for prefix")),
-                |r| Ok(r.clone())
-            )).is_err() {
+            if n.resolve(|p| {
+                state1.namespace.get(&p).map_or(
+                    Err(Error::new(
+                        ErrorKind::DynamicAbsent,
+                        "no namespace for prefix",
+                    )),
+                    |r| Ok(r.clone()),
+                )
+            })
+            .is_err()
+            {
                 return Err(ParseError::MissingNameSpace);
             }
-            let elementname = state1.get_qualified_name(n.namespace_uri(), n.prefix(), n.localname());
-            if state1.xmlversion=="1.1"
+            let elementname =
+                state1.get_qualified_name(n.namespace_uri(), n.prefix(), n.localname());
+            if state1.xmlversion == "1.1"
                 && elementname.namespace_uri_to_string() == Some("".to_string())
-                && elementname.prefix_to_string().is_some(){
+                && elementname.prefix_to_string().is_some()
+            {
                 return Err(ParseError::MissingNameSpace);
             }
             let d = state1.doc.clone().unwrap();
@@ -78,62 +90,69 @@ pub(crate) fn element<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput
             // We generate the attributes in two sweeps:
             // Once for attributes declared on the element and once for the DTD default attribute values.
 
-            let attlist = state1.dtd.attlists.get(&QualifiedName::new_from_values(None, n.prefix(), n.localname()));
+            let attlist = state1.dtd.attlists.get(&QualifiedName::new_from_values(
+                None,
+                n.prefix(),
+                n.localname(),
+            ));
 
             match attlist {
                 None => {
                     //No Attribute DTD, just insert all attributes.
-                    for (attname, attval) in av.into_iter(){
-                                //Ordinarily, you'll just treat attributes as CDATA and not normalize, however we need to check xml:id
-                                let av: String;
-                                let a: N;
-                                if attname.prefix_to_string() == Some("xml".to_string())  && attname.localname_to_string() == "id" {
-                                    av = attval.trim().replace("  ", " ");
-                                    a = d.new_attribute(
-                                        Rc::new(attname),
-                                        Rc::new(Value::ID(av))
-                                    ).expect("unable to create attribute");
-                                } else {
-                                    av = attval;
-                                    a = d.new_attribute(
-                                        Rc::new(attname),
-                                        state1.get_value(av),
-                                    ).expect("unable to create attribute");
-                                };
+                    for (attname, attval) in av.into_iter() {
+                        //Ordinarily, you'll just treat attributes as CDATA and not normalize, however we need to check xml:id
+                        let av: String;
+                        let a: N;
+                        if attname.prefix_to_string() == Some("xml".to_string())
+                            && attname.localname_to_string() == "id"
+                        {
+                            av = attval.trim().replace("  ", " ");
+                            a = d
+                                .new_attribute(Rc::new(attname), Rc::new(Value::ID(av)))
+                                .expect("unable to create attribute");
+                        } else {
+                            av = attval;
+                            a = d
+                                .new_attribute(Rc::new(attname), state1.get_value(av))
+                                .expect("unable to create attribute");
+                        };
 
-
-                                e.add_attribute(a).expect("unable to add attribute")
+                        e.add_attribute(a).expect("unable to add attribute")
                     }
                 }
                 Some(atts) => {
                     if state1.attr_defaults {
-                        for (attname, (atttype, defdecl, _)) in atts.iter(){
-
+                        for (attname, (atttype, defdecl, _)) in atts.iter() {
                             match defdecl {
                                 DefaultDecl::Default(s) | DefaultDecl::FIXED(s) => {
                                     let mut at = attname.clone();
                                     match at.prefix() {
                                         None => {}
                                         Some(_) => {
-                                            if at.resolve(|p| state1.namespace.get(&p).map_or(
-                                                Err(Error::new(ErrorKind::DynamicAbsent, "no namespace for prefix")),
-                                                |r| Ok(r.clone())
-                                            )).is_err() {
+                                            if at
+                                                .resolve(|p| {
+                                                    state1.namespace.get(&p).map_or(
+                                                        Err(Error::new(
+                                                            ErrorKind::DynamicAbsent,
+                                                            "no namespace for prefix",
+                                                        )),
+                                                        |r| Ok(r.clone()),
+                                                    )
+                                                })
+                                                .is_err()
+                                            {
                                                 return Err(ParseError::MissingNameSpace);
                                             }
                                         }
                                     }
                                     //https://www.w3.org/TR/xml11/#AVNormalize
                                     let attval = match atttype {
-                                        AttType::CDATA => { s.clone() }
-                                        _ => {
-                                            s.trim().replace("  ", " ")
-                                        }
+                                        AttType::CDATA => s.clone(),
+                                        _ => s.trim().replace("  ", " "),
                                     };
-                                    let a = d.new_attribute(
-                                        Rc::new(at),
-                                        state1.get_value(attval),
-                                    ).expect("unable to create attribute");
+                                    let a = d
+                                        .new_attribute(Rc::new(at), state1.get_value(attval))
+                                        .expect("unable to create attribute");
                                     e.add_attribute(a).expect("unable to add attribute")
                                 }
                                 _ => {}
@@ -142,40 +161,44 @@ pub(crate) fn element<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput
                     }
 
                     for (attname, attval) in av.into_iter() {
-                        match atts.get(&QualifiedName::new(None, attname.prefix_to_string(), attname.localname_to_string())) {
+                        match atts.get(&QualifiedName::new(
+                            None,
+                            attname.prefix_to_string(),
+                            attname.localname_to_string(),
+                        )) {
                             //No DTD found, we just create the value
                             None => {
                                 //Ordinarily, you'll just treat attributes as CDATA and not normalize, however we need to check xml:id
-                                let av = if attname.prefix_to_string() == Some("xml".to_string())  && attname.localname_to_string() == "id" {
+                                let av = if attname.prefix_to_string() == Some("xml".to_string())
+                                    && attname.localname_to_string() == "id"
+                                {
                                     attval.trim().replace("  ", " ")
                                 } else {
                                     attval
                                 };
-                                let a = d.new_attribute(
-                                    Rc::new(attname),
-                                    state1.get_value(av),
-                                ).expect("unable to create attribute");
+                                let a = d
+                                    .new_attribute(Rc::new(attname), state1.get_value(av))
+                                    .expect("unable to create attribute");
                                 e.add_attribute(a).expect("unable to add attribute")
                             }
                             Some((atttype, _, _)) => {
                                 //https://www.w3.org/TR/xml11/#AVNormalize
                                 let av = match atttype {
-                                    AttType::CDATA => { attval }
-                                    _ => {
-                                        attval.trim().replace("  ", " ")
-                                    }
+                                    AttType::CDATA => attval,
+                                    _ => attval.trim().replace("  ", " "),
                                 };
                                 //Assign IDs only if we are tracking.
                                 let v = match (atttype, state1.id_tracking) {
                                     (AttType::ID, true) => Rc::new(Value::ID(av)),
                                     (AttType::IDREF, true) => Rc::new(Value::IDREF(av)),
-                                    (AttType::IDREFS, true) => Rc::new(Value::IDREFS(av.split(" ").map(|s| s.to_string()).collect())),
+                                    (AttType::IDREFS, true) => Rc::new(Value::IDREFS(
+                                        av.split(" ").map(|s| s.to_string()).collect(),
+                                    )),
                                     (_, _) => state1.get_value(av),
                                 };
-                                let a = d.new_attribute(
-                                    Rc::new(attname),
-                                    v
-                                ).expect("unable to create attribute");
+                                let a = d
+                                    .new_attribute(Rc::new(attname), v)
+                                    .expect("unable to create attribute");
                                 e.add_attribute(a).expect("unable to add attribute")
                             }
                         }
@@ -186,23 +209,23 @@ pub(crate) fn element<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput
             //we've added the IDs and IDRefs, but we need to track all that.
             if state1.id_tracking {
                 for attribute in e.attribute_iter() {
-                    if attribute.is_id(){
-                        match state1.ids_read.insert(attribute.to_string()){
+                    if attribute.is_id() {
+                        match state1.ids_read.insert(attribute.to_string()) {
                             true => {}
                             false => {
                                 //Value already existed!
-                                return Err(ParseError::IDError(String::from("Diplicate ID found")))
+                                return Err(ParseError::IDError(String::from("Diplicate ID found")));
                             }
                         }
                     }
-                    if attribute.is_idrefs(){
+                    if attribute.is_idrefs() {
                         /*
                         If the IDRef matches a previously loaded ID, we're all good. If not, that ID
                         may exist further along, we'll make a note of it to check when we
                         have completely parsed the document.
                         */
-                        for idref in attribute.value().to_string().split_whitespace(){
-                            match state1.ids_read.get(idref){
+                        for idref in attribute.value().to_string().split_whitespace() {
+                            match state1.ids_read.get(idref) {
                                 Some(_) => {}
                                 None => {
                                     state1.ids_pending.insert(idref.to_string());
@@ -213,7 +236,8 @@ pub(crate) fn element<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput
                 }
             }
 
-            namespaces.iter()
+            namespaces
+                .iter()
                 .for_each(|b| e.add_namespace(b.clone()).expect("unable to add namespace"));
             // Add child nodes
             c.iter().for_each(|d| {

--- a/src/parser/xml/mod.rs
+++ b/src/parser/xml/mod.rs
@@ -97,17 +97,14 @@ fn document<N: Node>(input: ParseInput<N>) -> Result<(ParseInput<N>, N), ParseEr
         Ok(((input1, state1), (_, p, e, m))) => {
             //Check nothing remaining in iterator, nothing after the end of the root node.
             if input1.is_empty() {
-
                 /*
-                    We were checking XML IDRefs as we parsed, but sometimes an ID comes after the IDREF,
-                    we now check those cases to ensure that all IDs needed were reported.
-                 */
+                   We were checking XML IDRefs as we parsed, but sometimes an ID comes after the IDREF,
+                   we now check those cases to ensure that all IDs needed were reported.
+                */
                 if state1.id_tracking {
                     for idref in state1.ids_pending.iter() {
-                        match state1.ids_read.get(idref){
-                            None => {
-                                return Err(ParseError::IDError(String::from("ID missing")))
-                            }
+                        match state1.ids_read.get(idref) {
+                            None => return Err(ParseError::IDError(String::from("ID missing"))),
                             Some(_) => {}
                         }
                     }

--- a/src/parser/xml/mod.rs
+++ b/src/parser/xml/mod.rs
@@ -97,6 +97,22 @@ fn document<N: Node>(input: ParseInput<N>) -> Result<(ParseInput<N>, N), ParseEr
         Ok(((input1, state1), (_, p, e, m))) => {
             //Check nothing remaining in iterator, nothing after the end of the root node.
             if input1.is_empty() {
+
+                /*
+                    We were checking XML IDRefs as we parsed, but sometimes an ID comes after the IDREF,
+                    we now check those cases to ensure that all IDs needed were reported.
+                 */
+                if state1.id_tracking {
+                    for idref in state1.ids_pending.iter() {
+                        match state1.ids_read.get(idref){
+                            None => {
+                                return Err(ParseError::IDError(String::from("ID missing")))
+                            }
+                            Some(_) => {}
+                        }
+                    }
+                }
+
                 let pr = p.unwrap_or((None, vec![]));
 
                 pr.1.iter().for_each(|n| {

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -110,10 +110,7 @@ pub enum Pattern<N: Node> {
 impl<N: Node> Pattern<N> {
     /// Returns whether the Pattern is of type error.
     pub fn is_err(&self) -> bool {
-        match self {
-            Pattern::Error(_) => true,
-            _ => false,
-        }
+        matches!(self, Pattern::Error(_))
     }
     pub fn get_err(&self) -> Option<Error> {
         if let Pattern::Error(e) = self {
@@ -526,8 +523,7 @@ fn relativepath_expr_pattern<'a, N: Node + 'a>(
             if b.is_empty() {
                 // this is the terminal step
                 a
-            } else {
-                if let Pattern::Selection(mut ap) = a {
+            } else if let Pattern::Selection(mut ap) = a {
                     // TODO: handle "//" separator
                     for (_c, d) in b {
                         match d {
@@ -541,7 +537,7 @@ fn relativepath_expr_pattern<'a, N: Node + 'a>(
                 } else {
                     panic!("pattern must be a selection")
                 }
-            }
+
         },
     ))
 }

--- a/src/trees/nullo.rs
+++ b/src/trees/nullo.rs
@@ -184,6 +184,14 @@ impl Node for Nullo {
             String::from("not implemented"),
         ))
     }
+
+    fn is_id(&self) -> bool {
+        false
+    }
+
+    fn is_idrefs(&self) -> bool {
+        false
+    }
 }
 
 pub struct NulloIter();

--- a/src/trees/smite.rs
+++ b/src/trees/smite.rs
@@ -366,6 +366,7 @@ impl ItemNode for RNode {
         Ok(child)
     }
     fn new_attribute(&self, qn: Rc<QualifiedName>, v: Rc<Value>) -> Result<Self, Error> {
+        //TODO if the attribute is xml:id then type needs to be set as ID, regardless of DTD.
         let att = Rc::new(Node(NodeInner::Attribute(
             RefCell::new(Rc::downgrade(self)),
             qn.clone(),
@@ -803,6 +804,33 @@ impl ItemNode for RNode {
                 .clone()
                 .map_or_else(|| XMLDeclBuilder::new().build(), |x| x.clone()),
             _ => self.owner_document().xmldecl(),
+        }
+    }
+
+    fn is_id(&self) -> bool {
+        match &self.0 {
+            //TODO Add Element XML ID support
+            NodeInner::Attribute(_, _, v) => {
+                match v.as_ref() {
+                    Value::ID(_) => true,
+                    _ => false
+                }
+            }
+            _ => false
+        }
+    }
+
+    fn is_idrefs(&self) -> bool {
+        match &self.0 {
+            //TODO Add Element XML ID REF support
+            NodeInner::Attribute(_, _, v) => {
+                match v.as_ref() {
+                    Value::IDREF(_) => true,
+                    Value::IDREFS(_) => true,
+                    _ => false
+                }
+            }
+            _ => false
         }
     }
 }

--- a/src/trees/smite.rs
+++ b/src/trees/smite.rs
@@ -810,27 +810,23 @@ impl ItemNode for RNode {
     fn is_id(&self) -> bool {
         match &self.0 {
             //TODO Add Element XML ID support
-            NodeInner::Attribute(_, _, v) => {
-                match v.as_ref() {
-                    Value::ID(_) => true,
-                    _ => false
-                }
-            }
-            _ => false
+            NodeInner::Attribute(_, _, v) => match v.as_ref() {
+                Value::ID(_) => true,
+                _ => false,
+            },
+            _ => false,
         }
     }
 
     fn is_idrefs(&self) -> bool {
         match &self.0 {
             //TODO Add Element XML ID REF support
-            NodeInner::Attribute(_, _, v) => {
-                match v.as_ref() {
-                    Value::IDREF(_) => true,
-                    Value::IDREFS(_) => true,
-                    _ => false
-                }
-            }
-            _ => false
+            NodeInner::Attribute(_, _, v) => match v.as_ref() {
+                Value::IDREF(_) => true,
+                Value::IDREFS(_) => true,
+                _ => false,
+            },
+            _ => false,
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -447,7 +447,7 @@ impl Ord for Value {
                 _ => Ordering::Equal, // type error?
             },
             Value::Double(d) => match other {
-                Value::Double(e) => d.partial_cmp(e).unwrap_or_else(|| Ordering::Equal),
+                Value::Double(e) => d.partial_cmp(e).unwrap_or(Ordering::Equal),
                 _ => Ordering::Equal, // type error?
             },
             _ => Ordering::Equal,

--- a/src/value.rs
+++ b/src/value.rs
@@ -85,7 +85,7 @@ pub enum Value {
     /// base type of all simple types. i.e. not a node
     AnySimpleType,
     /// a list of IDREF
-    IDREFS,
+    IDREFS(Vec<String>),
     /// a list of NMTOKEN
     NMTOKENS,
     /// a list of ENTITY
@@ -135,9 +135,9 @@ pub enum Value {
     /// (Letter | '_') NCNameChar+ (i.e. a Name without the colon)
     NCName,
     /// Same format as NCName
-    ID,
+    ID(String),
     /// Same format as NCName
-    IDREF,
+    IDREF(String),
     /// Same format as NCName
     ENTITY,
     Boolean(bool),
@@ -177,6 +177,9 @@ impl fmt::Display for Value {
             Value::Date(d) => d.format("%Y-%m-%d").to_string(),
             Value::QName(q) => q.to_string(),
             Value::RQName(q) => q.to_string(),
+            Value::ID(s) => s.to_string(),
+            Value::IDREF(s) => s.to_string(),
+            Value::IDREFS(s) => s.join(" ").to_string(),
             _ => "".to_string(),
         };
         f.write_str(result.as_str())
@@ -236,7 +239,7 @@ impl Value {
             Value::AnyType => "AnyType",
             Value::Untyped => "Untyped",
             Value::AnySimpleType => "AnySimpleType",
-            Value::IDREFS => "IDREFS",
+            Value::IDREFS(_) => "IDREFS",
             Value::NMTOKENS => "NMTOKENS",
             Value::ENTITIES => "ENTITIES",
             Value::Numeric => "Numeric",
@@ -270,8 +273,8 @@ impl Value {
             Value::NMTOKEN => "NMTOKEN",
             Value::Name => "Name",
             Value::NCName => "NCName",
-            Value::ID => "ID",
-            Value::IDREF => "IDREF",
+            Value::ID(_) => "ID",
+            Value::IDREF(_) => "IDREF",
             Value::ENTITY => "ENTITY",
             Value::Boolean(_) => "boolean",
             Value::QName(_) => "QName",

--- a/src/xmldecl.rs
+++ b/src/xmldecl.rs
@@ -145,6 +145,7 @@ pub enum DTDDecl {
     ParamEntity(QualifiedName, String),
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum AttType {
     CDATA,
@@ -159,6 +160,7 @@ pub(crate) enum AttType {
     ENUMERATION(Vec<String>),
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum DefaultDecl {
     Required,

--- a/tests/conformance/mod.rs
+++ b/tests/conformance/mod.rs
@@ -5,6 +5,7 @@ use xrust::{Error, ErrorKind};
 
 //mod relaxng;
 mod xml;
+mod xml_id;
 
 use encoding_rs::UTF_16BE;
 use encoding_rs::UTF_16LE;

--- a/tests/conformance/xml/eduni_errata3e_invalid.rs
+++ b/tests/conformance/xml/eduni_errata3e_invalid.rs
@@ -10,7 +10,6 @@ use xrust::parser::xml;
 use xrust::trees::smite::RNode;
 
 #[test]
-#[ignore]
 fn rmte3e06a() {
     /*
         Test ID:rmt-e3e-06a
@@ -27,7 +26,6 @@ fn rmte3e06a() {
             .as_str(),
         None,
     );
-
     assert!(parseresult.is_err());
 }
 
@@ -53,7 +51,6 @@ fn rmte3e06b() {
 }
 
 #[test]
-#[ignore]
 fn rmte3e06c() {
     /*
         Test ID:rmt-e3e-06c

--- a/tests/conformance/xml/ibm_invalid.rs
+++ b/tests/conformance/xml/ibm_invalid.rs
@@ -444,7 +444,6 @@ fn ibminvalid_p56ibm56i06xml() {
 }
 
 #[test]
-#[ignore]
 fn ibminvalid_p56ibm56i07xml() {
     /*
         Test ID:ibm-invalid-P56-ibm56i07.xml
@@ -466,7 +465,6 @@ fn ibminvalid_p56ibm56i07xml() {
 }
 
 #[test]
-#[ignore]
 fn ibminvalid_p56ibm56i08xml() {
     /*
         Test ID:ibm-invalid-P56-ibm56i08.xml
@@ -488,7 +486,6 @@ fn ibminvalid_p56ibm56i08xml() {
 }
 
 #[test]
-#[ignore]
 fn ibminvalid_p56ibm56i09xml() {
     /*
         Test ID:ibm-invalid-P56-ibm56i09.xml
@@ -510,7 +507,6 @@ fn ibminvalid_p56ibm56i09xml() {
 }
 
 #[test]
-#[ignore]
 fn ibminvalid_p56ibm56i10xml() {
     /*
         Test ID:ibm-invalid-P56-ibm56i10.xml

--- a/tests/conformance/xml/sun_invalid.rs
+++ b/tests/conformance/xml/sun_invalid.rs
@@ -362,7 +362,6 @@ fn id07() {
 }
 
 #[test]
-#[ignore]
 fn id08() {
     /*
         Test ID:id08
@@ -379,12 +378,10 @@ fn id08() {
             .as_str(),
         None,
     );
-
     assert!(parseresult.is_err());
 }
 
 #[test]
-#[ignore]
 fn id09() {
     /*
         Test ID:id09

--- a/tests/conformance/xml_id/mod.rs
+++ b/tests/conformance/xml_id/mod.rs
@@ -1,0 +1,1 @@
+mod normwalsh;

--- a/tests/conformance/xml_id/normwalsh.rs
+++ b/tests/conformance/xml_id/normwalsh.rs
@@ -1,0 +1,365 @@
+use std::fs;
+use xrust::item::{Node, NodeType};
+use xrust::parser::xml;
+use xrust::trees::smite::RNode;
+
+/*
+
+    https://www.w3.org/XML/2005/01/xml-id/
+    Test catalog submitted by Norm Walsh of Sun Microsystems
+
+*/
+
+#[test]
+fn normal_001() {
+    /*
+        Test ID:normal_001
+        Spec Sections:4
+        Description:Check ID normalization
+        Expected:xml:id on para is an ID (te st)
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/001_normalize.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.clone().unwrap().first_child().unwrap();
+    let mut docchildren = doc
+        .child_iter()
+        .filter(|n| n.node_type() == NodeType::Element);
+    let para = docchildren.next().unwrap();
+
+    assert_eq!(
+        para.attribute_iter().next().unwrap().to_string(),
+        "te st".to_string()
+    );
+}
+
+#[test]
+fn undecl_001() {
+    /*
+        Test ID:undecl_001
+        Spec Sections:4
+        Description:Check that xml:id does not have to be declared
+        Expected:xml:id on para is an ID (test)
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/002_undecl.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.clone().unwrap().first_child().unwrap();
+    let mut docchildren = doc
+        .child_iter()
+        .filter(|n| n.node_type() == NodeType::Element);
+    let para = docchildren.next().unwrap();
+
+    assert_eq!(
+        para.attribute_iter().next().unwrap().to_string(),
+        "test".to_string()
+    );
+}
+
+#[test]
+fn declar_001() {
+    /*
+        Test ID:declar_001
+        Spec Sections:4
+        Description:Check that xml:id can be declared correctly with a DTD
+        Expected:xml:id on para is an ID (id)
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/003_dtd.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.clone().unwrap().first_child().unwrap();
+    let mut docchildren = doc
+        .child_iter()
+        .filter(|n| n.node_type() == NodeType::Element);
+    let para = docchildren.next().unwrap();
+
+    assert_eq!(
+        para.attribute_iter().next().unwrap().to_string(),
+        "id".to_string()
+    );
+}
+
+#[test]
+fn declar_002() {
+    /*
+        Test ID:declar_002
+        Spec Sections:4
+        Description:Check that xml:id can be declared correctly with a schema
+        Expected:xml:id on para is an ID (id)
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/004_schema.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.clone().unwrap().first_child().unwrap();
+    let mut docchildren = doc
+        .child_iter()
+        .filter(|n| n.node_type() == NodeType::Element);
+    let para = docchildren.next().unwrap();
+
+    assert_eq!(
+        para.attribute_iter().next().unwrap().to_string(),
+        "id".to_string()
+    );
+}
+
+#[test]
+fn baddcl_001() {
+    /*
+        Test ID:baddcl_001
+        Spec Sections:4
+        Description:Check that an incorrect DTD declaration is caught
+        Expected:Must generate invalid declared type error.
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/005_errdtdbad.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_err());
+}
+
+#[test]
+fn dupdup_001() {
+    /*
+        Test ID:dupdup_001
+        Spec Sections:4
+        Description:Test to see if duplicate IDs are detected.
+        Expected:Should generate duplicate ID error; may report both elements.
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/005_errdup.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_err());
+}
+
+#[test]
+#[ignore]
+fn baddcl_002() {
+    /*
+        Test ID:baddcl_002
+        Spec Sections:4
+        Description:Check that an incorrect schema declaration is caught
+        Expected:Must generate invalid declared type error; proper evaluation requires a schema-aware processor.
+    */
+
+    /* We need to support XSD to properly test this */
+
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/006_errschemabad.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_err());
+}
+
+#[test]
+fn dupdup_002() {
+    /*
+        Test ID:dupdup_002
+        Spec Sections:4
+        Description:Test to see if duplicate IDs are detected.
+        Expected:Should generate duplicate ID error; may report both elements.
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/007_errdup.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_err());
+}
+
+#[test]
+fn okchar_001() {
+    /*
+        Test ID:okchar_001
+        Spec Sections:4
+        Description:Check that an XML 1.0 document accepts 1.0 IDs
+        Expected:xml:id on p is an ID (anid)
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/008_ok10.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.clone().unwrap().first_child().unwrap();
+    let mut docchildren = doc
+        .child_iter()
+        .filter(|n| n.node_type() == NodeType::Element);
+    let para = docchildren.next().unwrap();
+
+    assert_eq!(
+        para.attribute_iter().next().unwrap().to_string(),
+        "anid".to_string()
+    );
+}
+
+#[test]
+fn okchar_002() {
+    /*
+        Test ID:okchar_002
+        Spec Sections:4
+        Description:Check that an XML 1.1 document accepts 1.1 IDs
+        Expected:xml:id on p is an ID (id&#11264;ok)
+        Note: Will fail if an XML 1.0 processor is used.
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/009_ok11.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.clone().unwrap().first_child().unwrap();
+    let mut docchildren = doc
+        .child_iter()
+        .filter(|n| n.node_type() == NodeType::Element);
+    let para = docchildren.next().unwrap();
+
+    assert_eq!(
+        para.attribute_iter().next().unwrap().to_string(),
+        "idⰀok".to_string()
+    );
+}
+
+#[test]
+fn xref_001() {
+    /*
+        Test ID:xref___001
+        Spec Sections:4
+        Description:Check that IDREFs work
+        Expected:id on para is an ID (id1) xml:id on para is an ID (id2)
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/010_okxref.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_ok());
+}
+
+#[test]
+fn normal_002() {
+    /*
+        Test ID:normal_002
+        Spec Sections:4
+        Description:Check that an ID is normalized
+        Expected:xml:id on p is an ID (anid)
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/011_oknormalize.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.clone().unwrap().first_child().unwrap();
+    let mut docchildren = doc
+        .child_iter()
+        .filter(|n| n.node_type() == NodeType::Element);
+    let p = docchildren.next().unwrap();
+
+    assert_eq!(
+        p.attribute_iter().next().unwrap().to_string(),
+        "anid".to_string()
+    );
+}
+
+#[test]
+#[ignore]
+fn normal_003() {
+    /*
+        Test ID:normal_003
+        Spec Sections:4
+        Description:Check that an ID is normalized
+        Expected:xml:id on para is an ID (&#x0D; p2)
+    */
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(
+        testxml,
+        fs::read_to_string("tests/conformance/xml_id/normwalsh/012_value.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
+
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.clone().unwrap().first_child().unwrap();
+    let mut docchildren = doc
+        .child_iter()
+        .filter(|n| n.node_type() == NodeType::Element);
+    let p = docchildren.next().unwrap();
+
+    assert_eq!(
+        p.attribute_iter().next().unwrap().to_string(),
+        "anid".to_string()
+    );
+}

--- a/tests/conformance/xml_id/normwalsh/001_normalize.xml
+++ b/tests/conformance/xml_id/normwalsh/001_normalize.xml
@@ -1,0 +1,3 @@
+<doc>
+  <para xml:id=" te  st ">MATCH</para>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/002_undecl.xml
+++ b/tests/conformance/xml_id/normwalsh/002_undecl.xml
@@ -1,0 +1,3 @@
+<doc>
+  <para xml:id="test">MATCH</para>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/003_dtd.xml
+++ b/tests/conformance/xml_id/normwalsh/003_dtd.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE doc [
+<!ATTLIST para
+	xml:id	ID	#IMPLIED
+>
+]>
+<doc>
+  <para xml:id="id">MATCH</para>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/004_schema.xml
+++ b/tests/conformance/xml_id/normwalsh/004_schema.xml
@@ -1,0 +1,5 @@
+<doc xmlns="http://www.example.org/schema"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.example.org/schema schema.xsd">
+  <para xml:id="id">MATCH</para>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/005_errdtdbad.xml
+++ b/tests/conformance/xml_id/normwalsh/005_errdtdbad.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE doc [
+<!ATTLIST para
+	xml:id	NMTOKENS	#IMPLIED
+>
+]>
+<doc>
+  <para xml:id="id">BADDECL</para>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/005_errdup.xml
+++ b/tests/conformance/xml_id/normwalsh/005_errdup.xml
@@ -1,0 +1,4 @@
+<doc>
+  <para xml:id="dup">DUPLICATE</para>
+  <para xml:id="dup">DUPLICATE</para>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/006_errschemabad.xml
+++ b/tests/conformance/xml_id/normwalsh/006_errschemabad.xml
@@ -1,0 +1,5 @@
+<doc xmlns="http://www.example.org/schema"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.example.org/schema badschema.xsd">
+  <para xml:id="id">MATCH</para>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/007_errdup.xml
+++ b/tests/conformance/xml_id/normwalsh/007_errdup.xml
@@ -1,0 +1,6 @@
+<!DOCTYPE doc [
+<!ATTLIST para id ID #IMPLIED>
+]>
+<doc>
+ <para id="id1" xml:id="id1"/>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/008_ok10.xml
+++ b/tests/conformance/xml_id/normwalsh/008_ok10.xml
@@ -1,0 +1,3 @@
+<doc>
+ <p xml:id="anid"/>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/009_ok11.xml
+++ b/tests/conformance/xml_id/normwalsh/009_ok11.xml
@@ -1,0 +1,4 @@
+<?xml version="1.1" encoding="utf-8"?>
+<doc>
+ <p xml:id="idⰀok"/>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/010_okxref.xml
+++ b/tests/conformance/xml_id/normwalsh/010_okxref.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE doc [
+<!ATTLIST para
+	id ID #IMPLIED
+	ref IDREF #IMPLIED
+>
+]>
+<doc>
+ <para id="id1" xml:id="id2"/>
+ <para ref="id1"/>
+ <para ref="id2"/>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/011_oknormalize.xml
+++ b/tests/conformance/xml_id/normwalsh/011_oknormalize.xml
@@ -1,0 +1,3 @@
+<doc>
+ <p xml:id="  anid  "/>
+</doc>

--- a/tests/conformance/xml_id/normwalsh/012_value.xml
+++ b/tests/conformance/xml_id/normwalsh/012_value.xml
@@ -1,0 +1,3 @@
+<doc>
+  <para xml:id="&#x0D;  p2  ">MATCH</para>
+</doc>

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -81,9 +81,26 @@ fn parser_config_default_attrs_1() {
     assert!(parseresult1.is_ok());
     assert!(parseresult2.is_ok());
 
-    assert_eq!(parseresult1.clone().unwrap().first_child().unwrap().attribute_iter().count(),2);
-    assert_eq!(parseresult2.clone().unwrap().first_child().unwrap().attribute_iter().count(),0);
-
+    assert_eq!(
+        parseresult1
+            .clone()
+            .unwrap()
+            .first_child()
+            .unwrap()
+            .attribute_iter()
+            .count(),
+        2
+    );
+    assert_eq!(
+        parseresult2
+            .clone()
+            .unwrap()
+            .first_child()
+            .unwrap()
+            .attribute_iter()
+            .count(),
+        0
+    );
 }
 
 #[test]
@@ -104,7 +121,6 @@ fn parser_issue_94() {
 
 #[test]
 fn parser_config_id_1() {
-
     /*
         Conformance tests will determine if the XML IDs are properly tracked by the parser,
         this tests only that it can be disabled.
@@ -123,7 +139,6 @@ fn parser_config_id_1() {
     <element1 id="a1"/>
 </doc>
 "#;
-
 
     let pc = ParserConfig::new();
 
@@ -143,7 +158,6 @@ fn parser_config_id_1() {
 
 #[test]
 fn parser_config_id_2() {
-
     /*
         Conformance tests will determine if the XML IDs are properly tracked by the parser,
         this tests only that it can be disabled.
@@ -161,7 +175,6 @@ fn parser_config_id_2() {
     <element1 idref="a1"/>
 </doc>
 "#;
-
 
     let pc = ParserConfig::new();
 
@@ -181,7 +194,6 @@ fn parser_config_id_2() {
 
 #[test]
 fn parser_config_id_3() {
-
     /*
         Conformance tests will determine if the XML IDs are properly tracked by the parser,
         this tests only that it can be disabled.
@@ -199,14 +211,23 @@ fn parser_config_id_3() {
 <doc id="a1"/>
 "#;
 
-
     let pc = ParserConfig::new();
 
     let testxml = RNode::new_document();
     let parseresult = xml::parse(testxml, doc, Some(pc));
 
     assert!(parseresult.is_ok());
-    assert_eq!(parseresult.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_id(), true);
+    assert_eq!(
+        parseresult
+            .unwrap()
+            .first_child()
+            .unwrap()
+            .attribute_iter()
+            .next()
+            .unwrap()
+            .is_id(),
+        true
+    );
 
     let mut pc2 = ParserConfig::new();
     pc2.id_tracking = false;
@@ -215,13 +236,21 @@ fn parser_config_id_3() {
     let parseresult2 = xml::parse(testxml2, doc, Some(pc2));
 
     assert!(parseresult2.is_ok());
-    assert_eq!(parseresult2.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_id(), false);
-
+    assert_eq!(
+        parseresult2
+            .unwrap()
+            .first_child()
+            .unwrap()
+            .attribute_iter()
+            .next()
+            .unwrap()
+            .is_id(),
+        false
+    );
 }
 
 #[test]
 fn parser_config_id_4() {
-
     /*
         Conformance tests will determine if the XML IDs are properly tracked by the parser,
         this tests only that it can be disabled.
@@ -244,14 +273,23 @@ fn parser_config_id_4() {
 </doc>
 "#;
 
-
     let pc = ParserConfig::new();
 
     let testxml = RNode::new_document();
     let parseresult = xml::parse(testxml, doc, Some(pc));
 
     assert!(parseresult.is_ok());
-    assert_eq!(parseresult.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_idrefs(), true);
+    assert_eq!(
+        parseresult
+            .unwrap()
+            .first_child()
+            .unwrap()
+            .attribute_iter()
+            .next()
+            .unwrap()
+            .is_idrefs(),
+        true
+    );
 
     let mut pc2 = ParserConfig::new();
     pc2.id_tracking = false;
@@ -260,6 +298,15 @@ fn parser_config_id_4() {
     let parseresult2 = xml::parse(testxml2, doc, Some(pc2));
 
     assert!(parseresult2.is_ok());
-    assert_eq!(parseresult2.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_idrefs(), false);
-
+    assert_eq!(
+        parseresult2
+            .unwrap()
+            .first_child()
+            .unwrap()
+            .attribute_iter()
+            .next()
+            .unwrap()
+            .is_idrefs(),
+        false
+    );
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -60,8 +60,8 @@ fn parser_config_namespace_nodes_1() {
 #[test]
 fn parser_config_default_attrs_1() {
     /*
-       Conformance tests will determine if the ATTLIST functions are working,
-       this tests only that it can be disabled.
+        Conformance tests will determine if the ATTLIST functions are working,
+        this tests only that it can be disabled.
     */
     let doc = r#"<!DOCTYPE doc [
         <!ELEMENT doc EMPTY>
@@ -81,26 +81,9 @@ fn parser_config_default_attrs_1() {
     assert!(parseresult1.is_ok());
     assert!(parseresult2.is_ok());
 
-    assert_eq!(
-        parseresult1
-            .clone()
-            .unwrap()
-            .first_child()
-            .unwrap()
-            .attribute_iter()
-            .count(),
-        2
-    );
-    assert_eq!(
-        parseresult2
-            .clone()
-            .unwrap()
-            .first_child()
-            .unwrap()
-            .attribute_iter()
-            .count(),
-        0
-    );
+    assert_eq!(parseresult1.clone().unwrap().first_child().unwrap().attribute_iter().count(),2);
+    assert_eq!(parseresult2.clone().unwrap().first_child().unwrap().attribute_iter().count(),0);
+
 }
 
 #[test]
@@ -117,4 +100,166 @@ fn parser_issue_94() {
     let parseresult = xml::parse(source.clone(), &data, None);
 
     assert!(parseresult.is_ok())
+}
+
+#[test]
+fn parser_config_id_1() {
+
+    /*
+        Conformance tests will determine if the XML IDs are properly tracked by the parser,
+        this tests only that it can be disabled.
+    */
+
+    let doc = r#"<!DOCTYPE root [
+    <!ELEMENT doc ANY>
+    <!ELEMENT element1 EMPTY>
+    <!ATTLIST element1
+	id	ID	#IMPLIED
+	idref	IDREF	#IMPLIED
+	>
+]>
+<doc>
+    <element1 id="a1"/>
+    <element1 id="a1"/>
+</doc>
+"#;
+
+
+    let pc = ParserConfig::new();
+
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(testxml, doc, Some(pc));
+
+    assert!(parseresult.is_err());
+
+    let mut pc2 = ParserConfig::new();
+    pc2.id_tracking = false;
+
+    let testxml2 = RNode::new_document();
+    let parseresult2 = xml::parse(testxml2, doc, Some(pc2));
+
+    assert!(parseresult2.is_ok());
+}
+
+#[test]
+fn parser_config_id_2() {
+
+    /*
+        Conformance tests will determine if the XML IDs are properly tracked by the parser,
+        this tests only that it can be disabled.
+    */
+
+    let doc = r#"<!DOCTYPE root [
+    <!ELEMENT doc ANY>
+    <!ELEMENT element1 EMPTY>
+    <!ATTLIST element1
+	id	ID	#IMPLIED
+	idref	IDREF	#IMPLIED
+	>
+]>
+<doc>
+    <element1 idref="a1"/>
+</doc>
+"#;
+
+
+    let pc = ParserConfig::new();
+
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(testxml, doc, Some(pc));
+
+    assert!(parseresult.is_err());
+
+    let mut pc2 = ParserConfig::new();
+    pc2.id_tracking = false;
+
+    let testxml2 = RNode::new_document();
+    let parseresult2 = xml::parse(testxml2, doc, Some(pc2));
+
+    assert!(parseresult2.is_ok());
+}
+
+#[test]
+fn parser_config_id_3() {
+
+    /*
+        Conformance tests will determine if the XML IDs are properly tracked by the parser,
+        this tests only that it can be disabled.
+
+        When we disable XML ID tracking, the is-id and is-idrefs properties will not populate.
+    */
+
+    let doc = r#"<!DOCTYPE root [
+    <!ELEMENT doc ANY>
+    <!ATTLIST doc
+	id	ID	#IMPLIED
+	idref	IDREF	#IMPLIED
+	>
+]>
+<doc id="a1"/>
+"#;
+
+
+    let pc = ParserConfig::new();
+
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(testxml, doc, Some(pc));
+
+    assert!(parseresult.is_ok());
+    assert_eq!(parseresult.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_id(), true);
+
+    let mut pc2 = ParserConfig::new();
+    pc2.id_tracking = false;
+
+    let testxml2 = RNode::new_document();
+    let parseresult2 = xml::parse(testxml2, doc, Some(pc2));
+
+    assert!(parseresult2.is_ok());
+    assert_eq!(parseresult2.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_id(), false);
+
+}
+
+#[test]
+fn parser_config_id_4() {
+
+    /*
+        Conformance tests will determine if the XML IDs are properly tracked by the parser,
+        this tests only that it can be disabled.
+
+        When we disable XML ID tracking, the is-id and is-idrefs properties will not populate.
+    */
+
+    let doc = r#"<!DOCTYPE root [
+    <!ELEMENT doc ANY>
+    <!ATTLIST doc
+	idref	IDREF	#IMPLIED
+	>
+	<!ELEMENT element1 EMPTY>
+    <!ATTLIST element1
+	id	ID	#IMPLIED
+	>
+]>
+<doc idref="a1">
+    <element1 id="a1"/>
+</doc>
+"#;
+
+
+    let pc = ParserConfig::new();
+
+    let testxml = RNode::new_document();
+    let parseresult = xml::parse(testxml, doc, Some(pc));
+
+    assert!(parseresult.is_ok());
+    assert_eq!(parseresult.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_idrefs(), true);
+
+    let mut pc2 = ParserConfig::new();
+    pc2.id_tracking = false;
+
+    let testxml2 = RNode::new_document();
+    let parseresult2 = xml::parse(testxml2, doc, Some(pc2));
+
+    assert!(parseresult2.is_ok());
+    assert_eq!(parseresult2.unwrap().first_child().unwrap().attribute_iter().next().unwrap().is_idrefs(), false);
+
 }


### PR DESCRIPTION
Hi Steve,

A revised pull request for the ID support.

- xml:id and DTD IDs both supported
- ParserConfig has a id_tracking option to enable/disable support, it is on by default.
- Elements do not yet have IDs, will need to add that at a later stage.
- The taggedelem and emptyelem have been merged into a single "element" function, as they were mostly the same.
- Attribute creation is now done in the new elem function, as the ATTList DTD declarations have to be checked before creation.
- Have added the xml:id conformance tests.
- Some misc cleanups of things.

Let me know what changes to make.

