### PR TITLE
DTD support - first draft

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -12,11 +12,12 @@ use crate::output::OutputDefinition;
 use crate::qname::QualifiedName;
 use crate::value::{Operator, Value};
 use crate::xdmerror::{Error, ErrorKind};
-use crate::xmldecl::XMLDecl;
+use crate::xmldecl::{DTD, XMLDecl};
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::Formatter;
 use std::rc::Rc;
+use crate::validators::{Schema, ValidationError};
 
 /// In XPath, the Sequence is the fundamental data structure.
 /// It is an ordered collection of [Item]s.
@@ -600,4 +601,13 @@ pub trait Node: Clone + PartialEq + fmt::Debug {
     /// It is not guaranteed that the namespace nodes returned
     /// will specify the current element node as their parent.
     fn namespace_iter(&self) -> Self::NodeIterator;
+
+    /// Retrieve the internal representation of the DTD, for use in validation functions.
+    fn get_dtd(&self) -> Option<DTD>;
+
+    /// Store an internal representation of the DTD. Does not keep a copy of the original text
+    fn set_dtd(&self, dtd: DTD) -> Result<(), Error>;
+
+    fn validate(&self, schema: Schema) -> Result<(), ValidationError>;
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,5 +97,5 @@ pub use transform::Transform;
 pub mod trees;
 
 pub mod testutils;
-//pub mod validators;
+pub mod validators;
 pub mod namespace;

--- a/src/parser/xml/dtd/attlistdecl.rs
+++ b/src/parser/xml/dtd/attlistdecl.rs
@@ -198,44 +198,37 @@ pub(crate) fn attlistdecl<N: Node>(
                 )));
             }
 
-            match state2.dtd.attlists.get(&n) {
-                None => {
-                    state2.dtd.attlists.insert(n, atts);
-                    Ok(((input2, state2), ()))
-                }
-                Some(al) => {
-                    let mut newal = al.clone();
-                    for (attname, (atttype, defaultdecl, is_editable)) in atts.iter() {
-                        match newal.get(attname) {
-                            None => {
-                                newal.insert(
-                                    attname.clone(),
-                                    (atttype.clone(), defaultdecl.clone(), *is_editable),
-                                );
-                            }
-                            Some((_, _, existing_is_editable)) => {
-                                if *existing_is_editable {
+            if !atts.is_empty() {
+                match state2.dtd.attlists.get(&n) {
+                    None => {
+                        state2.dtd.attlists.insert(n, atts);
+                    }
+                    Some(al) => {
+                        let mut newal = al.clone();
+                        for (attname, (atttype, defaultdecl, is_editable)) in atts.iter() {
+                            match newal.get(attname) {
+                                None => {
                                     newal.insert(
                                         attname.clone(),
                                         (atttype.clone(), defaultdecl.clone(), *is_editable),
                                     );
                                 }
+                                Some((_, _, existing_is_editable)) => {
+                                    if *existing_is_editable {
+                                        newal.insert(
+                                            attname.clone(),
+                                            (atttype.clone(), defaultdecl.clone(), *is_editable),
+                                        );
+                                    }
+                                }
                             }
                         }
+                        state2.dtd.attlists.insert(n, newal);
                     }
-                    state2.dtd.attlists.insert(n, newal);
-                    Ok(((input2, state2), ()))
                 }
             }
 
-            /*
-                   state2
-                       .dtd
-                       .attlists
-                       .insert(n, atts);
-                   Ok(((input2, state2), ()))
-
-            */
+            Ok(((input2, state2), ()))
         }
         Err(err) => Err(err),
     }

--- a/src/parser/xml/dtd/elementdecl.rs
+++ b/src/parser/xml/dtd/elementdecl.rs
@@ -5,7 +5,7 @@ use crate::parser::combinators::whitespace::{whitespace0, whitespace1};
 use crate::parser::xml::dtd::misc::contentspec;
 use crate::parser::xml::qname::qualname;
 use crate::parser::{ParseError, ParseInput};
-use crate::xmldecl::DTDDecl;
+use crate::xmldecl::Contentspec;
 
 //elementdecl	   ::=   	'<!ELEMENT' S Name S contentspec S? '>'
 pub(crate) fn elementdecl<N: Node>(
@@ -21,10 +21,14 @@ pub(crate) fn elementdecl<N: Node>(
     )(input)
     {
         Ok(((input2, mut state2), (_, _, n, _, s, _, _))) => {
+            match s {
+                Contentspec::ANY => {}
+                Contentspec::DTDPattern(_) => {}
+            }
             state2
                 .dtd
                 .elements
-                .insert(n.to_string(), DTDDecl::Element(n, s));
+                .insert(n, s);
             Ok(((input2, state2), ()))
         }
         Err(err) => Err(err),

--- a/src/parser/xml/dtd/externalid.rs
+++ b/src/parser/xml/dtd/externalid.rs
@@ -1,0 +1,124 @@
+use crate::Node;
+use crate::parser::{ParseError, ParseInput};
+use crate::parser::combinators::alt::alt2;
+use crate::parser::combinators::delimited::delimited;
+use crate::parser::combinators::map::map;
+use crate::parser::combinators::opt::opt;
+use crate::parser::combinators::tag::tag;
+use crate::parser::combinators::take::{take_until, take_while};
+use crate::parser::combinators::tuple::{tuple3, tuple5};
+use crate::parser::combinators::whitespace::{whitespace0, whitespace1};
+use crate::parser::common::{is_pubid_char, is_pubid_charwithapos};
+use crate::parser::xml::dtd::extsubset::extsubset;
+use crate::parser::xml::dtd::textdecl::textdecl;
+
+pub(crate) fn externalid<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
+    move |(input, state)| {
+        match alt2(
+            map(
+                tuple3(
+                    tag("SYSTEM"),
+                    whitespace0(),
+                    alt2(
+                        delimited(tag("'"), take_until("'"), tag("'")),
+                        delimited(tag("\""), take_until("\""), tag("\"")),
+                    ), //SystemLiteral
+                ),
+                |(_, _, sid)| (sid, None),
+            ),
+            map(
+                tuple5(
+                    tag("PUBLIC"),
+                    whitespace0(),
+                    alt2(
+                        delimited(tag("'"), take_while(|c| is_pubid_char(&c)), tag("'")),
+                        delimited(
+                            tag("\""),
+                            take_while(|c| is_pubid_charwithapos(&c)),
+                            tag("\""),
+                        ),
+                    ), //PubidLiteral TODO validate chars here (PubidChar from spec).
+                    whitespace1(),
+                    alt2(
+                        delimited(tag("'"), take_until("'"), tag("'")),
+                        delimited(tag("\""), take_until("\""), tag("\"")),
+                    ), //SystemLiteral
+                ),
+                |(_, _, pid, _, sid)| (sid, Some(pid)),
+            ),
+        )((input, state))
+        {
+            Err(e) => Err(e),
+            Ok(((input2, mut state2), (sid, _))) => {
+                if !state2.currentlyexternal {
+                    state2.ext_entities_to_parse.push(sid);
+                    Ok(((input2, state2), ()))
+                } else {
+                    match state2.clone().resolve(state2.docloc.clone(), sid) {
+                        Err(_) => Err(ParseError::ExtDTDLoadError),
+                        Ok(s) => match extsubset()((s.as_str(), state2)) {
+                            Err(e) => Err(e),
+                            Ok(((_, state3), _)) => Ok(((input2, state3), ())),
+                        },
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn textexternalid<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError>
+{
+    move |(input, state)| {
+        match alt2(
+            map(
+                tuple3(
+                    tag("SYSTEM"),
+                    whitespace0(),
+                    alt2(
+                        delimited(tag("'"), take_until("'"), tag("'")),
+                        delimited(tag("\""), take_until("\""), tag("\"")),
+                    ), //SystemLiteral
+                ),
+                |(_, _, sid)| (sid, None),
+            ),
+            map(
+                tuple5(
+                    tag("PUBLIC"),
+                    whitespace1(),
+                    alt2(
+                        delimited(tag("'"), take_while(|c| is_pubid_char(&c)), tag("'")),
+                        delimited(
+                            tag("\""),
+                            take_while(|c| is_pubid_charwithapos(&c)),
+                            tag("\""),
+                        ),
+                    ), //PubidLiteral TODO validate chars here (PubidChar from spec).
+                    whitespace1(),
+                    alt2(
+                        delimited(tag("'"), take_until("'"), tag("'")),
+                        delimited(tag("\""), take_until("\""), tag("\"")),
+                    ), //SystemLiteral
+                ),
+                |(_, _, pid, _, sid)| (sid, Some(pid)),
+            ),
+        )((input, state))
+        {
+            Err(e) => Err(e),
+            Ok(((input2, state2), (sid, _pid))) => {
+                match state2.clone().resolve(state2.docloc.clone(), sid) {
+                    Err(_) => Err(ParseError::ExtDTDLoadError),
+                    Ok(s) => {
+                        match opt(textdecl())((
+                            s.replace("\r\n", "\n").replace('\r', "\n").as_str(),
+                            state2.clone(),
+                        )) {
+                            Err(_) => Ok(((input2, state2), s)),
+                            Ok(((i3, _), _)) => Ok(((input2, state2), i3.to_string())),
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/parser/xml/dtd/gedecl.rs
+++ b/src/parser/xml/dtd/gedecl.rs
@@ -12,9 +12,9 @@ use crate::parser::common::{is_char10, is_char11, is_unrestricted_char11};
 use crate::parser::xml::chardata::chardata_unicode_codepoint;
 use crate::parser::xml::dtd::intsubset::intsubset;
 use crate::parser::xml::dtd::pereference::petextreference;
-use crate::parser::xml::dtd::textexternalid;
 use crate::parser::xml::qname::qualname;
 use crate::parser::{ParseError, ParseInput};
+use crate::parser::xml::dtd::externalid::textexternalid;
 
 pub(crate) fn gedecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError>
 {

--- a/src/parser/xml/dtd/misc.rs
+++ b/src/parser/xml/dtd/misc.rs
@@ -5,13 +5,16 @@ use crate::parser::combinators::map::map;
 use crate::parser::combinators::opt::opt;
 use crate::parser::combinators::tag::tag;
 use crate::parser::combinators::take::take_while;
-use crate::parser::combinators::tuple::{tuple2, tuple4, tuple5, tuple6};
+use crate::parser::combinators::tuple::{tuple2, tuple3, tuple4, tuple5, tuple6};
 use crate::parser::combinators::value::value;
 use crate::parser::combinators::whitespace::whitespace0;
 use crate::parser::common::is_namechar;
 use crate::parser::xml::dtd::pereference::petextreference;
 use crate::parser::xml::qname::name;
 use crate::parser::{ParseError, ParseInput};
+use crate::parser::xml::dtd::Occurances;
+use crate::qname::QualifiedName;
+use crate::xmldecl::{Contentspec, DTDPattern};
 
 pub(crate) fn nmtoken<N: Node>(
 ) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
@@ -19,18 +22,18 @@ pub(crate) fn nmtoken<N: Node>(
 }
 
 pub(crate) fn contentspec<N: Node>(
-) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, Contentspec), ParseError> {
     alt4(
-        value(tag("EMPTY"), "EMPTY".to_string()),
-        value(tag("ANY"), "ANY".to_string()),
-        mixed(),
-        children(),
+        value(tag("EMPTY"), Contentspec::DTDPattern(DTDPattern::Empty)),
+        value(tag("ANY"), Contentspec::ANY),
+        map(mixed(),|m|{Contentspec::DTDPattern(m)}),
+        map(children(),|c|{Contentspec::DTDPattern(c)}),
     )
 }
 
 //Mixed	   ::=   	'(' S? '#PCDATA' (S? '|' S? Name)* S? ')*' | '(' S? '#PCDATA' S? ')'
 pub(crate) fn mixed<N: Node>(
-) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, DTDPattern), ParseError> {
     alt2(
         map(
             tuple6(
@@ -46,7 +49,32 @@ pub(crate) fn mixed<N: Node>(
                 whitespace0(),
                 tag(")*"),
             ),
-            |_x| "".to_string(),
+            |(_,_,_,vn,_,_)| {
+                let mut r = DTDPattern::Text;
+                for (_,_,_,name) in vn {
+                    let q: QualifiedName = if name.contains(':'){
+                        let mut nameparts = name.split(':');
+                        QualifiedName::new(None, Some(nameparts.next().unwrap().parse().unwrap()), nameparts.next().unwrap())
+                    } else {
+                        QualifiedName::new(None, None, name)
+                    };
+                    r = DTDPattern::Choice(
+                        Box::new(DTDPattern::Ref(q)),
+                        Box::new(r)
+                    )
+                }
+                //Zero or More
+                DTDPattern::Choice(
+                    Box::new(
+                        DTDPattern::OneOrMore(
+                            Box::new(r)
+                        )
+                    ),
+                    Box::new(
+                        DTDPattern::Empty
+                    )
+                )
+            },
         ),
         map(
             tuple5(
@@ -56,57 +84,227 @@ pub(crate) fn mixed<N: Node>(
                 whitespace0(),
                 tag(")"),
             ),
-            |_x| "".to_string(),
-        ),
+            |_x| DTDPattern::Text
+        )
     )
 }
 
 // children	   ::=   	(choice | seq) ('?' | '*' | '+')?
 pub(crate) fn children<N: Node>(
-) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
-    map(
-        tuple2(
-            alt3(petextreference(), choice(), seq()),
-            opt(alt3(tag("?"), tag("*"), tag("+"))),
-        ),
-        |_x| "".to_string(),
-    )
+) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, DTDPattern), ParseError> {
+    move |(input, state)| {
+        map(
+            tuple2(
+                alt3(
+                    |(input1, state1)| {
+                        match petextreference()((input1, state1)){
+                            Err(e) => Err(e),
+                            Ok(((input2, state2), s)) => {
+                                match tuple3(
+                                    whitespace0(),
+                                        alt2(
+                                            choice(),
+                                            seq()
+                                        ),
+                                    whitespace0()
+                                )((s.as_str(), state2)){
+                                    Err(e) => Err(e),
+                                    Ok(((_input3, state3), (_, d, _))) => {
+                                        Ok(((input2, state3), d))
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    choice(),
+                    seq()),
+                opt(
+                    alt3(
+                        value(tag("?"), Occurances::ZeroOrOne),
+                        value(tag("*"), Occurances::ZeroOrMore),
+                        value(tag("+"), Occurances::OneOrMore)
+                    )
+                ),
+            ),
+            |(dtdp, occ)| {
+                match occ{
+                    None => dtdp,
+                    Some(o) => {
+                        match o {
+                            Occurances::ZeroOrMore => {
+                                DTDPattern::Choice(
+                                    Box::new(
+                                        DTDPattern::OneOrMore(Box::new(dtdp))
+                                    ),
+                                    Box::new(
+                                        DTDPattern::Empty
+                                    )
+                                )
+                            }
+                            Occurances::OneOrMore => {
+                                DTDPattern::OneOrMore(Box::new(dtdp))
+                            }
+                            Occurances::One => {dtdp}
+                            Occurances::ZeroOrOne => {
+                                DTDPattern::Choice(
+                                    Box::new(
+                                        dtdp
+                                    ),
+                                    Box::new(
+                                        DTDPattern::Empty
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        )((input, state))
+    }
 }
 
 // cp	   ::=   	(Name | choice | seq) ('?' | '*' | '+')?
-fn cp<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
-    move |input| {
+fn cp<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, DTDPattern), ParseError> {
+    move |(input1, state1)| {
         map(
             tuple2(
-                alt4(petextreference(), name(), choice(), seq()),
-                opt(alt3(tag("?"), tag("*"), tag("+"))),
+                alt4(
+                    |(input1, state1)| {
+                        match petextreference()((input1, state1)){
+                            Err(e) => Err(e),
+                            Ok(((input2, state2), s)) => {
+                                match tuple3(
+                                    whitespace0(),
+                                    alt3(
+                                        map(name(), |n|{
+                                            if n.contains(':'){
+                                                let mut nameparts = n.split(':');
+                                                DTDPattern::Ref(QualifiedName::new(None,Some(nameparts.next().unwrap().to_string()),nameparts.next().unwrap()))
+                                            } else {
+                                                DTDPattern::Ref(QualifiedName::new(None, None, n))
+                                            }
+                                        }),
+                                        choice(),
+                                        seq()
+                                    ),
+                                    whitespace0()
+                                )((s.as_str(), state2)){
+                                    Err(e) => Err(e),
+                                    Ok(((_input3, state3), (_, d, _))) => {
+                                        Ok(((input2, state3), d))
+                                    }
+                                }
+                            }
+                        }
+                    },
+                map(name(), |n|{
+                    if n.contains(':'){
+                        let mut nameparts = n.split(':');
+                        DTDPattern::Ref(QualifiedName::new(None,Some(nameparts.next().unwrap().to_string()),nameparts.next().unwrap()))
+                    } else {
+                        DTDPattern::Ref(QualifiedName::new(None, None, n))
+                    }
+                }),
+                choice(),
+                seq()
+                ),
+                map(
+                    opt(
+                        alt3(
+                             value(tag("?"), Occurances::ZeroOrOne),
+                             value(tag("*"), Occurances::ZeroOrMore),
+                             value(tag("+"), Occurances::OneOrMore)
+                        )
+                    ),|o|{
+                        match o {
+                            None => { Occurances::One }
+                            Some(oc) => {oc}
+                        }
+                    },
+                )
             ),
-            |_x| "".to_string(),
-        )(input)
+            |(cs, occ) | {
+                match occ{
+                    Occurances::ZeroOrMore => {
+                        DTDPattern::Choice(
+                            Box::new(
+                                DTDPattern::OneOrMore(Box::new(cs))
+                            ),
+                            Box::new(
+                                DTDPattern::Empty
+                            )
+                        )
+                    }
+                    Occurances::OneOrMore => {
+                        DTDPattern::OneOrMore(Box::new(cs))
+                    }
+                    Occurances::One => {
+                        cs
+                    }
+                    Occurances::ZeroOrOne => {
+                        DTDPattern::Choice(
+                            Box::new(
+                                cs
+                            ),
+                            Box::new(
+                                DTDPattern::Empty
+                            )
+                        )
+                    }
+                }
+            },
+        )((input1, state1))
     }
 }
 //choice	   ::=   	'(' S? cp ( S? '|' S? cp )+ S? ')'
-fn choice<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
-    move |input| {
+fn choice<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, DTDPattern), ParseError> {
+    move |(input, state)| {
         map(
             tuple6(
                 tag("("),
                 whitespace0(),
                 cp(),
-                many0(alt2(
-                    map(petextreference(), |x| ((), (), (), x)),
+                many0(
+                    alt2(
+                    |(input1, state1)| {
+                        match petextreference()((input1, state1)){
+                            Err(e) => Err(e),
+                            Ok(((input2, state2), s)) => {
+                                match tuple3(
+                                    whitespace0(),
+                                    cp(),
+                                    whitespace0()
+                                )((s.as_str(), state2)){
+                                    Err(e) => Err(e),
+                                    Ok(((_input3, state3), (_, d, _))) => {
+                                        Ok(((input2, state3), ((),(),(),d)))
+                                    }
+                                }
+                            }
+                        }
+                    },
                     tuple4(whitespace0(), tag("|"), whitespace0(), cp()),
-                )),
+                )
+                ),
                 whitespace0(),
                 tag(")"),
             ),
-            |_x| "".to_string(),
-        )(input)
+            |(_,_,c1, vc1, _, _)| {
+                let mut res = c1;
+                for (_,_,_,c) in vc1 {
+                    res = DTDPattern::Choice(
+                        Box::new(res),
+                        Box::new(c)
+                    )
+                };
+                res
+            }
+        )((input, state))
     }
 }
 
 //seq	   ::=   	'(' S? cp ( S? ',' S? cp )* S? ')'
-fn seq<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError> {
+fn seq<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, DTDPattern), ParseError> {
     map(
         tuple6(
             tag("("),
@@ -116,6 +314,28 @@ fn seq<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), P
             whitespace0(),
             tag(")"),
         ),
-        |_x| "".to_string(),
+        |(_,_,cp, mut veccp,_,_)| {
+            let groupstart = cp;
+            let mut prev: Option<DTDPattern> = None;
+            veccp.reverse();
+            for (_,_,_,c) in veccp {
+                if prev.is_none(){
+                    prev = Some(c);
+                } else {
+                    prev = Some(DTDPattern::Group(
+                        Box::new(c),
+                        Box::new(prev.unwrap())
+                    ))
+                }
+            }
+            if prev.is_none(){
+                groupstart
+            } else {
+                DTDPattern::Group(
+                    Box::new(groupstart),
+                    Box::new(prev.unwrap())
+                )
+            }
+        },
     )
 }

--- a/src/parser/xml/dtd/mod.rs
+++ b/src/parser/xml/dtd/mod.rs
@@ -10,23 +10,31 @@ mod notation;
 mod pedecl;
 pub(crate) mod pereference;
 mod textdecl;
+mod externalid;
 
 use crate::item::Node;
-use crate::parser::combinators::alt::alt2;
 use crate::parser::combinators::delimited::delimited;
-use crate::parser::combinators::map::map;
 use crate::parser::combinators::opt::opt;
 use crate::parser::combinators::tag::tag;
-use crate::parser::combinators::take::{take_until, take_while};
-use crate::parser::combinators::tuple::{tuple3, tuple5, tuple8};
+use crate::parser::combinators::tuple::{ tuple8};
 use crate::parser::combinators::whitespace::{whitespace0, whitespace1};
-use crate::parser::common::{is_pubid_char, is_pubid_charwithapos};
 use crate::parser::xml::dtd::extsubset::extsubset;
 use crate::parser::xml::dtd::intsubset::intsubset;
-use crate::parser::xml::dtd::textdecl::textdecl;
 use crate::parser::xml::qname::name;
 use crate::parser::xml::reference::reference;
 use crate::parser::{ParseError, ParseInput};
+use crate::parser::xml::dtd::externalid::externalid;
+use crate::qname::QualifiedName;
+use crate::xmldecl::{AttType, Contentspec, DefaultDecl, DTDPattern};
+
+
+#[derive(Clone)]
+pub(crate) enum Occurances {
+    ZeroOrMore,
+    OneOrMore,
+    One,
+    ZeroOrOne
+}
 
 pub(crate) fn doctypedecl<N: Node>(
 ) -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
@@ -41,7 +49,14 @@ pub(crate) fn doctypedecl<N: Node>(
         tag(">"),
     )(input)
     {
-        Ok(((input1, state1), (_, _, _n, _, _, _, _inss, _))) => {
+        Ok(((input1, mut state1), (_, _, n, _, _, _, _inss, _))) => {
+            let q: QualifiedName = if n.contains(':'){
+                let mut nameparts = n.split(':');
+                QualifiedName::new(None, Some(nameparts.next().unwrap().parse().unwrap()), nameparts.next().unwrap())
+            } else {
+                QualifiedName::new(None, None, n)
+            };
+            state1.dtd.name = Some(q);
             /*  We're doing nothing with the below, just evaluating the external entity to check its well formed */
             let exdtd = state1.ext_entities_to_parse.clone().pop();
             match exdtd {
@@ -68,119 +83,130 @@ pub(crate) fn doctypedecl<N: Node>(
                     }
                 }
             }
+
+            // Construction of DTDPatterns for validation
+
+            // First, we construct our "ANY" pattern. It can be any text or comment or declared element, so we loop through the DTD to build it.
+            let mut anypattern = DTDPattern::Text;
+
+            for el in &state1.dtd.elements {
+                anypattern = DTDPattern::Choice(
+                    Box::new(DTDPattern::Ref(el.0.clone())),
+                    Box::new(anypattern)
+                );
+            }
+            anypattern = DTDPattern::Choice(
+                Box::new(DTDPattern::Empty),
+                Box::new(
+                    DTDPattern::OneOrMore(
+                        Box::new(anypattern)
+                    )
+                ),
+            );
+
+            //println!("dtdelements");
+            //println!("{:?}", &state1.dtd.elements);
+            //println!("{:?}", &state1.dtd.patterns);
+
+            //let mut patternrefs = HashMap::new();
+
+            for (elname, eldecl) in &state1.dtd.elements {
+
+                let mut pat = match eldecl {
+                    Contentspec::ANY => {
+                        //println!("element-{:?}", elname);
+                        //println!("elementp-{:?}", anypattern.clone());
+                        anypattern.clone()
+                    }
+                    Contentspec::DTDPattern(d) => {
+                        //println!("element-{:?}", elname);
+                        //println!("elementp-{:?}", d.clone());
+                        d.clone()
+                    }
+                };
+                match &state1.dtd.attlists.get(elname){
+                    None => {
+                        pat = DTDPattern::Element(elname.clone(), Box::new(pat));
+                        state1.dtd.patterns.insert(elname.clone(), pat);
+                    }
+                    Some(attlist) => {
+                        let mut attpat = None;
+                        for (attname, (at,dd,_)) in attlist.iter() {
+                            let mut ap = match at {
+                                AttType::CDATA => { DTDPattern::Text }
+                                AttType::ID => { DTDPattern::Text }
+                                AttType::IDREF => { DTDPattern::Text }
+                                AttType::IDREFS => { DTDPattern::Text }
+                                AttType::ENTITY => { DTDPattern::Text }
+                                AttType::ENTITIES => {DTDPattern::Text }
+                                AttType::NMTOKEN => { DTDPattern::Text }
+                                AttType::NMTOKENS => { DTDPattern::Text }
+                                AttType::NOTATION(_) => { DTDPattern::Text }
+                                AttType::ENUMERATION(el) => {
+                                    let mut enumers = el.iter();
+                                    let mut pat = DTDPattern::Value(enumers.next().unwrap().clone());
+                                    for s in enumers {
+                                        pat = DTDPattern::Group(
+                                            Box::new(pat),
+                                            Box::new(DTDPattern::Value(s.clone()))
+                                        )
+                                    };
+                                    pat
+                                }
+                            };
+
+                            match dd {
+                                DefaultDecl::Implied => {
+                                    ap = DTDPattern::Choice(
+                                        Box::new(DTDPattern::Attribute(
+                                            attname.clone(),
+                                            Box::new(ap)
+                                        )),
+                                        Box::new(DTDPattern::Empty)
+                                    )
+                                }
+                                _ => {
+                                    ap = DTDPattern::Attribute(
+                                        attname.clone(),
+                                        Box::new(ap)
+                                    )
+                                }
+                            }
+
+                            match attpat {
+                                None => {
+                                    attpat = Some(ap);
+                                },
+                                Some(ap2) => {
+                                    attpat = Some(
+                                        DTDPattern::Group(
+                                            Box::new(
+                                                ap
+                                            ),
+                                            Box::new(ap2)
+                                        )
+                                    );
+                                }
+                            }
+                        };
+                        state1.dtd.patterns.insert(elname.clone(),
+                            DTDPattern::Element(elname.clone(),
+                               Box::new(DTDPattern::Group(
+                                    Box::new(pat),
+                                    Box::new(
+                                        attpat.unwrap())
+                               ))
+                            )
+                        );
+                    }
+                }
+            }
+            //println!("{:?}", patternrefs);
             Ok(((input1, state1), ()))
         }
-        Err(err) => Err(err),
+        Err(err) => {
+            Err(err)
+        },
     }
 }
 
-fn externalid<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError> {
-    move |(input, state)| {
-        match alt2(
-            map(
-                tuple3(
-                    tag("SYSTEM"),
-                    whitespace0(),
-                    alt2(
-                        delimited(tag("'"), take_until("'"), tag("'")),
-                        delimited(tag("\""), take_until("\""), tag("\"")),
-                    ), //SystemLiteral
-                ),
-                |(_, _, sid)| (sid, None),
-            ),
-            map(
-                tuple5(
-                    tag("PUBLIC"),
-                    whitespace0(),
-                    alt2(
-                        delimited(tag("'"), take_while(|c| is_pubid_char(&c)), tag("'")),
-                        delimited(
-                            tag("\""),
-                            take_while(|c| is_pubid_charwithapos(&c)),
-                            tag("\""),
-                        ),
-                    ), //PubidLiteral TODO validate chars here (PubidChar from spec).
-                    whitespace1(),
-                    alt2(
-                        delimited(tag("'"), take_until("'"), tag("'")),
-                        delimited(tag("\""), take_until("\""), tag("\"")),
-                    ), //SystemLiteral
-                ),
-                |(_, _, pid, _, sid)| (sid, Some(pid)),
-            ),
-        )((input, state))
-        {
-            Err(e) => Err(e),
-            Ok(((input2, mut state2), (sid, _))) => {
-                if !state2.currentlyexternal {
-                    state2.ext_entities_to_parse.push(sid);
-                    Ok(((input2, state2), ()))
-                } else {
-                    match state2.clone().resolve(state2.docloc.clone(), sid) {
-                        Err(_) => Err(ParseError::ExtDTDLoadError),
-                        Ok(s) => match extsubset()((s.as_str(), state2)) {
-                            Err(e) => Err(e),
-                            Ok(((_, state3), _)) => Ok(((input2, state3), ())),
-                        },
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn textexternalid<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, String), ParseError>
-{
-    move |(input, state)| {
-        match alt2(
-            map(
-                tuple3(
-                    tag("SYSTEM"),
-                    whitespace0(),
-                    alt2(
-                        delimited(tag("'"), take_until("'"), tag("'")),
-                        delimited(tag("\""), take_until("\""), tag("\"")),
-                    ), //SystemLiteral
-                ),
-                |(_, _, sid)| (sid, None),
-            ),
-            map(
-                tuple5(
-                    tag("PUBLIC"),
-                    whitespace1(),
-                    alt2(
-                        delimited(tag("'"), take_while(|c| is_pubid_char(&c)), tag("'")),
-                        delimited(
-                            tag("\""),
-                            take_while(|c| is_pubid_charwithapos(&c)),
-                            tag("\""),
-                        ),
-                    ), //PubidLiteral TODO validate chars here (PubidChar from spec).
-                    whitespace1(),
-                    alt2(
-                        delimited(tag("'"), take_until("'"), tag("'")),
-                        delimited(tag("\""), take_until("\""), tag("\"")),
-                    ), //SystemLiteral
-                ),
-                |(_, _, pid, _, sid)| (sid, Some(pid)),
-            ),
-        )((input, state))
-        {
-            Err(e) => Err(e),
-            Ok(((input2, state2), (sid, _pid))) => {
-                match state2.clone().resolve(state2.docloc.clone(), sid) {
-                    Err(_) => Err(ParseError::ExtDTDLoadError),
-                    Ok(s) => {
-                        match opt(textdecl())((
-                            s.replace("\r\n", "\n").replace('\r', "\n").as_str(),
-                            state2.clone(),
-                        )) {
-                            Err(_) => Ok(((input2, state2), s)),
-                            Ok(((i3, _), _)) => Ok(((input2, state2), i3.to_string())),
-                        }
-                    }
-                }
-            }
-        }
-    }
-}

--- a/src/parser/xml/dtd/pedecl.rs
+++ b/src/parser/xml/dtd/pedecl.rs
@@ -12,9 +12,9 @@ use crate::parser::common::{is_char10, is_unrestricted_char11};
 use crate::parser::xml::chardata::chardata_unicode_codepoint;
 use crate::parser::xml::dtd::intsubset::intsubset;
 use crate::parser::xml::dtd::pereference::petextreference;
-use crate::parser::xml::dtd::textexternalid;
 use crate::parser::xml::qname::qualname;
 use crate::parser::{ParseError, ParseInput};
+use crate::parser::xml::dtd::externalid::textexternalid;
 
 pub(crate) fn pedecl<N: Node>() -> impl Fn(ParseInput<N>) -> Result<(ParseInput<N>, ()), ParseError>
 {

--- a/src/parser/xml/mod.rs
+++ b/src/parser/xml/mod.rs
@@ -112,31 +112,26 @@ fn document<N: Node>(input: ParseInput<N>) -> Result<(ParseInput<N>, N), ParseEr
 
                 let pr = p.unwrap_or((None, vec![]));
 
+                let mut d = state1.doc.clone().unwrap();
+
                 pr.1.iter().for_each(|n| {
-                    state1
-                        .doc
-                        .clone()
-                        .unwrap()
-                        .push(n.clone())
+                    d.push(n.clone())
                         .expect("unable to add node")
                 });
-                state1
-                    .doc
-                    .clone()
-                    .unwrap()
-                    .push(e)
-                    .expect("unable to add node");
+                    d.push(e)
+                        .expect("unable to add node");
                 m.unwrap_or_default().iter().for_each(|n| {
-                    state1
-                        .doc
-                        .clone()
-                        .unwrap()
-                        .push(n.clone())
+                    d.push(n.clone())
                         .expect("unable to add node")
                 });
                 if let Some(x) = pr.0 {
-                    let _ = state1.doc.clone().unwrap().set_xmldecl(x);
+                    let _ = d.set_xmldecl(x);
                 }
+
+                if !state1.dtd.patterns.is_empty() {
+                    let _ = d.set_dtd(state1.dtd.clone());
+                };
+
                 Ok((
                     (input1, state1.clone()),
                     state1.doc.clone().unwrap().clone(),

--- a/src/trees/nullo.rs
+++ b/src/trees/nullo.rs
@@ -3,7 +3,7 @@ use crate::output::OutputDefinition;
 use crate::qname::QualifiedName;
 use crate::value::Value;
 use crate::xdmerror::{Error, ErrorKind};
-use crate::xmldecl::{XMLDecl, XMLDeclBuilder};
+use crate::xmldecl::{DTD, XMLDecl, XMLDeclBuilder};
 /// A null tree implementation
 ///
 /// This tree implementation implements nothing.
@@ -13,6 +13,7 @@ use crate::xmldecl::{XMLDecl, XMLDeclBuilder};
 use std::cmp::Ordering;
 use std::fmt;
 use std::rc::Rc;
+use crate::validators::{Schema, ValidationError};
 
 #[derive(Clone)]
 pub struct Nullo();
@@ -192,6 +193,20 @@ impl Node for Nullo {
     fn is_idrefs(&self) -> bool {
         false
     }
+    fn get_dtd(&self) -> Option<DTD> {
+        None
+    }
+    fn set_dtd(&self, _dtd: DTD) -> Result<(), Error>{
+        Err(Error::new(
+            ErrorKind::NotImplemented,
+            String::from("not implemented"),
+        ))
+    }
+
+    fn validate(&self, _sch: Schema) -> Result<(), ValidationError>{
+        Err(ValidationError::SchemaError("Not Implemented".to_string()))
+    }
+
 }
 
 pub struct NulloIter();

--- a/src/validators/dtd/derive.rs
+++ b/src/validators/dtd/derive.rs
@@ -1,0 +1,505 @@
+use crate::item::NodeType;
+use crate::Node;
+use crate::qname::QualifiedName;
+
+use crate::xmldecl::{DTD, DTDPattern};
+
+
+
+pub(crate) fn is_nullable(pat: DTDPattern) -> bool {
+    match pat{
+        DTDPattern::Empty => true,
+        DTDPattern::Text => true,
+        DTDPattern::Group(pat1, pat2) => {
+            is_nullable(*pat1) && is_nullable(*pat2)
+        },
+        DTDPattern::Interleave(pat1, pat2) => {
+            is_nullable(*pat1) && is_nullable(*pat2)
+        },
+        DTDPattern::Choice(pat1, pat2) => {
+            is_nullable(*pat1) || is_nullable(*pat2)
+        },
+        DTDPattern::OneOrMore(pat1) => {
+            is_nullable(*pat1)
+        },
+        _ => false
+    }
+}
+
+fn contains(nc: QualifiedName, qn: QualifiedName) -> bool {
+    nc.prefix() == qn.prefix() && nc.localname() == qn.localname()
+}
+
+fn after(pat1: DTDPattern, pat2: DTDPattern) -> DTDPattern {
+    if pat1 == DTDPattern::NotAllowed || pat2 == DTDPattern::NotAllowed {
+        DTDPattern::NotAllowed
+    } else {
+        DTDPattern::After(
+            Box::new(pat1),
+            Box::new(pat2)
+        )
+    }
+}
+fn choice(pat1: DTDPattern, pat2: DTDPattern) -> DTDPattern {
+    match (pat1, pat2) {
+        (p, DTDPattern::NotAllowed) => p,
+        (DTDPattern::NotAllowed, p) => p,
+        (p1, p2) => DTDPattern::Choice(
+            Box::new(p1),
+            Box::new(p2)
+        )
+    }
+}
+fn interleave(pat1: DTDPattern, pat2: DTDPattern) -> DTDPattern {
+    match (pat1, pat2) {
+        (DTDPattern::NotAllowed, _) => DTDPattern::NotAllowed,
+        (_, DTDPattern::NotAllowed) => DTDPattern::NotAllowed,
+        (DTDPattern::Empty, p2) => p2,
+        (p1, DTDPattern::Empty) => p1,
+        (p1, p2) => {
+            DTDPattern::Interleave(
+                Box::new(p1),
+                Box::new(p2)
+            )
+        }
+    }
+}
+fn group(pat1: DTDPattern, pat2: DTDPattern) -> DTDPattern {
+    match (pat1, pat2) {
+        (DTDPattern::NotAllowed, _) => DTDPattern::NotAllowed,
+        (_, DTDPattern::NotAllowed) => DTDPattern::NotAllowed,
+        (DTDPattern::Empty, p2) => p2,
+        (p1, DTDPattern::Empty) => p1,
+        (p1, p2) => {
+            DTDPattern::Group(
+                Box::new(p1),
+                Box::new(p2)
+            )
+        }
+    }
+}
+
+pub fn apply_after<F1>(pat: DTDPattern, f: F1) -> DTDPattern
+where
+    F1: Fn(DTDPattern) -> DTDPattern + Clone,
+{
+    match pat {
+        DTDPattern::After(pat1, pat2) => {
+            after(*pat1, f(*pat2))
+        }
+        DTDPattern::Choice(pat1, pat2) => {
+            choice(
+                apply_after(*pat1, f.clone()),
+                apply_after(*pat2, f)
+            )
+        }
+        _ => DTDPattern::NotAllowed
+    }
+}
+
+fn value_match(pat: DTDPattern, s: String) -> bool {
+    (is_nullable(pat.clone()) && whitespace(s.clone())) || is_nullable(text_deriv(pat, s))
+}
+
+fn text_deriv(pat: DTDPattern, s: String) -> DTDPattern {
+    match pat{
+        DTDPattern::Choice(pat1, pat2) => {
+            choice(
+                text_deriv(*pat1, s.clone()),
+                text_deriv(*pat2, s)
+            )
+        }
+        DTDPattern::Interleave(pat1, pat2) => {
+            choice(
+                interleave(
+                    text_deriv(*pat1.clone(), s.clone()),
+                    *pat2.clone()
+                ),
+                interleave(
+                    *pat1,
+                    text_deriv(*pat2, s.clone())
+                ),
+            )
+        }
+        DTDPattern::Group(pat1, pat2) => {
+            let p = group(
+                text_deriv(*pat1, s.clone()),
+                *pat2.clone()
+            );
+            if is_nullable(p.clone()){
+                choice(
+                    p,
+                    text_deriv(*pat2, s)
+                )
+            } else {
+                p
+            }
+        }
+        DTDPattern::After(pat1, pat2) => {
+            after(
+                text_deriv(*pat1, s),
+                *pat2
+            )
+        }
+        DTDPattern::OneOrMore(pat1) => {
+            group(
+                text_deriv(*pat1.clone(), s),
+                choice(
+                    *pat1,
+                    DTDPattern::Empty
+                )
+            )
+        }
+        DTDPattern::List(pat1) => {
+            if is_nullable(list_deriv(*pat1, s.split(' ').map(|st| st.to_string()).collect())){
+                DTDPattern::Empty
+            } else {
+                DTDPattern::NotAllowed
+            }
+        }
+        DTDPattern::Value(val) => {
+            if s == val {
+                DTDPattern::Empty
+            } else {
+                DTDPattern::NotAllowed
+            }
+        }
+        //textDeriv cx1 (Value dt value cx2) s = if datatypeEqual dt value cx2 s cx1 then Empty else NotAllowed
+        DTDPattern::Text => pat,
+        DTDPattern::Empty => DTDPattern::NotAllowed,
+        DTDPattern::NotAllowed => DTDPattern::NotAllowed,
+        DTDPattern::Attribute(_, _) => DTDPattern::NotAllowed,
+        DTDPattern::Element(_, _) => DTDPattern::NotAllowed,
+        DTDPattern::Ref(_) => DTDPattern::NotAllowed
+    }
+}
+
+fn list_deriv(p: DTDPattern, vs: Vec<String>) -> DTDPattern {
+    let mut vsi = vs.into_iter();
+    match vsi.next() {
+        None => p,
+        Some(p1) => list_deriv(text_deriv(p, p1), vsi.collect()),
+    }
+}
+
+pub(crate) fn child_deriv(pat: DTDPattern, n: impl Node, dtd: DTD) -> DTDPattern {
+    //println!("child_deriv");
+    //println!("    {:?}", &pat);
+    //println!("    {:?}", &n);
+    match n.node_type(){
+        NodeType::Document => DTDPattern::NotAllowed,
+        NodeType::Attribute => DTDPattern::NotAllowed,
+        NodeType::Comment => DTDPattern::NotAllowed,
+        NodeType::ProcessingInstruction => DTDPattern::NotAllowed,
+        NodeType::Reference => DTDPattern::NotAllowed,
+        NodeType::Namespace => DTDPattern::NotAllowed,
+        NodeType::Unknown => DTDPattern::NotAllowed,
+        NodeType::Text => text_deriv(pat, n.to_string()),
+        NodeType::Element => {
+            let mut pat1 = start_tag_open_deriv(pat, n.name().as_ref().clone(), dtd.clone());
+            for attribute in n.attribute_iter(){
+                pat1 = att_deriv(pat1, attribute)
+            };
+            pat1 = start_tag_close_deriv(pat1);
+            //println!("    STOD{:?}", &pat1);
+            pat1 = children_deriv(pat1, n, dtd);
+            //println!("    CHDE-{:?}", &pat1);
+            pat1 = end_tag_deriv(pat1);
+            //println!("    ETD-{:?}", &pat1);
+            pat1
+        }
+    }
+}
+
+fn start_tag_open_deriv(pat: DTDPattern, qn: QualifiedName, dtd: DTD) -> DTDPattern {
+    //println!("start_tag_open_deriv");
+    //println!("    {:?}", &pat);
+    //println!("    {:?}", &qn);
+    match pat {
+        DTDPattern::Ref(q) => {
+            match dtd.patterns.get(&q) {
+                None => DTDPattern::NotAllowed,
+                Some(p1) => start_tag_open_deriv(p1.clone(), qn, dtd)
+            }
+        }
+        DTDPattern::Element(nc, pat1) => {
+            if contains(nc, qn){
+                //TODO THE ERROR MIGHT BE HERE????
+
+                after(
+                    *pat1,
+                    DTDPattern::Empty
+                )
+            } else {
+                DTDPattern::NotAllowed
+            }
+        }
+        DTDPattern::Choice(pat1, pat2) => {
+            let x = choice(
+                start_tag_open_deriv(*pat1, qn.clone(), dtd.clone()),
+                start_tag_open_deriv(*pat2, qn, dtd)
+            );
+            //println!("x-{:?}", &x);
+            x
+        }
+        DTDPattern::Interleave(pat1, pat2) => {
+            choice(
+                apply_after(
+                    start_tag_open_deriv(*pat1.clone(), qn.clone(), dtd.clone()),
+                    |p: DTDPattern| {DTDPattern::Interleave(Box::new(p), pat2.clone())}
+                ),
+                apply_after(
+                    start_tag_open_deriv(*pat2.clone(), qn.clone(), dtd),
+                    |p: DTDPattern| {DTDPattern::Interleave(Box::new(p), pat1.clone())}
+                ),
+            )
+        }
+        DTDPattern::Group(pat1, pat2) => {
+            let x = apply_after(
+                start_tag_open_deriv(*pat1.clone(), qn.clone(), dtd.clone()),
+                |pat| {group(pat, *pat2.clone())}
+            );
+            if is_nullable(*pat1){
+                choice(
+                    x,
+                    start_tag_open_deriv(*pat2, qn, dtd)
+                )
+            } else {
+                x
+            }
+        }
+        DTDPattern::OneOrMore(pat1) => {
+            apply_after(
+                start_tag_open_deriv(*pat1.clone(), qn, dtd),
+                |pt|{
+                    group(
+                        pt,
+                        choice(
+                            DTDPattern::OneOrMore(pat1.clone()),
+                            DTDPattern::Empty
+                        )
+                    )
+                }
+            )
+        }
+        DTDPattern::After(pat1, pat2) => {
+            apply_after(
+                start_tag_open_deriv(*pat1, qn, dtd),
+                |p| {after(p, *pat2.clone())}
+            )
+        }
+        DTDPattern::Value(_) => DTDPattern::NotAllowed,
+        DTDPattern::Empty => DTDPattern::NotAllowed,
+        DTDPattern::NotAllowed => DTDPattern::NotAllowed,
+        DTDPattern::Text => DTDPattern::NotAllowed,
+        DTDPattern::List(_) => DTDPattern::NotAllowed,
+        DTDPattern::Attribute(_, _) => DTDPattern::NotAllowed,
+
+    }
+}
+
+fn att_deriv(pat: DTDPattern, att: impl Node) -> DTDPattern {
+    //println!("att_deriv");
+    //println!("    {:?}", &pat);
+    //println!("    {:?}", &att);
+    match pat{
+        DTDPattern::Choice(pat1, pat2) => {
+            choice(
+                att_deriv(*pat1, att.clone()),
+                att_deriv(*pat2, att.clone()),
+            )
+        }
+        DTDPattern::Interleave(pat1, pat2) => {
+            choice(
+                interleave(
+                    att_deriv(*pat1.clone(), att.clone()),
+                    *pat2.clone()
+                ),
+                interleave(
+                    att_deriv(*pat2.clone(), att),
+                    *pat1
+                )
+            )
+        }
+        DTDPattern::Group(pat1, pat2) => {
+            choice(
+                group(
+                    att_deriv(*pat1.clone(), att.clone()),
+                    *pat2.clone()
+                ),
+                group(
+                    att_deriv(*pat2.clone(), att.clone()),
+                    *pat1
+                )
+            )
+        }
+        DTDPattern::OneOrMore(pat1) => {
+            group(
+                att_deriv(*pat1.clone(), att),
+                choice(
+                    *pat1,
+                    DTDPattern::Empty
+                )
+            )
+        }
+        DTDPattern::After(pat1, pat2) => {
+            after(
+                att_deriv(*pat1, att),
+                *pat2
+            )
+        }
+        DTDPattern::Attribute(nc , pat1) => {
+            if contains(nc,  att.name().as_ref().clone()) && value_match(*pat1, att.value().to_string()) {
+                DTDPattern::Empty
+            } else {
+                DTDPattern::NotAllowed
+            }
+        }
+        DTDPattern::Value(_) => DTDPattern::NotAllowed,
+        DTDPattern::Empty => DTDPattern::NotAllowed,
+        DTDPattern::NotAllowed => DTDPattern::NotAllowed,
+        DTDPattern::Text => DTDPattern::NotAllowed,
+        DTDPattern::List(_) => DTDPattern::NotAllowed,
+        DTDPattern::Element(_, _) => DTDPattern::NotAllowed,
+        DTDPattern::Ref(_) => DTDPattern::NotAllowed
+    }
+}
+
+fn start_tag_close_deriv(pat: DTDPattern) -> DTDPattern {
+    //println!("start_tag_close_deriv");
+    //println!("    {:?}", &pat);
+    match pat{
+        DTDPattern::Choice(pat1, pat2) => {
+            choice(
+                start_tag_close_deriv(*pat1),
+                start_tag_close_deriv(*pat2)
+            )
+        }
+        DTDPattern::Interleave(pat1, pat2) => {
+            interleave(
+                start_tag_close_deriv(*pat1),
+                start_tag_close_deriv(*pat2)
+            )
+        }
+        DTDPattern::Group(pat1, pat2) => {
+            group(
+                start_tag_close_deriv(*pat1),
+                start_tag_close_deriv(*pat2)
+            )
+        }
+        DTDPattern::OneOrMore(pat1) => {
+            match start_tag_close_deriv(*pat1.clone()) {
+                DTDPattern::NotAllowed => DTDPattern::NotAllowed,
+                _ => DTDPattern::OneOrMore(Box::new(start_tag_close_deriv(*pat1)))
+            }
+        }
+        DTDPattern::After(pat1, pat2) => {
+            after(
+                start_tag_close_deriv(*pat1),
+                *pat2
+            )
+        }
+        DTDPattern::Attribute(_, _) => DTDPattern::NotAllowed,
+        DTDPattern::Value(_) => pat,
+        DTDPattern::Empty => pat,
+        DTDPattern::NotAllowed => pat,
+        DTDPattern::Text => pat,
+        DTDPattern::List(_) => pat,
+        DTDPattern::Element(_, _) => pat,
+        DTDPattern::Ref(_) => pat
+    }
+}
+
+fn children_deriv(pat: DTDPattern, cn: impl Node, dtd: DTD) -> DTDPattern {
+    //println!("children_deriv");
+    //println!("    {:?}", &pat);
+    //println!("    {:?}", cn.child_iter().collect::<Vec<_>>());
+    //Filter out comments, processing instructions, empty text nodes
+    let children: Vec<_> = cn.child_iter().filter(
+        |node| {
+            node.node_type() != NodeType::ProcessingInstruction
+                &&  node.node_type() != NodeType::Comment
+                && !(node.node_type() == NodeType::Text && whitespace(node.value().to_string()))
+        }
+    ).collect();
+    //println!("children_deriv_children-{:?}", &children);
+    match children.len(){
+        0 => {
+            choice(pat.clone(), text_deriv(pat, "".to_string()))
+        },
+        1 => {
+            match children[0].node_type() {
+                NodeType::Text => {
+                    let p1 = child_deriv(pat.clone(), children[0].clone(), dtd);
+                    if whitespace(children[0].value().to_string()){
+                        choice(pat, p1)
+                    } else {
+                        p1
+                    }
+                }
+                _ => {
+                    strip_children_deriv(pat, children, dtd)
+                }
+            }
+        }
+        _ => strip_children_deriv(pat, cn.child_iter().filter(
+            |node| {
+                node.node_type() != NodeType::ProcessingInstruction
+                    &&  node.node_type() != NodeType::Comment
+                    && !(node.node_type() == NodeType::Text && node.value().to_string() == "".to_string())
+            }
+        ).map(|c| c.clone()).collect(), dtd),
+    }
+}
+
+fn end_tag_deriv(pat: DTDPattern) -> DTDPattern {
+    //println!("end_tag_deriv");
+    //println!("    {:?}", &pat);
+    match pat {
+        DTDPattern::Choice(pat1, pat2) => {
+            choice(
+                end_tag_deriv(*pat1),
+                end_tag_deriv(*pat2)
+            )
+        }
+        DTDPattern::After(pat1, pat2) => {
+            if is_nullable(*pat1) {
+                *pat2
+            } else {
+                DTDPattern::NotAllowed
+            }
+        }
+        _ => DTDPattern::NotAllowed
+    }
+}
+
+fn strip_children_deriv<T>(pat: DTDPattern, cnodes: Vec<T> , dtd: DTD) -> DTDPattern
+where
+    T: Node
+{
+    let mut ci = cnodes.iter();
+    match ci.next() {
+        None => pat,
+        Some(h) => {
+            strip_children_deriv(
+                if strip(h.clone()){
+                    pat
+                } else {
+                    child_deriv(pat, h.clone(), dtd.clone())
+                },
+                ci.map(|c| c.clone()).collect(),
+                dtd
+            )
+        }
+    }
+}
+
+fn whitespace(s: String) -> bool {
+    s.chars().all(char::is_whitespace)
+}
+fn strip(c: impl Node) -> bool {
+    match c.node_type() {
+        NodeType::Text => whitespace(c.value().to_string()),
+        _ => false,
+    }
+}

--- a/src/validators/dtd/mod.rs
+++ b/src/validators/dtd/mod.rs
@@ -1,0 +1,45 @@
+mod derive;
+
+use crate::item::NodeType;
+use crate::Node;
+use crate::validators::{ValidationError};
+use crate::validators::dtd::derive::{is_nullable,child_deriv};
+
+pub(crate) fn validate_dtd(doc: impl Node) -> Result<(), ValidationError>{
+    match doc.node_type(){
+        NodeType::Document => {
+            match doc.get_dtd() {
+                None => Err(ValidationError::DocumentError("No DTD Information on the document".to_string())),
+                Some(dtd) => {
+                    match &dtd.name{
+                        None => Err(ValidationError::DocumentError("Document name not found in DTD".to_string())),
+                        Some(n) => {
+                            match dtd.patterns.get(n){
+                                None => {
+                                    Err(ValidationError::DocumentError("Element Declaration not found.".to_string()))
+                                }
+                                Some(pat) => {
+                                    //println!("pat-{:?}", pat);
+                                    //for pt in &dtd.patterns {
+                                    //    println!("{:?}", pt)
+                                    //}
+                                    match is_nullable(child_deriv(pat.clone(), doc.child_iter().filter( |node| {
+                                        node.node_type() != NodeType::ProcessingInstruction
+                                            &&  node.node_type() != NodeType::Comment
+                                            && !(node.node_type() == NodeType::Text && node.value().to_string() == "".to_string())
+                                    }).next().unwrap(), dtd)){
+                                        true => Ok(()),
+                                        false => Err(ValidationError::SchemaError("Invalid".to_string()))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        _ => {
+            Err(ValidationError::DocumentError("Node provided was not a document".to_string()))
+        }
+    }
+}

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -1,30 +1,33 @@
-pub mod relaxng;
 
-use crate::item::Node;
-use crate::trees::smite::RNode;
-use crate::parser::xml;
-use crate::validators::relaxng::validate_relaxng;
+pub mod dtd;
 
+use crate::item::{Node, NodeType};
+use crate::validators::dtd::validate_dtd;
 
-pub(crate) enum Schema{
-    //Schematron(String), //Schema File
-    //XMLSchema(schemafile)
-    RelaxNG(String) //Schema File
-    //DTD //How do we pull the DTD? Store on doc while parsing?
+#[derive(Clone)]
+pub enum Schema{
+    DTD
+    //Will add the rest as they become available.
 }
 
+#[derive(Debug)]
 pub enum ValidationError{
     DocumentError(String),
     SchemaError(String)
 }
 
 
-pub(crate) fn validate(doc: &RNode, s: Schema) -> Result<(), ValidationError>  {
-    match s {
-        Schema::RelaxNG(schema) => {
-            let schemadoc = RNode::new_document();
-            let _ = xml::parse(schemadoc.clone(), schema.as_str(), None);
-            validate_relaxng(doc, &schemadoc)
+pub(crate) fn validate(doc: &impl Node, schema: Schema) -> Result<(), ValidationError>{
+    match doc.node_type(){
+        NodeType::Document => {
+            match schema {
+                Schema::DTD => {
+                    validate_dtd(doc.clone())
+                }
+            }
+        }
+        _ => {
+            Err(ValidationError::DocumentError("Node provided was not a document".to_string()))
         }
     }
 }

--- a/tests/conformance/xml/eduni_errata2e_invalid.rs
+++ b/tests/conformance/xml/eduni_errata2e_invalid.rs
@@ -9,6 +9,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::{xml, ParserConfig};
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 #[ignore]
@@ -29,7 +30,13 @@ fn rmte2e2a() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -51,10 +58,17 @@ fn rmte2e2b() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn rmte2e9b() {
     /*
         Test ID:rmt-e2e-9b
@@ -72,7 +86,13 @@ fn rmte2e9b() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -98,6 +118,7 @@ fn rmte2e14() {
     );
 
     assert!(parseresult.is_err());
+
 }
 
 #[test]
@@ -119,7 +140,13 @@ fn rmte2e15a() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -141,7 +168,13 @@ fn rmte2e15b() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -163,7 +196,13 @@ fn rmte2e15c() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -185,7 +224,13 @@ fn rmte2e15d() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -207,7 +252,13 @@ fn rmte2e15g() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -229,7 +280,13 @@ fn rmte2e15h() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -251,5 +308,11 @@ fn rmte2e20() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }

--- a/tests/conformance/xml/eduni_errata2e_valid.rs
+++ b/tests/conformance/xml/eduni_errata2e_valid.rs
@@ -9,6 +9,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::{xml, ParserConfig};
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 #[ignore]
@@ -30,6 +31,12 @@ fn rmte2e9a() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -51,6 +58,12 @@ fn rmte2e15e() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -72,6 +85,12 @@ fn rmte2e15f() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -93,6 +112,12 @@ fn rmte2e15i() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -114,6 +139,12 @@ fn rmte2e15j() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -135,6 +166,12 @@ fn rmte2e15k() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -156,6 +193,12 @@ fn rmte2e15l() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -187,10 +230,17 @@ fn rmte2e18() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -222,10 +272,17 @@ fn rmte2e19() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -248,6 +305,12 @@ fn rmte2e22() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -269,6 +332,12 @@ fn rmte2e24() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -290,6 +359,12 @@ fn rmte2e29() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -312,6 +387,12 @@ fn rmte2e36() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -333,6 +414,12 @@ fn rmte2e41() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -354,6 +441,12 @@ fn rmte2e48() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -376,6 +469,12 @@ fn rmte2e50() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -401,4 +500,10 @@ fn rmte2e60() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }

--- a/tests/conformance/xml/eduni_errata3e_valid.rs
+++ b/tests/conformance/xml/eduni_errata3e_valid.rs
@@ -6,6 +6,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::xml;
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 fn rmte3e05a() {
@@ -26,6 +27,12 @@ fn rmte3e05a() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -47,6 +54,12 @@ fn rmte3e05b() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -69,4 +82,10 @@ fn rmte3e06i() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }

--- a/tests/conformance/xml/eduni_errata4e_invalid.rs
+++ b/tests/conformance/xml/eduni_errata4e_invalid.rs
@@ -8,8 +8,10 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::xml;
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
+#[ignore]
 fn invalidbo1() {
     /*
         Test ID:invalid-bo-1
@@ -27,10 +29,17 @@ fn invalidbo1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn invalidbo2() {
     /*
         Test ID:invalid-bo-2
@@ -48,10 +57,16 @@ fn invalidbo2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
+#[ignore]
 fn invalidbo3() {
     /*
         Test ID:invalid-bo-3
@@ -69,10 +84,17 @@ fn invalidbo3() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn invalidbo4() {
     /*
         Test ID:invalid-bo-4
@@ -90,10 +112,17 @@ fn invalidbo4() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn invalidbo5() {
     /*
         Test ID:invalid-bo-5
@@ -111,10 +140,17 @@ fn invalidbo5() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn invalidbo6() {
     /*
         Test ID:invalid-bo-6
@@ -132,7 +168,13 @@ fn invalidbo6() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 /*
@@ -304,7 +346,12 @@ fn ibminvalid_p89ibm89n06xml() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
@@ -326,7 +373,12 @@ fn ibminvalid_p89ibm89n07xml() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
@@ -348,7 +400,12 @@ fn ibminvalid_p89ibm89n08xml() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
@@ -370,7 +427,12 @@ fn ibminvalid_p89ibm89n09xml() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
@@ -392,7 +454,12 @@ fn ibminvalid_p89ibm89n10xml() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
@@ -414,7 +481,12 @@ fn ibminvalid_p89ibm89n11xml() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
@@ -436,5 +508,10 @@ fn ibminvalid_p89ibm89n12xml() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }

--- a/tests/conformance/xml/eduni_errata4e_valid.rs
+++ b/tests/conformance/xml/eduni_errata4e_valid.rs
@@ -8,6 +8,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::xml;
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 fn xrmt008b() {
@@ -28,6 +29,11 @@ fn xrmt008b() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -49,6 +55,11 @@ fn xrmt5014a() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -71,9 +82,15 @@ fn xibm105valid_p04ibm04v01xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
+#[ignore]
 fn xibm105valid_p04ibm04av01xml() {
     /*
         Test ID:x-ibm-1-0.5-valid-P04-ibm04av01.xml
@@ -92,6 +109,11 @@ fn xibm105valid_p04ibm04av01xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -114,6 +136,11 @@ fn xibm105valid_p05ibm05v01xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -140,6 +167,11 @@ fn xibm105valid_p05ibm05v02xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -166,6 +198,11 @@ fn xibm105valid_p05ibm05v03xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -187,6 +224,11 @@ fn xibm105valid_p05ibm05v04xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -209,6 +251,11 @@ fn xibm105valid_p05ibm05v05xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -230,6 +277,11 @@ fn xibm105valid_p047ibm07v01xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -251,6 +303,11 @@ fn ibmvalid_p85ibm85n03xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -272,6 +329,11 @@ fn ibmvalid_p85ibm85n04xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -293,6 +355,11 @@ fn ibmvalid_p85ibm85n05xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -314,6 +381,11 @@ fn ibmvalid_p85ibm85n06xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -335,6 +407,11 @@ fn ibmvalid_p85ibm85n07xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -356,6 +433,11 @@ fn ibmvalid_p85ibm85n08xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -377,6 +459,11 @@ fn ibmvalid_p85ibm85n09xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -398,6 +485,11 @@ fn ibmvalid_p85ibm85n10xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -419,6 +511,11 @@ fn ibmvalid_p85ibm85n100xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -440,6 +537,11 @@ fn ibmvalid_p85ibm85n101xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -461,6 +563,11 @@ fn ibmvalid_p85ibm85n102xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -482,6 +589,11 @@ fn ibmvalid_p85ibm85n103xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -503,6 +615,11 @@ fn ibmvalid_p85ibm85n104xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -524,6 +641,11 @@ fn ibmvalid_p85ibm85n105xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -545,6 +667,11 @@ fn ibmvalid_p85ibm85n106xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -566,6 +693,11 @@ fn ibmvalid_p85ibm85n107xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -587,6 +719,11 @@ fn ibmvalid_p85ibm85n108xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -608,6 +745,11 @@ fn ibmvalid_p85ibm85n109xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -629,6 +771,11 @@ fn ibmvalid_p85ibm85n11xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -650,6 +797,11 @@ fn ibmvalid_p85ibm85n110xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -671,6 +823,11 @@ fn ibmvalid_p85ibm85n111xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -692,6 +849,11 @@ fn ibmvalid_p85ibm85n112xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -713,6 +875,11 @@ fn ibmvalid_p85ibm85n113xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -734,6 +901,11 @@ fn ibmvalid_p85ibm85n114xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -755,6 +927,11 @@ fn ibmvalid_p85ibm85n115xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -776,6 +953,11 @@ fn ibmvalid_p85ibm85n116xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -797,6 +979,11 @@ fn ibmvalid_p85ibm85n117xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -818,6 +1005,11 @@ fn ibmvalid_p85ibm85n118xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -839,6 +1031,11 @@ fn ibmvalid_p85ibm85n119xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -860,6 +1057,11 @@ fn ibmvalid_p85ibm85n12xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -881,6 +1083,11 @@ fn ibmvalid_p85ibm85n120xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -902,6 +1109,11 @@ fn ibmvalid_p85ibm85n121xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -923,6 +1135,11 @@ fn ibmvalid_p85ibm85n122xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -944,6 +1161,11 @@ fn ibmvalid_p85ibm85n123xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -965,6 +1187,11 @@ fn ibmvalid_p85ibm85n124xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -986,6 +1213,11 @@ fn ibmvalid_p85ibm85n125xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1007,6 +1239,11 @@ fn ibmvalid_p85ibm85n126xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1028,6 +1265,11 @@ fn ibmvalid_p85ibm85n127xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1049,6 +1291,11 @@ fn ibmvalid_p85ibm85n128xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1070,6 +1317,11 @@ fn ibmvalid_p85ibm85n129xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1091,6 +1343,11 @@ fn ibmvalid_p85ibm85n13xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1112,6 +1369,11 @@ fn ibmvalid_p85ibm85n130xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1133,6 +1395,11 @@ fn ibmvalid_p85ibm85n131xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1154,6 +1421,11 @@ fn ibmvalid_p85ibm85n132xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1175,6 +1447,11 @@ fn ibmvalid_p85ibm85n133xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1196,6 +1473,11 @@ fn ibmvalid_p85ibm85n134xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1217,6 +1499,11 @@ fn ibmvalid_p85ibm85n135xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1238,6 +1525,11 @@ fn ibmvalid_p85ibm85n136xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1259,6 +1551,11 @@ fn ibmvalid_p85ibm85n137xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1280,6 +1577,11 @@ fn ibmvalid_p85ibm85n138xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1301,6 +1603,11 @@ fn ibmvalid_p85ibm85n139xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1322,6 +1629,11 @@ fn ibmvalid_p85ibm85n14xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1343,6 +1655,11 @@ fn ibmvalid_p85ibm85n140xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1364,6 +1681,11 @@ fn ibmvalid_p85ibm85n141xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1385,6 +1707,11 @@ fn ibmvalid_p85ibm85n142xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1406,6 +1733,11 @@ fn ibmvalid_p85ibm85n143xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1427,6 +1759,11 @@ fn ibmvalid_p85ibm85n144xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1448,6 +1785,11 @@ fn ibmvalid_p85ibm85n145xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1469,6 +1811,11 @@ fn ibmvalid_p85ibm85n146xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1490,6 +1837,11 @@ fn ibmvalid_p85ibm85n147xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1511,6 +1863,11 @@ fn ibmvalid_p85ibm85n148xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1532,6 +1889,11 @@ fn ibmvalid_p85ibm85n149xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1553,6 +1915,11 @@ fn ibmvalid_p85ibm85n15xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1574,6 +1941,11 @@ fn ibmvalid_p85ibm85n150xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1595,6 +1967,11 @@ fn ibmvalid_p85ibm85n151xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1616,6 +1993,11 @@ fn ibmvalid_p85ibm85n152xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1637,6 +2019,11 @@ fn ibmvalid_p85ibm85n153xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1658,6 +2045,11 @@ fn ibmvalid_p85ibm85n154xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1679,6 +2071,11 @@ fn ibmvalid_p85ibm85n155xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1700,6 +2097,11 @@ fn ibmvalid_p85ibm85n156xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1721,6 +2123,11 @@ fn ibmvalid_p85ibm85n157xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1742,6 +2149,11 @@ fn ibmvalid_p85ibm85n158xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1763,6 +2175,11 @@ fn ibmvalid_p85ibm85n159xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1784,6 +2201,11 @@ fn ibmvalid_p85ibm85n16xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1805,6 +2227,11 @@ fn ibmvalid_p85ibm85n160xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1826,6 +2253,11 @@ fn ibmvalid_p85ibm85n161xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1847,6 +2279,11 @@ fn ibmvalid_p85ibm85n162xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1868,6 +2305,11 @@ fn ibmvalid_p85ibm85n163xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1889,6 +2331,11 @@ fn ibmvalid_p85ibm85n164xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1910,6 +2357,11 @@ fn ibmvalid_p85ibm85n165xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1931,6 +2383,11 @@ fn ibmvalid_p85ibm85n166xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1952,6 +2409,11 @@ fn ibmvalid_p85ibm85n167xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1973,6 +2435,11 @@ fn ibmvalid_p85ibm85n168xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -1994,6 +2461,11 @@ fn ibmvalid_p85ibm85n169xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2015,6 +2487,11 @@ fn ibmvalid_p85ibm85n17xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2036,6 +2513,11 @@ fn ibmvalid_p85ibm85n170xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2057,6 +2539,11 @@ fn ibmvalid_p85ibm85n171xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2078,6 +2565,11 @@ fn ibmvalid_p85ibm85n172xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2099,6 +2591,11 @@ fn ibmvalid_p85ibm85n173xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2120,6 +2617,11 @@ fn ibmvalid_p85ibm85n174xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2141,6 +2643,11 @@ fn ibmvalid_p85ibm85n175xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2162,6 +2669,11 @@ fn ibmvalid_p85ibm85n176xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2183,6 +2695,11 @@ fn ibmvalid_p85ibm85n177xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2204,6 +2721,11 @@ fn ibmvalid_p85ibm85n178xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2225,6 +2747,11 @@ fn ibmvalid_p85ibm85n179xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2246,6 +2773,11 @@ fn ibmvalid_p85ibm85n18xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2267,6 +2799,11 @@ fn ibmvalid_p85ibm85n180xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2288,6 +2825,11 @@ fn ibmvalid_p85ibm85n181xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2309,6 +2851,11 @@ fn ibmvalid_p85ibm85n182xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2330,6 +2877,11 @@ fn ibmvalid_p85ibm85n183xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2351,6 +2903,11 @@ fn ibmvalid_p85ibm85n184xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2372,6 +2929,11 @@ fn ibmvalid_p85ibm85n185xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2393,6 +2955,11 @@ fn ibmvalid_p85ibm85n186xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2414,6 +2981,11 @@ fn ibmvalid_p85ibm85n187xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2435,6 +3007,11 @@ fn ibmvalid_p85ibm85n188xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2456,6 +3033,11 @@ fn ibmvalid_p85ibm85n189xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2477,6 +3059,11 @@ fn ibmvalid_p85ibm85n19xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2498,6 +3085,11 @@ fn ibmvalid_p85ibm85n190xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2519,6 +3111,11 @@ fn ibmvalid_p85ibm85n191xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2540,6 +3137,11 @@ fn ibmvalid_p85ibm85n192xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2561,6 +3163,11 @@ fn ibmvalid_p85ibm85n193xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2582,6 +3189,11 @@ fn ibmvalid_p85ibm85n194xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2603,6 +3215,11 @@ fn ibmvalid_p85ibm85n195xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2624,6 +3241,11 @@ fn ibmvalid_p85ibm85n196xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2645,6 +3267,11 @@ fn ibmvalid_p85ibm85n197xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2666,6 +3293,11 @@ fn ibmvalid_p85ibm85n198xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2687,6 +3319,11 @@ fn ibmvalid_p85ibm85n20xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2708,6 +3345,11 @@ fn ibmvalid_p85ibm85n21xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2729,6 +3371,11 @@ fn ibmvalid_p85ibm85n22xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2750,6 +3397,11 @@ fn ibmvalid_p85ibm85n23xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2771,6 +3423,11 @@ fn ibmvalid_p85ibm85n24xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2792,6 +3449,11 @@ fn ibmvalid_p85ibm85n25xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2813,6 +3475,11 @@ fn ibmvalid_p85ibm85n26xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2834,6 +3501,11 @@ fn ibmvalid_p85ibm85n27xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2855,6 +3527,11 @@ fn ibmvalid_p85ibm85n28xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2876,6 +3553,11 @@ fn ibmvalid_p85ibm85n29xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2897,6 +3579,11 @@ fn ibmvalid_p85ibm85n30xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2918,6 +3605,11 @@ fn ibmvalid_p85ibm85n31xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2939,6 +3631,11 @@ fn ibmvalid_p85ibm85n32xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2960,6 +3657,11 @@ fn ibmvalid_p85ibm85n33xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -2981,6 +3683,11 @@ fn ibmvalid_p85ibm85n34xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3002,6 +3709,11 @@ fn ibmvalid_p85ibm85n35xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3023,6 +3735,11 @@ fn ibmvalid_p85ibm85n36xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3044,6 +3761,11 @@ fn ibmvalid_p85ibm85n37xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3065,6 +3787,11 @@ fn ibmvalid_p85ibm85n38xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3086,6 +3813,11 @@ fn ibmvalid_p85ibm85n39xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3107,6 +3839,11 @@ fn ibmvalid_p85ibm85n40xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3128,6 +3865,11 @@ fn ibmvalid_p85ibm85n41xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3149,6 +3891,11 @@ fn ibmvalid_p85ibm85n42xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3170,6 +3917,11 @@ fn ibmvalid_p85ibm85n43xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3191,6 +3943,11 @@ fn ibmvalid_p85ibm85n44xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3212,6 +3969,11 @@ fn ibmvalid_p85ibm85n45xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3233,6 +3995,11 @@ fn ibmvalid_p85ibm85n46xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3254,6 +4021,11 @@ fn ibmvalid_p85ibm85n47xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3275,6 +4047,11 @@ fn ibmvalid_p85ibm85n48xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3296,6 +4073,11 @@ fn ibmvalid_p85ibm85n49xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3317,6 +4099,11 @@ fn ibmvalid_p85ibm85n50xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3338,6 +4125,11 @@ fn ibmvalid_p85ibm85n51xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3359,6 +4151,11 @@ fn ibmvalid_p85ibm85n52xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3380,6 +4177,11 @@ fn ibmvalid_p85ibm85n53xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3401,6 +4203,11 @@ fn ibmvalid_p85ibm85n54xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3422,6 +4229,11 @@ fn ibmvalid_p85ibm85n55xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3443,6 +4255,11 @@ fn ibmvalid_p85ibm85n56xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3464,6 +4281,11 @@ fn ibmvalid_p85ibm85n57xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3485,6 +4307,11 @@ fn ibmvalid_p85ibm85n58xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3506,6 +4333,11 @@ fn ibmvalid_p85ibm85n59xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3527,6 +4359,11 @@ fn ibmvalid_p85ibm85n60xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3548,6 +4385,11 @@ fn ibmvalid_p85ibm85n61xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3569,6 +4411,11 @@ fn ibmvalid_p85ibm85n62xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3590,6 +4437,11 @@ fn ibmvalid_p85ibm85n63xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3611,6 +4463,11 @@ fn ibmvalid_p85ibm85n64xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3632,6 +4489,11 @@ fn ibmvalid_p85ibm85n65xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3653,6 +4515,11 @@ fn ibmvalid_p85ibm85n66xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3674,6 +4541,11 @@ fn ibmvalid_p85ibm85n67xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3695,6 +4567,11 @@ fn ibmvalid_p85ibm85n68xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3716,6 +4593,11 @@ fn ibmvalid_p85ibm85n69xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3737,6 +4619,11 @@ fn ibmvalid_p85ibm85n70xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3758,6 +4645,11 @@ fn ibmvalid_p85ibm85n71xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3779,6 +4671,11 @@ fn ibmvalid_p85ibm85n72xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3800,6 +4697,11 @@ fn ibmvalid_p85ibm85n73xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3821,6 +4723,11 @@ fn ibmvalid_p85ibm85n74xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3842,6 +4749,11 @@ fn ibmvalid_p85ibm85n75xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3863,6 +4775,11 @@ fn ibmvalid_p85ibm85n76xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3884,6 +4801,11 @@ fn ibmvalid_p85ibm85n77xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3905,6 +4827,11 @@ fn ibmvalid_p85ibm85n78xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3926,6 +4853,11 @@ fn ibmvalid_p85ibm85n79xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3947,6 +4879,11 @@ fn ibmvalid_p85ibm85n80xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3968,6 +4905,11 @@ fn ibmvalid_p85ibm85n81xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -3989,6 +4931,11 @@ fn ibmvalid_p85ibm85n82xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4010,6 +4957,11 @@ fn ibmvalid_p85ibm85n83xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4031,6 +4983,11 @@ fn ibmvalid_p85ibm85n84xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4052,6 +5009,11 @@ fn ibmvalid_p85ibm85n85xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4073,6 +5035,11 @@ fn ibmvalid_p85ibm85n86xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4094,6 +5061,11 @@ fn ibmvalid_p85ibm85n87xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4115,6 +5087,11 @@ fn ibmvalid_p85ibm85n88xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4136,6 +5113,11 @@ fn ibmvalid_p85ibm85n89xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4157,6 +5139,11 @@ fn ibmvalid_p85ibm85n90xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4178,6 +5165,11 @@ fn ibmvalid_p85ibm85n91xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4199,6 +5191,11 @@ fn ibmvalid_p85ibm85n92xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4220,6 +5217,11 @@ fn ibmvalid_p85ibm85n93xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4241,6 +5243,11 @@ fn ibmvalid_p85ibm85n94xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4262,6 +5269,11 @@ fn ibmvalid_p85ibm85n95xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4283,6 +5295,11 @@ fn ibmvalid_p85ibm85n96xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4304,6 +5321,11 @@ fn ibmvalid_p85ibm85n97xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4325,6 +5347,11 @@ fn ibmvalid_p85ibm85n98xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4346,6 +5373,11 @@ fn ibmvalid_p85ibm85n99xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4367,6 +5399,11 @@ fn ibmvalid_p86ibm86n01xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4388,6 +5425,11 @@ fn ibmvalid_p86ibm86n02xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4409,6 +5451,11 @@ fn ibmvalid_p86ibm86n03xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4430,6 +5477,11 @@ fn ibmvalid_p86ibm86n04xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4451,6 +5503,11 @@ fn ibmvalid_p87ibm87n01xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4472,6 +5529,11 @@ fn ibmvalid_p87ibm87n02xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4493,6 +5555,11 @@ fn ibmvalid_p87ibm87n03xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4514,6 +5581,11 @@ fn ibmvalid_p87ibm87n04xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4535,6 +5607,11 @@ fn ibmvalid_p87ibm87n05xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4556,6 +5633,11 @@ fn ibmvalid_p87ibm87n06xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4577,6 +5659,11 @@ fn ibmvalid_p87ibm87n07xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4598,6 +5685,11 @@ fn ibmvalid_p87ibm87n08xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4619,6 +5711,11 @@ fn ibmvalid_p87ibm87n09xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4640,6 +5737,11 @@ fn ibmvalid_p87ibm87n10xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4661,6 +5763,11 @@ fn ibmvalid_p87ibm87n11xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4682,6 +5789,11 @@ fn ibmvalid_p87ibm87n12xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4703,6 +5815,11 @@ fn ibmvalid_p87ibm87n13xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4724,6 +5841,11 @@ fn ibmvalid_p87ibm87n14xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4745,6 +5867,11 @@ fn ibmvalid_p87ibm87n15xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4766,6 +5893,11 @@ fn ibmvalid_p87ibm87n16xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4787,6 +5919,11 @@ fn ibmvalid_p87ibm87n17xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4808,6 +5945,11 @@ fn ibmvalid_p87ibm87n18xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4829,6 +5971,11 @@ fn ibmvalid_p87ibm87n19xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4850,6 +5997,11 @@ fn ibmvalid_p87ibm87n20xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4871,6 +6023,11 @@ fn ibmvalid_p87ibm87n21xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4892,6 +6049,11 @@ fn ibmvalid_p87ibm87n22xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4913,6 +6075,11 @@ fn ibmvalid_p87ibm87n23xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4934,6 +6101,11 @@ fn ibmvalid_p87ibm87n24xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4955,6 +6127,11 @@ fn ibmvalid_p87ibm87n25xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4976,6 +6153,11 @@ fn ibmvalid_p87ibm87n26xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -4997,6 +6179,11 @@ fn ibmvalid_p87ibm87n27xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5018,6 +6205,11 @@ fn ibmvalid_p87ibm87n28xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5039,6 +6231,11 @@ fn ibmvalid_p87ibm87n29xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5060,6 +6257,11 @@ fn ibmvalid_p87ibm87n30xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5081,6 +6283,11 @@ fn ibmvalid_p87ibm87n31xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5102,6 +6309,11 @@ fn ibmvalid_p87ibm87n32xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5123,6 +6335,11 @@ fn ibmvalid_p87ibm87n33xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5144,6 +6361,11 @@ fn ibmvalid_p87ibm87n34xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5165,6 +6387,11 @@ fn ibmvalid_p87ibm87n35xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5186,6 +6413,11 @@ fn ibmvalid_p87ibm87n36xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5207,6 +6439,11 @@ fn ibmvalid_p87ibm87n37xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5228,6 +6465,11 @@ fn ibmvalid_p87ibm87n38xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5249,6 +6491,11 @@ fn ibmvalid_p87ibm87n39xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5270,6 +6517,11 @@ fn ibmvalid_p87ibm87n40xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5291,6 +6543,11 @@ fn ibmvalid_p87ibm87n41xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5312,6 +6569,11 @@ fn ibmvalid_p87ibm87n42xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5333,6 +6595,11 @@ fn ibmvalid_p87ibm87n43xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5354,6 +6621,11 @@ fn ibmvalid_p87ibm87n44xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5375,6 +6647,11 @@ fn ibmvalid_p87ibm87n45xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5396,6 +6673,11 @@ fn ibmvalid_p87ibm87n46xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5417,6 +6699,11 @@ fn ibmvalid_p87ibm87n47xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5438,6 +6725,11 @@ fn ibmvalid_p87ibm87n48xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5459,6 +6751,11 @@ fn ibmvalid_p87ibm87n49xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5480,6 +6777,11 @@ fn ibmvalid_p87ibm87n50xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5501,6 +6803,11 @@ fn ibmvalid_p87ibm87n51xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5522,6 +6829,11 @@ fn ibmvalid_p87ibm87n52xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5543,6 +6855,11 @@ fn ibmvalid_p87ibm87n53xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5564,6 +6881,11 @@ fn ibmvalid_p87ibm87n54xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5585,6 +6907,11 @@ fn ibmvalid_p87ibm87n55xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5606,6 +6933,11 @@ fn ibmvalid_p87ibm87n56xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5627,6 +6959,11 @@ fn ibmvalid_p87ibm87n57xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5648,6 +6985,11 @@ fn ibmvalid_p87ibm87n58xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5669,6 +7011,11 @@ fn ibmvalid_p87ibm87n59xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5690,6 +7037,11 @@ fn ibmvalid_p87ibm87n60xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5711,6 +7063,11 @@ fn ibmvalid_p87ibm87n61xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5732,6 +7089,11 @@ fn ibmvalid_p87ibm87n62xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5753,6 +7115,11 @@ fn ibmvalid_p87ibm87n63xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5774,6 +7141,11 @@ fn ibmvalid_p87ibm87n64xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5795,6 +7167,11 @@ fn ibmvalid_p87ibm87n66xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5816,6 +7193,11 @@ fn ibmvalid_p87ibm87n67xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5837,6 +7219,11 @@ fn ibmvalid_p87ibm87n68xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5858,6 +7245,11 @@ fn ibmvalid_p87ibm87n69xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5879,6 +7271,11 @@ fn ibmvalid_p87ibm87n70xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5900,6 +7297,11 @@ fn ibmvalid_p87ibm87n71xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5921,6 +7323,11 @@ fn ibmvalid_p87ibm87n72xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5942,6 +7349,11 @@ fn ibmvalid_p87ibm87n73xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5963,6 +7375,11 @@ fn ibmvalid_p87ibm87n74xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -5984,6 +7401,11 @@ fn ibmvalid_p87ibm87n75xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6005,6 +7427,11 @@ fn ibmvalid_p87ibm87n76xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6026,6 +7453,11 @@ fn ibmvalid_p87ibm87n77xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6047,6 +7479,11 @@ fn ibmvalid_p87ibm87n78xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6068,6 +7505,11 @@ fn ibmvalid_p87ibm87n79xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6089,6 +7531,11 @@ fn ibmvalid_p87ibm87n80xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6110,6 +7557,11 @@ fn ibmvalid_p87ibm87n81xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6131,6 +7583,11 @@ fn ibmvalid_p87ibm87n82xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6152,6 +7609,11 @@ fn ibmvalid_p87ibm87n83xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6173,6 +7635,11 @@ fn ibmvalid_p87ibm87n84xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6194,6 +7661,11 @@ fn ibmvalid_p87ibm87n85xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6215,6 +7687,11 @@ fn ibmvalid_p88ibm88n03xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6236,6 +7713,11 @@ fn ibmvalid_p88ibm88n04xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6257,6 +7739,11 @@ fn ibmvalid_p88ibm88n05xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6278,6 +7765,11 @@ fn ibmvalid_p88ibm88n06xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6299,6 +7791,11 @@ fn ibmvalid_p88ibm88n08xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6320,6 +7817,11 @@ fn ibmvalid_p88ibm88n09xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6341,6 +7843,11 @@ fn ibmvalid_p88ibm88n10xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6362,6 +7869,11 @@ fn ibmvalid_p88ibm88n11xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6383,6 +7895,11 @@ fn ibmvalid_p88ibm88n12xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6404,6 +7921,11 @@ fn ibmvalid_p88ibm88n13xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6425,6 +7947,11 @@ fn ibmvalid_p88ibm88n14xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6446,6 +7973,11 @@ fn ibmvalid_p88ibm88n15xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6467,6 +7999,11 @@ fn ibmvalid_p88ibm88n16xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6488,6 +8025,11 @@ fn ibmvalid_p89ibm89n03xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6509,6 +8051,11 @@ fn ibmvalid_p89ibm89n04xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -6530,4 +8077,9 @@ fn ibmvalid_p89ibm89n05xml() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }

--- a/tests/conformance/xml/eduni_misc_invalid.rs
+++ b/tests/conformance/xml/eduni_misc_invalid.rs
@@ -8,6 +8,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::xml;
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 #[ignore]
@@ -28,7 +29,13 @@ fn hstbh005() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -50,5 +57,11 @@ fn hstbh006() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }

--- a/tests/conformance/xml/eduni_namespaces_10_invalid.rs
+++ b/tests/conformance/xml/eduni_namespaces_10_invalid.rs
@@ -8,9 +8,9 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::xml;
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
-#[ignore]
 fn rmtns10017() {
     /*
         Test ID:rmt-ns10-017
@@ -28,11 +28,16 @@ fn rmtns10017() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10018() {
     /*
         Test ID:rmt-ns10-018
@@ -50,11 +55,16 @@ fn rmtns10018() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10019() {
     /*
         Test ID:rmt-ns10-019
@@ -72,11 +82,16 @@ fn rmtns10019() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10020() {
     /*
         Test ID:rmt-ns10-020
@@ -94,11 +109,16 @@ fn rmtns10020() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10021() {
     /*
         Test ID:rmt-ns10-021
@@ -116,11 +136,16 @@ fn rmtns10021() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10022() {
     /*
         Test ID:rmt-ns10-022
@@ -138,11 +163,16 @@ fn rmtns10022() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10024() {
     /*
         Test ID:rmt-ns10-024
@@ -160,11 +190,16 @@ fn rmtns10024() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10027() {
     /*
         Test ID:rmt-ns10-027
@@ -182,11 +217,16 @@ fn rmtns10027() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10028() {
     /*
         Test ID:rmt-ns10-028
@@ -204,11 +244,16 @@ fn rmtns10028() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10034() {
     /*
         Test ID:rmt-ns10-034
@@ -226,11 +271,16 @@ fn rmtns10034() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10037() {
     /*
         Test ID:rmt-ns10-037
@@ -248,11 +298,16 @@ fn rmtns10037() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10038() {
     /*
         Test ID:rmt-ns10-038
@@ -270,11 +325,16 @@ fn rmtns10038() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10039() {
     /*
         Test ID:rmt-ns10-039
@@ -292,11 +352,16 @@ fn rmtns10039() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10040() {
     /*
         Test ID:rmt-ns10-040
@@ -314,11 +379,16 @@ fn rmtns10040() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn rmtns10041() {
     /*
         Test ID:rmt-ns10-041
@@ -336,7 +406,13 @@ fn rmtns10041() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -358,7 +434,13 @@ fn rmtns10045() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -380,5 +462,11 @@ fn rmtns10046() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }

--- a/tests/conformance/xml/eduni_namespaces_10_valid.rs
+++ b/tests/conformance/xml/eduni_namespaces_10_valid.rs
@@ -8,6 +8,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::xml;
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 fn rmtns10001() {
@@ -28,6 +29,12 @@ fn rmtns10001() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -49,6 +56,12 @@ fn rmtns10002() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -70,9 +83,16 @@ fn rmtns10003() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
+#[ignore]
 fn rmtns10007() {
     /*
         Test ID:rmt-ns10-007
@@ -91,9 +111,16 @@ fn rmtns10007() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
+#[ignore]
 fn rmtns10008() {
     /*
         Test ID:rmt-ns10-008
@@ -112,6 +139,12 @@ fn rmtns10008() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -133,6 +166,12 @@ fn htns10047() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -154,4 +193,10 @@ fn htns10048() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }

--- a/tests/conformance/xml/eduni_namespaces_11_valid.rs
+++ b/tests/conformance/xml/eduni_namespaces_11_valid.rs
@@ -6,6 +6,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::xml;
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 #[ignore]
@@ -27,6 +28,7 @@ fn rmtns11001() {
     );
 
     assert!(parseresult.is_ok());
+
 }
 
 #[test]
@@ -49,6 +51,12 @@ fn rmtns11002() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -70,6 +78,12 @@ fn rmtns11003() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -91,9 +105,16 @@ fn rmtns11004() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
+#[ignore]
 fn rmtns11006() {
     /*
         Test ID:rmt-ns11-006
@@ -112,4 +133,10 @@ fn rmtns11006() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }

--- a/tests/conformance/xml/eduni_xml11_invalid.rs
+++ b/tests/conformance/xml/eduni_xml11_invalid.rs
@@ -8,7 +8,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::xml;
 use xrust::trees::smite::RNode;
-
+use xrust::validators::Schema;
 /*
 #[test]
 fn rmt015() {
@@ -111,7 +111,12 @@ fn rmt030() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
@@ -133,7 +138,12 @@ fn rmt032() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
@@ -197,7 +207,12 @@ fn rmt046() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]

--- a/tests/conformance/xml/eduni_xml11_valid.rs
+++ b/tests/conformance/xml/eduni_xml11_valid.rs
@@ -9,6 +9,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::xml;
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 #[ignore]
@@ -39,10 +40,17 @@ fn rmt006() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -73,10 +81,17 @@ fn rmt007() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -106,10 +121,17 @@ fn rmt010() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -140,10 +162,17 @@ fn rmt012() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -173,10 +202,17 @@ fn rmt022() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -206,10 +242,17 @@ fn rmt023() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -240,10 +283,17 @@ fn rmt024() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -275,10 +325,17 @@ fn rmt025() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -310,10 +367,17 @@ fn rmt026() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -345,10 +409,17 @@ fn rmt027() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -380,10 +451,17 @@ fn rmt028() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -415,10 +493,17 @@ fn rmt029() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -448,10 +533,17 @@ fn rmt031() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -482,10 +574,17 @@ fn rmt033() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -516,10 +615,17 @@ fn rmt034() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -550,10 +656,17 @@ fn rmt035() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -583,10 +696,17 @@ fn rmt040() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -617,10 +737,17 @@ fn rmt043() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -651,10 +778,17 @@ fn rmt044() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -685,10 +819,17 @@ fn rmt045() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -718,10 +859,17 @@ fn rmt047() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -753,13 +901,21 @@ fn rmt049() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
+#[ignore]
 fn rmt050() {
     /*
         Test ID:rmt-050
@@ -787,13 +943,21 @@ fn rmt050() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
+#[ignore]
 fn rmt051() {
     /*
         Test ID:rmt-051
@@ -821,10 +985,17 @@ fn rmt051() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -856,8 +1027,15 @@ fn rmt054() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }

--- a/tests/conformance/xml/ibm11_valid.rs
+++ b/tests/conformance/xml/ibm11_valid.rs
@@ -9,6 +9,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::{xml, ParserConfig};
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 fn ibm11valid_p02ibm02v01xml() {
@@ -29,6 +30,8 @@ fn ibm11valid_p02ibm02v01xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -50,6 +53,8 @@ fn ibm11valid_p02ibm02v02xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -72,6 +77,8 @@ fn ibm11valid_p02ibm02v03xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -93,6 +100,8 @@ fn ibm11valid_p02ibm02v04xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -114,6 +123,8 @@ fn ibm11valid_p02ibm02v05xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -136,6 +147,8 @@ fn ibm11valid_p02ibm02v06xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -167,10 +180,17 @@ fn ibm11valid_p03ibm03v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -202,10 +222,17 @@ fn ibm11valid_p03ibm03v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -237,10 +264,17 @@ fn ibm11valid_p03ibm03v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -272,10 +306,17 @@ fn ibm11valid_p03ibm03v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -307,10 +348,17 @@ fn ibm11valid_p03ibm03v05xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -342,10 +390,17 @@ fn ibm11valid_p03ibm03v06xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -377,10 +432,17 @@ fn ibm11valid_p03ibm03v07xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -411,10 +473,17 @@ fn ibm11valid_p03ibm03v08xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -446,10 +515,17 @@ fn ibm11valid_p03ibm03v09xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -472,9 +548,12 @@ fn ibm11valid_p04ibm04v01xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
+#[ignore]
 fn ibm11valid_p04ibm04av01xml() {
     /*
         Test ID:ibm-1-1-valid-P04-ibm04av01.xml
@@ -493,6 +572,8 @@ fn ibm11valid_p04ibm04av01xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -515,6 +596,8 @@ fn ibm11valid_p05ibm05v01xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -537,6 +620,8 @@ fn ibm11valid_p05ibm05v02xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -559,6 +644,8 @@ fn ibm11valid_p05ibm05v03xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -580,6 +667,8 @@ fn ibm11valid_p05ibm05v04xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -602,6 +691,8 @@ fn ibm11valid_p05ibm05v05xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -623,6 +714,8 @@ fn ibm11valid_p047ibm07v01xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -649,6 +742,8 @@ fn ibm11valid_p77ibm77v01xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -675,6 +770,8 @@ fn ibm11valid_p77ibm77v02xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -701,6 +798,8 @@ fn ibm11valid_p77ibm77v03xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -723,6 +822,8 @@ fn ibm11valid_p77ibm77v04xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -745,6 +846,8 @@ fn ibm11valid_p77ibm77v05xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -767,6 +870,8 @@ fn ibm11valid_p77ibm77v06xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -793,6 +898,8 @@ fn ibm11valid_p77ibm77v07xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -819,6 +926,8 @@ fn ibm11valid_p77ibm77v08xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -845,6 +954,8 @@ fn ibm11valid_p77ibm77v09xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -867,6 +978,8 @@ fn ibm11valid_p77ibm77v10xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -889,6 +1002,8 @@ fn ibm11valid_p77ibm77v11xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -911,6 +1026,8 @@ fn ibm11valid_p77ibm77v12xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -937,6 +1054,8 @@ fn ibm11valid_p77ibm77v13xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -963,6 +1082,8 @@ fn ibm11valid_p77ibm77v14xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -989,6 +1110,8 @@ fn ibm11valid_p77ibm77v15xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1011,6 +1134,8 @@ fn ibm11valid_p77ibm77v16xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1033,6 +1158,8 @@ fn ibm11valid_p77ibm77v17xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1055,6 +1182,8 @@ fn ibm11valid_p77ibm77v18xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1081,6 +1210,8 @@ fn ibm11valid_p77ibm77v19xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1107,6 +1238,8 @@ fn ibm11valid_p77ibm77v20xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1133,6 +1266,8 @@ fn ibm11valid_p77ibm77v21xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1155,6 +1290,8 @@ fn ibm11valid_p77ibm77v22xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1177,6 +1314,8 @@ fn ibm11valid_p77ibm77v23xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1199,6 +1338,8 @@ fn ibm11valid_p77ibm77v24xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1225,6 +1366,8 @@ fn ibm11valid_p77ibm77v25xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1251,6 +1394,8 @@ fn ibm11valid_p77ibm77v26xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1277,6 +1422,8 @@ fn ibm11valid_p77ibm77v27xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1299,6 +1446,8 @@ fn ibm11valid_p77ibm77v28xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1321,6 +1470,8 @@ fn ibm11valid_p77ibm77v29xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }
 
 #[test]
@@ -1343,4 +1494,6 @@ fn ibm11valid_p77ibm77v30xml() {
     );
 
     assert!(parseresult.is_ok());
+    assert!(parseresult.unwrap().validate(Schema::DTD).is_ok())
+
 }

--- a/tests/conformance/xml/ibm_valid.rs
+++ b/tests/conformance/xml/ibm_valid.rs
@@ -10,6 +10,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::{xml, ParserConfig};
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 fn ibmvalid_p01ibm01v01xml() {
@@ -39,13 +40,20 @@ fn ibmvalid_p01ibm01v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p02ibm02v01xml() {
     /*
         Test ID:ibm-valid-P02-ibm02v01.xml
@@ -62,11 +70,32 @@ fn ibmvalid_p02ibm02v01xml() {
             .as_str(),
         None,
     );
+    let canonicalxml = RNode::new_document();
+    let canonicalparseresult = xml::parse(
+        canonicalxml,
+        fs::read_to_string("tests/conformance/xml/xmlconf/ibm/valid/P02/out/ibm02v01.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
 
     assert!(parseresult.is_ok());
+    assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
+    assert_eq!(
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
+    );
+
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p03ibm03v01xml() {
     /*
         Test ID:ibm-valid-P03-ibm03v01.xml
@@ -83,8 +112,28 @@ fn ibmvalid_p03ibm03v01xml() {
             .as_str(),
         None,
     );
+    let canonicalxml = RNode::new_document();
+    let canonicalparseresult = xml::parse(
+        canonicalxml,
+        fs::read_to_string("tests/conformance/xml/xmlconf/ibm/valid/P03/out/ibm03v01.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
 
     assert!(parseresult.is_ok());
+    assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
+    assert_eq!(
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
+    );
+
 }
 
 #[test]
@@ -115,8 +164,14 @@ fn ibmvalid_p09ibm09v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -149,8 +204,14 @@ fn ibmvalid_p09ibm09v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -184,8 +245,14 @@ fn ibmvalid_p09ibm09v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -218,8 +285,14 @@ fn ibmvalid_p09ibm09v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -253,8 +326,14 @@ fn ibmvalid_p09ibm09v05xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -287,8 +366,14 @@ fn ibmvalid_p10ibm10v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -321,8 +406,14 @@ fn ibmvalid_p10ibm10v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -355,8 +446,14 @@ fn ibmvalid_p10ibm10v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -389,8 +486,14 @@ fn ibmvalid_p10ibm10v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -423,8 +526,14 @@ fn ibmvalid_p10ibm10v05xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -457,8 +566,14 @@ fn ibmvalid_p10ibm10v06xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -491,8 +606,14 @@ fn ibmvalid_p10ibm10v07xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -525,8 +646,14 @@ fn ibmvalid_p10ibm10v08xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -560,8 +687,14 @@ fn ibmvalid_p11ibm11v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -595,8 +728,14 @@ fn ibmvalid_p11ibm11v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -634,8 +773,14 @@ fn ibmvalid_p11ibm11v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -673,8 +818,14 @@ fn ibmvalid_p11ibm11v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -708,8 +859,14 @@ fn ibmvalid_p12ibm12v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -743,8 +900,14 @@ fn ibmvalid_p12ibm12v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -778,8 +941,14 @@ fn ibmvalid_p12ibm12v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -813,8 +982,14 @@ fn ibmvalid_p12ibm12v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -848,8 +1023,14 @@ fn ibmvalid_p13ibm13v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -882,8 +1063,14 @@ fn ibmvalid_p14ibm14v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -950,8 +1137,14 @@ fn ibmvalid_p14ibm14v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -984,8 +1177,14 @@ fn ibmvalid_p15ibm15v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1018,8 +1217,14 @@ fn ibmvalid_p15ibm15v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1052,8 +1257,14 @@ fn ibmvalid_p15ibm15v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1086,8 +1297,14 @@ fn ibmvalid_p15ibm15v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1120,8 +1337,14 @@ fn ibmvalid_p16ibm16v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1154,8 +1377,14 @@ fn ibmvalid_p16ibm16v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1222,8 +1451,14 @@ fn ibmvalid_p17ibm17v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1290,8 +1525,14 @@ fn ibmvalid_p19ibm19v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1324,8 +1565,14 @@ fn ibmvalid_p20ibm20v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1392,8 +1639,14 @@ fn ibmvalid_p21ibm21v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1426,8 +1679,14 @@ fn ibmvalid_p22ibm22v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1460,8 +1719,14 @@ fn ibmvalid_p22ibm22v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1494,8 +1759,14 @@ fn ibmvalid_p22ibm22v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1528,8 +1799,14 @@ fn ibmvalid_p22ibm22v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1562,8 +1839,14 @@ fn ibmvalid_p22ibm22v05xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1596,8 +1879,14 @@ fn ibmvalid_p22ibm22v06xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1630,8 +1919,14 @@ fn ibmvalid_p22ibm22v07xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1664,8 +1959,14 @@ fn ibmvalid_p23ibm23v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1698,8 +1999,14 @@ fn ibmvalid_p23ibm23v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1732,8 +2039,14 @@ fn ibmvalid_p23ibm23v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1766,8 +2079,14 @@ fn ibmvalid_p23ibm23v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1800,8 +2119,14 @@ fn ibmvalid_p23ibm23v05xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1834,8 +2159,14 @@ fn ibmvalid_p23ibm23v06xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1868,8 +2199,14 @@ fn ibmvalid_p24ibm24v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1902,8 +2239,14 @@ fn ibmvalid_p24ibm24v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1936,8 +2279,14 @@ fn ibmvalid_p25ibm25v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1970,8 +2319,14 @@ fn ibmvalid_p25ibm25v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2004,8 +2359,14 @@ fn ibmvalid_p25ibm25v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2038,8 +2399,14 @@ fn ibmvalid_p25ibm25v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2072,8 +2439,14 @@ fn ibmvalid_p26ibm26v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2106,8 +2479,14 @@ fn ibmvalid_p27ibm27v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2140,8 +2519,14 @@ fn ibmvalid_p27ibm27v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2174,8 +2559,14 @@ fn ibmvalid_p27ibm27v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2208,8 +2599,14 @@ fn ibmvalid_p28ibm28v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2243,8 +2640,14 @@ fn ibmvalid_p28ibm28v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2278,8 +2681,14 @@ fn ibmvalid_p29ibm29v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2313,8 +2722,14 @@ fn ibmvalid_p29ibm29v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2352,8 +2767,14 @@ fn ibmvalid_p30ibm30v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2391,8 +2812,14 @@ fn ibmvalid_p30ibm30v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2430,8 +2857,14 @@ fn ibmvalid_p31ibm31v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2469,8 +2902,14 @@ fn ibmvalid_p32ibm32v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2508,8 +2947,14 @@ fn ibmvalid_p32ibm32v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2547,8 +2992,14 @@ fn ibmvalid_p32ibm32v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2582,8 +3033,14 @@ fn ibmvalid_p32ibm32v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2616,8 +3073,14 @@ fn ibmvalid_p33ibm33v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2650,8 +3113,14 @@ fn ibmvalid_p34ibm34v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2684,8 +3153,14 @@ fn ibmvalid_p35ibm35v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2718,8 +3193,14 @@ fn ibmvalid_p36ibm36v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2752,8 +3233,14 @@ fn ibmvalid_p37ibm37v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2786,8 +3273,14 @@ fn ibmvalid_p38ibm38v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2820,8 +3313,14 @@ fn ibmvalid_p39ibm39v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2854,13 +3353,20 @@ fn ibmvalid_p40ibm40v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p41ibm41v01xml() {
     /*
         Test ID:ibm-valid-P41-ibm41v01.xml
@@ -2888,8 +3394,14 @@ fn ibmvalid_p41ibm41v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2922,8 +3434,14 @@ fn ibmvalid_p42ibm42v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2957,13 +3475,20 @@ fn ibmvalid_p43ibm43v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p44ibm44v01xml() {
     /*
         Test ID:ibm-valid-P44-ibm44v01.xml
@@ -2991,13 +3516,20 @@ fn ibmvalid_p44ibm44v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p45ibm45v01xml() {
     /*
         Test ID:ibm-valid-P45-ibm45v01.xml
@@ -3025,8 +3557,14 @@ fn ibmvalid_p45ibm45v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3059,8 +3597,14 @@ fn ibmvalid_p47ibm47v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3098,8 +3642,14 @@ fn ibmvalid_p49ibm49v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3137,13 +3687,20 @@ fn ibmvalid_p50ibm50v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p51ibm51v01xml() {
     /*
         Test ID:ibm-valid-P51-ibm51v01.xml
@@ -3175,8 +3732,14 @@ fn ibmvalid_p51ibm51v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3214,13 +3777,20 @@ fn ibmvalid_p51ibm51v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p52ibm52v01xml() {
     /*
         Test ID:ibm-valid-P52-ibm52v01.xml
@@ -3248,8 +3818,14 @@ fn ibmvalid_p52ibm52v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3272,8 +3848,27 @@ fn ibmvalid_p54ibm54v01xml() {
             .as_str(),
         None,
     );
+    let canonicalxml = RNode::new_document();
+    let canonicalparseresult = xml::parse(
+        canonicalxml,
+        fs::read_to_string("tests/conformance/xml/xmlconf/ibm/valid/P54/out/ibm54v01.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
 
     assert!(parseresult.is_ok());
+    assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
+    assert_eq!(
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
+    );
 }
 
 #[test]
@@ -3304,8 +3899,14 @@ fn ibmvalid_p54ibm54v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3338,8 +3939,14 @@ fn ibmvalid_p54ibm54v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3372,8 +3979,14 @@ fn ibmvalid_p55ibm55v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3406,8 +4019,14 @@ fn ibmvalid_p56ibm56v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3440,8 +4059,14 @@ fn ibmvalid_p56ibm56v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3474,8 +4099,14 @@ fn ibmvalid_p56ibm56v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3508,8 +4139,14 @@ fn ibmvalid_p56ibm56v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3542,8 +4179,14 @@ fn ibmvalid_p56ibm56v05xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3576,8 +4219,14 @@ fn ibmvalid_p56ibm56v06xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3610,8 +4259,14 @@ fn ibmvalid_p56ibm56v07xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3645,8 +4300,14 @@ fn ibmvalid_p56ibm56v08xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3679,8 +4340,14 @@ fn ibmvalid_p56ibm56v09xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3713,13 +4380,20 @@ fn ibmvalid_p56ibm56v10xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p57ibm57v01xml() {
     /*
         Test ID:ibm-valid-P57-ibm57v01.xml
@@ -3747,8 +4421,14 @@ fn ibmvalid_p57ibm57v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3781,8 +4461,14 @@ fn ibmvalid_p58ibm58v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3815,8 +4501,14 @@ fn ibmvalid_p58ibm58v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3849,13 +4541,20 @@ fn ibmvalid_p59ibm59v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p59ibm59v02xml() {
     /*
         Test ID:ibm-valid-P59-ibm59v02.xml
@@ -3883,8 +4582,14 @@ fn ibmvalid_p59ibm59v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3917,8 +4622,14 @@ fn ibmvalid_p60ibm60v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3951,8 +4662,14 @@ fn ibmvalid_p60ibm60v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3985,8 +4702,14 @@ fn ibmvalid_p60ibm60v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4019,8 +4742,14 @@ fn ibmvalid_p60ibm60v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4058,8 +4787,14 @@ fn ibmvalid_p61ibm61v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4097,8 +4832,14 @@ fn ibmvalid_p61ibm61v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4136,8 +4877,14 @@ fn ibmvalid_p62ibm62v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4175,8 +4922,14 @@ fn ibmvalid_p62ibm62v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4214,8 +4967,14 @@ fn ibmvalid_p62ibm62v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4253,8 +5012,14 @@ fn ibmvalid_p62ibm62v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4292,8 +5057,14 @@ fn ibmvalid_p62ibm62v05xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4331,8 +5102,14 @@ fn ibmvalid_p63ibm63v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4370,8 +5147,14 @@ fn ibmvalid_p63ibm63v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4409,8 +5192,14 @@ fn ibmvalid_p63ibm63v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4448,8 +5237,14 @@ fn ibmvalid_p63ibm63v04xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4487,8 +5282,14 @@ fn ibmvalid_p63ibm63v05xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4526,8 +5327,14 @@ fn ibmvalid_p64ibm64v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4565,8 +5372,14 @@ fn ibmvalid_p64ibm64v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4604,8 +5417,14 @@ fn ibmvalid_p64ibm64v03xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4643,8 +5462,14 @@ fn ibmvalid_p65ibm65v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4682,13 +5507,20 @@ fn ibmvalid_p65ibm65v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p66ibm66v01xml() {
     /*
         Test ID:ibm-valid-P66-ibm66v01.xml
@@ -4716,13 +5548,15 @@ fn ibmvalid_p66ibm66v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
-    //    assert_eq!(
-    //        parseresult.unwrap().get_canonical().unwrap(),
-    //        canonicalparseresult.unwrap()
-    //    );
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
@@ -4754,8 +5588,14 @@ fn ibmvalid_p67ibm67v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4789,8 +5629,14 @@ fn ibmvalid_p68ibm68v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4824,8 +5670,14 @@ fn ibmvalid_p68ibm68v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4859,8 +5711,14 @@ fn ibmvalid_p69ibm69v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4894,8 +5752,14 @@ fn ibmvalid_p69ibm69v02xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4929,8 +5793,14 @@ fn ibmvalid_p70ibm70v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4964,8 +5834,14 @@ fn ibmvalid_p78ibm78v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4988,8 +5864,27 @@ fn ibmvalid_p79ibm79v01xml() {
             .as_str(),
         None,
     );
+    let canonicalxml = RNode::new_document();
+    let canonicalparseresult = xml::parse(
+        canonicalxml,
+        fs::read_to_string("tests/conformance/xml/xmlconf/ibm/valid/P79/out/ibm79v01.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
 
     assert!(parseresult.is_ok());
+    assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
+    assert_eq!(
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
+    );
 }
 
 #[test]
@@ -5021,13 +5916,20 @@ fn ibmvalid_p82ibm82v01xml() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p85ibm85v01xml() {
     /*
         Test ID:ibm-valid-P85-ibm85v01.xml
@@ -5044,11 +5946,31 @@ fn ibmvalid_p85ibm85v01xml() {
             .as_str(),
         None,
     );
+    let canonicalxml = RNode::new_document();
+    let canonicalparseresult = xml::parse(
+        canonicalxml,
+        fs::read_to_string("tests/conformance/xml/xmlconf/ibm/valid/P85/out/ibm85v01.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
 
     assert!(parseresult.is_ok());
+    assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
+    assert_eq!(
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
+    );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p86ibm86v01xml() {
     /*
         Test ID:ibm-valid-P86-ibm86v01.xml
@@ -5065,11 +5987,31 @@ fn ibmvalid_p86ibm86v01xml() {
             .as_str(),
         None,
     );
+    let canonicalxml = RNode::new_document();
+    let canonicalparseresult = xml::parse(
+        canonicalxml,
+        fs::read_to_string("tests/conformance/xml/xmlconf/ibm/valid/P86/out/ibm86v01.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
 
     assert!(parseresult.is_ok());
+    assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
+    assert_eq!(
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
+    );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p87ibm87v01xml() {
     /*
         Test ID:ibm-valid-P87-ibm87v01.xml
@@ -5086,11 +6028,31 @@ fn ibmvalid_p87ibm87v01xml() {
             .as_str(),
         None,
     );
+    let canonicalxml = RNode::new_document();
+    let canonicalparseresult = xml::parse(
+        canonicalxml,
+        fs::read_to_string("tests/conformance/xml/xmlconf/ibm/valid/P87/out/ibm87v01.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
 
     assert!(parseresult.is_ok());
+    assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
+    assert_eq!(
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
+    );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p88ibm88v01xml() {
     /*
         Test ID:ibm-valid-P88-ibm88v01.xml
@@ -5107,11 +6069,31 @@ fn ibmvalid_p88ibm88v01xml() {
             .as_str(),
         None,
     );
+    let canonicalxml = RNode::new_document();
+    let canonicalparseresult = xml::parse(
+        canonicalxml,
+        fs::read_to_string("tests/conformance/xml/xmlconf/ibm/valid/P88/out/ibm88v01.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
 
     assert!(parseresult.is_ok());
+    assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
+    assert_eq!(
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
+    );
 }
 
 #[test]
+#[ignore]
 fn ibmvalid_p89ibm89v01xml() {
     /*
         Test ID:ibm-valid-P89-ibm89v01.xml
@@ -5128,6 +6110,25 @@ fn ibmvalid_p89ibm89v01xml() {
             .as_str(),
         None,
     );
+    let canonicalxml = RNode::new_document();
+    let canonicalparseresult = xml::parse(
+        canonicalxml,
+        fs::read_to_string("tests/conformance/xml/xmlconf/ibm/valid/P89/out/ibm89v01.xml")
+            .unwrap()
+            .as_str(),
+        None,
+    );
 
     assert!(parseresult.is_ok());
+    assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
+    assert_eq!(
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
+    );
 }

--- a/tests/conformance/xml/oasis_invalid.rs
+++ b/tests/conformance/xml/oasis_invalid.rs
@@ -9,9 +9,9 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::{xml, ParserConfig};
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
-#[ignore]
 fn op01pass1() {
     /*
         Test ID:o-p01pass1
@@ -33,11 +33,14 @@ fn op01pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
-#[ignore]
 fn op01pass3() {
     /*
         Test ID:o-p01pass3
@@ -59,11 +62,14 @@ fn op01pass3() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
-#[ignore]
 fn op03pass1() {
     /*
         Test ID:o-p03pass1
@@ -85,7 +91,11 @@ fn op03pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
@@ -95,6 +105,9 @@ fn op04pass1() {
         Test URI:p04pass1.xml
         Spec Sections:2.3 [4]
         Description:names with all valid ASCII characters, and one from each other class in NameChar
+
+        Note: While this may be well formed in a not namespace-aware XML processor, we don't have any
+        interest in supporting those at this time.
     */
 
     let mut pc = ParserConfig::new();
@@ -120,6 +133,9 @@ fn op05pass1() {
         Test URI:p05pass1.xml
         Spec Sections:2.3 [5]
         Description:various valid Name constructions
+
+        Note: While this may be well formed in a not namespace-aware XML processor, we don't have any
+        interest in supporting those at this time.
     */
 
     let mut pc = ParserConfig::new();
@@ -149,6 +165,7 @@ fn op06fail1() {
     */
 
     let mut pc = ParserConfig::new();
+    pc.id_tracking = true;
     pc.ext_dtd_resolver = Some(dtdfileresolve());
     pc.docloc = Some("tests/conformance/xml/xmlconf/oasis/".to_string());
 
@@ -217,7 +234,6 @@ fn op08fail2() {
 }
 
 #[test]
-#[ignore]
 fn op10pass1() {
     /*
         Test ID:o-p10pass1
@@ -239,11 +255,14 @@ fn op10pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
-#[ignore]
 fn op14pass1() {
     /*
         Test ID:o-p14pass1
@@ -265,11 +284,14 @@ fn op14pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
-#[ignore]
 fn op15pass1() {
     /*
         Test ID:o-p15pass1
@@ -291,11 +313,14 @@ fn op15pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
-#[ignore]
 fn op16pass1() {
     /*
         Test ID:o-p16pass1
@@ -317,11 +342,14 @@ fn op16pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
-#[ignore]
 fn op16pass2() {
     /*
         Test ID:o-p16pass2
@@ -343,11 +371,14 @@ fn op16pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
 }
 
 #[test]
-#[ignore]
 fn op16pass3() {
     /*
         Test ID:o-p16pass3
@@ -369,11 +400,16 @@ fn op16pass3() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
+
 #[test]
-#[ignore]
 fn op18pass1() {
     /*
         Test ID:o-p18pass1
@@ -395,11 +431,15 @@ fn op18pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op22pass1() {
     /*
         Test ID:o-p22pass1
@@ -421,11 +461,15 @@ fn op22pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op22pass2() {
     /*
         Test ID:o-p22pass2
@@ -447,11 +491,15 @@ fn op22pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op22pass3() {
     /*
         Test ID:o-p22pass3
@@ -473,11 +521,15 @@ fn op22pass3() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op23pass1() {
     /*
         Test ID:o-p23pass1
@@ -499,11 +551,15 @@ fn op23pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op23pass2() {
     /*
         Test ID:o-p23pass2
@@ -525,11 +581,15 @@ fn op23pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op23pass3() {
     /*
         Test ID:o-p23pass3
@@ -551,11 +611,15 @@ fn op23pass3() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op23pass4() {
     /*
         Test ID:o-p23pass4
@@ -577,11 +641,15 @@ fn op23pass4() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op24pass1() {
     /*
         Test ID:o-p24pass1
@@ -603,11 +671,15 @@ fn op24pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op24pass2() {
     /*
         Test ID:o-p24pass2
@@ -629,11 +701,15 @@ fn op24pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op24pass3() {
     /*
         Test ID:o-p24pass3
@@ -655,11 +731,15 @@ fn op24pass3() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op24pass4() {
     /*
         Test ID:o-p24pass4
@@ -681,11 +761,15 @@ fn op24pass4() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op25pass1() {
     /*
         Test ID:o-p25pass1
@@ -707,11 +791,15 @@ fn op25pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op25pass2() {
     /*
         Test ID:o-p25pass2
@@ -733,11 +821,15 @@ fn op25pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op26pass1() {
     /*
         Test ID:o-p26pass1
@@ -759,11 +851,15 @@ fn op26pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op27pass1() {
     /*
         Test ID:o-p27pass1
@@ -785,11 +881,15 @@ fn op27pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op27pass2() {
     /*
         Test ID:o-p27pass2
@@ -811,11 +911,15 @@ fn op27pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op27pass3() {
     /*
         Test ID:o-p27pass3
@@ -837,11 +941,15 @@ fn op27pass3() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op27pass4() {
     /*
         Test ID:o-p27pass4
@@ -863,11 +971,15 @@ fn op27pass4() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op32pass1() {
     /*
         Test ID:o-p32pass1
@@ -889,11 +1001,15 @@ fn op32pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op32pass2() {
     /*
         Test ID:o-p32pass2
@@ -915,11 +1031,15 @@ fn op32pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op39pass1() {
     /*
         Test ID:o-p39pass1
@@ -941,11 +1061,15 @@ fn op39pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op39pass2() {
     /*
         Test ID:o-p39pass2
@@ -967,11 +1091,15 @@ fn op39pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op40pass1() {
     /*
         Test ID:o-p40pass1
@@ -993,11 +1121,15 @@ fn op40pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op40pass2() {
     /*
         Test ID:o-p40pass2
@@ -1019,11 +1151,15 @@ fn op40pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op40pass3() {
     /*
         Test ID:o-p40pass3
@@ -1045,11 +1181,15 @@ fn op40pass3() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op40pass4() {
     /*
         Test ID:o-p40pass4
@@ -1071,11 +1211,15 @@ fn op40pass4() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op41pass1() {
     /*
         Test ID:o-p41pass1
@@ -1097,11 +1241,15 @@ fn op41pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op41pass2() {
     /*
         Test ID:o-p41pass2
@@ -1123,11 +1271,15 @@ fn op41pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op42pass1() {
     /*
         Test ID:o-p42pass1
@@ -1149,11 +1301,15 @@ fn op42pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op42pass2() {
     /*
         Test ID:o-p42pass2
@@ -1175,11 +1331,15 @@ fn op42pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op44pass1() {
     /*
         Test ID:o-p44pass1
@@ -1201,11 +1361,15 @@ fn op44pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op44pass2() {
     /*
         Test ID:o-p44pass2
@@ -1227,11 +1391,15 @@ fn op44pass2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op44pass3() {
     /*
         Test ID:o-p44pass3
@@ -1253,11 +1421,15 @@ fn op44pass3() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op44pass4() {
     /*
         Test ID:o-p44pass4
@@ -1279,11 +1451,15 @@ fn op44pass4() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op44pass5() {
     /*
         Test ID:o-p44pass5
@@ -1305,11 +1481,15 @@ fn op44pass5() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn op66pass1() {
     /*
         Test ID:o-p66pass1
@@ -1331,10 +1511,16 @@ fn op66pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn op74pass1() {
     /*
         Test ID:o-p74pass1
@@ -1356,10 +1542,16 @@ fn op74pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn op75pass1() {
     /*
         Test ID:o-p75pass1
@@ -1381,11 +1573,15 @@ fn op75pass1() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn oe2() {
     /*
         Test ID:o-e2
@@ -1407,5 +1603,10 @@ fn oe2() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }

--- a/tests/conformance/xml/oasis_valid.rs
+++ b/tests/conformance/xml/oasis_valid.rs
@@ -8,6 +8,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::xml;
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 fn op01pass2() {
@@ -28,6 +29,11 @@ fn op01pass2() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -49,6 +55,11 @@ fn op06pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
 }
 
 #[test]
@@ -70,6 +81,10 @@ fn op07pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -91,6 +106,10 @@ fn op08pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -113,6 +132,10 @@ fn op09pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -134,6 +157,10 @@ fn op12pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -155,6 +182,10 @@ fn op22pass4() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -176,6 +207,10 @@ fn op22pass5() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -197,6 +232,10 @@ fn op22pass6() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -218,9 +257,14 @@ fn op28pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
+#[ignore]
 fn op28pass3() {
     /*
         Test ID:o-p28pass3
@@ -239,6 +283,10 @@ fn op28pass3() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -261,6 +309,10 @@ fn op28pass4() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -283,6 +335,10 @@ fn op28pass5() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -304,6 +360,10 @@ fn op29pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -326,6 +386,10 @@ fn op30pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -348,6 +412,10 @@ fn op30pass2() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -370,6 +438,10 @@ fn op31pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -392,9 +464,14 @@ fn op31pass2() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
+#[ignore]
 fn op43pass1() {
     /*
         Test ID:o-p43pass1
@@ -413,6 +490,10 @@ fn op43pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -434,6 +515,10 @@ fn op45pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -455,6 +540,10 @@ fn op46pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -476,6 +565,10 @@ fn op47pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -497,6 +590,10 @@ fn op48pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -518,6 +615,10 @@ fn op49pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -539,6 +640,10 @@ fn op50pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -560,9 +665,14 @@ fn op51pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
+#[ignore]
 fn op52pass1() {
     /*
         Test ID:o-p52pass1
@@ -581,6 +691,10 @@ fn op52pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -602,6 +716,10 @@ fn op53pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -623,6 +741,10 @@ fn op54pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -644,6 +766,10 @@ fn op55pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -665,6 +791,10 @@ fn op56pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -686,6 +816,10 @@ fn op57pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -707,6 +841,10 @@ fn op58pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -728,6 +866,10 @@ fn op59pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -749,6 +891,10 @@ fn op60pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -771,6 +917,10 @@ fn op61pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -793,6 +943,10 @@ fn op62pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -815,6 +969,10 @@ fn op63pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -837,6 +995,10 @@ fn op64pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -858,6 +1020,10 @@ fn op68pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -879,6 +1045,10 @@ fn op69pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -900,6 +1070,10 @@ fn op70pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -921,6 +1095,10 @@ fn op71pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -942,6 +1120,10 @@ fn op72pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -964,6 +1146,10 @@ fn op73pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }
 
 #[test]
@@ -986,4 +1172,8 @@ fn op76pass1() {
     );
 
     assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
 }

--- a/tests/conformance/xml/sun_invalid.rs
+++ b/tests/conformance/xml/sun_invalid.rs
@@ -9,6 +9,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::{xml, ParserConfig};
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 #[ignore]
@@ -29,10 +30,17 @@ fn invdtd01() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn invdtd02() {
     /*
         Test ID:inv-dtd02
@@ -50,11 +58,16 @@ fn invdtd02() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn invdtd03() {
     /*
         Test ID:inv-dtd03
@@ -72,11 +85,16 @@ fn invdtd03() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn el01() {
     /*
         Test ID:el01
@@ -94,11 +112,16 @@ fn el01() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn el02() {
     /*
         Test ID:el02
@@ -116,11 +139,16 @@ fn el02() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn el03() {
     /*
         Test ID:el03
@@ -138,7 +166,13 @@ fn el03() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -160,7 +194,13 @@ fn el04() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -182,11 +222,16 @@ fn el05() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn el06() {
     /*
         Test ID:el06
@@ -204,7 +249,13 @@ fn el06() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -226,7 +277,13 @@ fn id01() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -248,7 +305,13 @@ fn id02() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -270,11 +333,16 @@ fn id03() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn id04() {
     /*
         Test ID:id04
@@ -292,7 +360,13 @@ fn id04() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -314,7 +388,13 @@ fn id05() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -336,7 +416,13 @@ fn id06() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -358,10 +444,17 @@ fn id07() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn id08() {
     /*
         Test ID:id08
@@ -378,10 +471,17 @@ fn id08() {
             .as_str(),
         None,
     );
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn id09() {
     /*
         Test ID:id09
@@ -399,7 +499,13 @@ fn id09() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -425,7 +531,13 @@ fn invnotsa01() {
         Some(pc),
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -447,7 +559,13 @@ fn invnotsa02() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -469,7 +587,13 @@ fn invnotsa04() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -491,7 +615,13 @@ fn invnotsa05() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -513,7 +643,13 @@ fn invnotsa06() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -535,7 +671,13 @@ fn invnotsa07() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -557,7 +699,13 @@ fn invnotsa08() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -579,7 +727,13 @@ fn invnotsa09() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -601,7 +755,13 @@ fn invnotsa10() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -623,7 +783,13 @@ fn invnotsa11() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -645,7 +811,13 @@ fn invnotsa12() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -667,7 +839,13 @@ fn invnotsa13() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -689,7 +867,13 @@ fn invnotsa14() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -711,7 +895,13 @@ fn optional01() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -733,7 +923,13 @@ fn optional02() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -755,7 +951,13 @@ fn optional03() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -777,7 +979,13 @@ fn optional04() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -799,7 +1007,13 @@ fn optional05() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -821,7 +1035,13 @@ fn optional06() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -843,7 +1063,13 @@ fn optional07() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -865,7 +1091,13 @@ fn optional08() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -887,7 +1119,13 @@ fn optional09() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -909,7 +1147,13 @@ fn optional10() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -931,7 +1175,13 @@ fn optional11() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -953,7 +1203,13 @@ fn optional12() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -975,7 +1231,13 @@ fn optional13() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -997,7 +1259,13 @@ fn optional14() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1019,7 +1287,13 @@ fn optional20() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1041,7 +1315,13 @@ fn optional21() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1063,7 +1343,13 @@ fn optional22() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1085,7 +1371,13 @@ fn optional23() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1107,7 +1399,13 @@ fn optional24() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1129,11 +1427,16 @@ fn optional25() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn invrequired00() {
     /*
         Test ID:inv-required00
@@ -1151,10 +1454,17 @@ fn invrequired00() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn invrequired01() {
     /*
         Test ID:inv-required01
@@ -1172,11 +1482,16 @@ fn invrequired01() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn invrequired02() {
     /*
         Test ID:inv-required02
@@ -1194,7 +1509,13 @@ fn invrequired02() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1216,7 +1537,13 @@ fn root() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1238,10 +1565,17 @@ fn attr01() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn attr02() {
     /*
         Test ID:attr02
@@ -1259,7 +1593,13 @@ fn attr02() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1281,7 +1621,13 @@ fn attr03() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1303,7 +1649,13 @@ fn attr04() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1325,7 +1677,13 @@ fn attr05() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1347,11 +1705,16 @@ fn attr06() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
-#[ignore]
 fn attr07() {
     /*
         Test ID:attr07
@@ -1369,7 +1732,13 @@ fn attr07() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1391,7 +1760,13 @@ fn attr08() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1413,7 +1788,13 @@ fn attr09() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1435,10 +1816,17 @@ fn attr10() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn attr11() {
     /*
         Test ID:attr11
@@ -1456,10 +1844,17 @@ fn attr11() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
+#[ignore]
 fn attr12() {
     /*
         Test ID:attr12
@@ -1477,7 +1872,13 @@ fn attr12() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1499,7 +1900,13 @@ fn attr13() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1521,7 +1928,13 @@ fn attr14() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1543,7 +1956,13 @@ fn attr15() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1565,7 +1984,13 @@ fn attr16() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1587,7 +2012,13 @@ fn utf16b() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1609,7 +2040,13 @@ fn utf16l() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }
 
 #[test]
@@ -1631,5 +2068,11 @@ fn empty() {
         None,
     );
 
-    assert!(parseresult.is_err());
+    assert!(parseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_err());
+
 }

--- a/tests/conformance/xml/sun_valid.rs
+++ b/tests/conformance/xml/sun_valid.rs
@@ -3,6 +3,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::{xml, ParserConfig};
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 #[ignore]
@@ -33,8 +34,14 @@ fn pe01() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -67,8 +74,14 @@ fn dtd00() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -101,8 +114,14 @@ fn dtd01() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -170,8 +189,14 @@ fn ext01() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -205,8 +230,14 @@ fn ext02() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -244,8 +275,14 @@ fn notsa01() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -279,8 +316,14 @@ fn notsa02() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -314,8 +357,14 @@ fn notsa03() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -349,8 +398,14 @@ fn notsa04() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -384,8 +439,14 @@ fn notation01() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -419,8 +480,14 @@ fn optional() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -453,8 +520,14 @@ fn required00() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -487,8 +560,14 @@ fn sa01() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -522,8 +601,14 @@ fn sa02() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -557,8 +642,14 @@ fn sa03() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -592,13 +683,20 @@ fn sa04() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn sa05() {
     /*
         Test ID:sa05
@@ -630,8 +728,14 @@ fn sa05() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -665,8 +769,14 @@ fn vsgml01() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -699,8 +809,14 @@ fn vlang01() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -733,8 +849,14 @@ fn vlang02() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -767,8 +889,14 @@ fn vlang03() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -801,8 +929,14 @@ fn vlang04() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -835,8 +969,14 @@ fn vlang05() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -869,8 +1009,14 @@ fn vlang06() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -904,8 +1050,14 @@ fn vpe00() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -973,8 +1125,14 @@ fn vpe02() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }

--- a/tests/conformance/xml/xmltest_valid_ext_sa.rs
+++ b/tests/conformance/xml/xmltest_valid_ext_sa.rs
@@ -11,6 +11,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::{xml, ParserConfig};
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 fn validextsa001() {
@@ -44,8 +45,14 @@ fn validextsa001() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -82,8 +89,14 @@ fn validextsa002() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -120,8 +133,14 @@ fn validextsa003() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -158,8 +177,14 @@ fn validextsa004() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -196,13 +221,20 @@ fn validextsa005() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validextsa006() {
     /*
         Test ID:valid-ext-sa-006
@@ -234,8 +266,14 @@ fn validextsa006() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -273,8 +311,14 @@ fn validextsa007() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -312,8 +356,14 @@ fn validextsa008() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -350,8 +400,14 @@ fn validextsa009() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -388,8 +444,14 @@ fn validextsa011() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -426,8 +488,14 @@ fn validextsa012() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -465,8 +533,14 @@ fn validextsa013() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -504,8 +578,14 @@ fn validextsa014() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }

--- a/tests/conformance/xml/xmltest_valid_not_sa.rs
+++ b/tests/conformance/xml/xmltest_valid_not_sa.rs
@@ -12,9 +12,9 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::{xml, ParserConfig};
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
-#[ignore]
 fn validnotsa001() {
     /*
         Test ID:valid-not-sa-001
@@ -46,14 +46,19 @@ fn validnotsa001() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
-#[ignore]
 fn validnotsa002() {
     /*
         Test ID:valid-not-sa-002
@@ -85,8 +90,14 @@ fn validnotsa002() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -124,8 +135,14 @@ fn validnotsa003() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -163,8 +180,14 @@ fn validnotsa004() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -202,8 +225,14 @@ fn validnotsa005() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -241,8 +270,14 @@ fn validnotsa006() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -280,8 +315,14 @@ fn validnotsa007() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -319,8 +360,14 @@ fn validnotsa008() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -358,8 +405,14 @@ fn validnotsa009() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -397,8 +450,14 @@ fn validnotsa010() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -436,8 +495,14 @@ fn validnotsa011() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -475,8 +540,14 @@ fn validnotsa012() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -514,8 +585,14 @@ fn validnotsa013() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -553,8 +630,14 @@ fn validnotsa014() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -592,8 +675,14 @@ fn validnotsa015() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -631,8 +720,14 @@ fn validnotsa016() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -670,8 +765,14 @@ fn validnotsa017() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -709,8 +810,14 @@ fn validnotsa018() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -748,8 +855,14 @@ fn validnotsa019() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -787,8 +900,14 @@ fn validnotsa020() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -826,8 +945,14 @@ fn validnotsa021() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -865,8 +990,14 @@ fn validnotsa023() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -904,8 +1035,14 @@ fn validnotsa024() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -943,8 +1080,14 @@ fn validnotsa025() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -982,8 +1125,14 @@ fn validnotsa026() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1021,8 +1170,14 @@ fn validnotsa027() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1060,8 +1215,14 @@ fn validnotsa028() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1099,8 +1260,14 @@ fn validnotsa029() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1138,8 +1305,14 @@ fn validnotsa030() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1177,8 +1350,14 @@ fn validnotsa031() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }

--- a/tests/conformance/xml/xmltest_valid_sa.rs
+++ b/tests/conformance/xml/xmltest_valid_sa.rs
@@ -13,6 +13,7 @@ use std::fs;
 use xrust::item::Node;
 use xrust::parser::{xml, ParserConfig};
 use xrust::trees::smite::RNode;
+use xrust::validators::Schema;
 
 #[test]
 fn validsa001() {
@@ -42,10 +43,17 @@ fn validsa001() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
+
 }
 
 #[test]
@@ -76,8 +84,14 @@ fn validsa002() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -110,8 +124,14 @@ fn validsa003() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -144,8 +164,14 @@ fn validsa004() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -178,8 +204,14 @@ fn validsa005() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -212,8 +244,14 @@ fn validsa006() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -246,13 +284,20 @@ fn validsa007() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validsa008() {
     /*
         Test ID:valid-sa-008
@@ -280,9 +325,15 @@ fn validsa008() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
@@ -314,8 +365,14 @@ fn validsa009() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -348,8 +405,14 @@ fn validsa010() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -382,8 +445,14 @@ fn validsa011() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -450,8 +519,14 @@ fn validsa013() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -484,8 +559,14 @@ fn validsa014() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -518,8 +599,14 @@ fn validsa015() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -552,8 +639,14 @@ fn validsa016() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -586,13 +679,20 @@ fn validsa017() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validsa018() {
     /*
         Test ID:valid-sa-018
@@ -620,13 +720,20 @@ fn validsa018() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validsa019() {
     /*
         Test ID:valid-sa-019
@@ -654,13 +761,20 @@ fn validsa019() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validsa020() {
     /*
         Test ID:valid-sa-020
@@ -688,9 +802,15 @@ fn validsa020() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
@@ -722,8 +842,14 @@ fn validsa021() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -756,8 +882,14 @@ fn validsa022() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -790,8 +922,14 @@ fn validsa023() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -824,8 +962,14 @@ fn validsa024() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -858,8 +1002,14 @@ fn validsa025() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -892,8 +1042,14 @@ fn validsa026() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -926,8 +1082,14 @@ fn validsa027() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -960,8 +1122,14 @@ fn validsa028() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -994,8 +1162,14 @@ fn validsa029() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1028,8 +1202,14 @@ fn validsa030() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1062,8 +1242,14 @@ fn validsa031() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1096,8 +1282,14 @@ fn validsa032() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1161,8 +1353,14 @@ fn validsa034() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1195,8 +1393,14 @@ fn validsa035() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1229,13 +1433,20 @@ fn validsa036() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validsa017a() {
     /*
         Test ID:valid-sa-017a
@@ -1263,9 +1474,15 @@ fn validsa017a() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
@@ -1297,8 +1514,14 @@ fn validsa037() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1331,8 +1554,14 @@ fn validsa038() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1365,8 +1594,14 @@ fn validsa039() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1399,8 +1634,14 @@ fn validsa040() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1433,8 +1674,14 @@ fn validsa041() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1467,8 +1714,14 @@ fn validsa042() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1501,8 +1754,14 @@ fn validsa043() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1535,8 +1794,14 @@ fn validsa044() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1569,8 +1834,14 @@ fn validsa045() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1603,8 +1874,14 @@ fn validsa046() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1637,8 +1914,14 @@ fn validsa047() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1671,8 +1954,14 @@ fn validsa048() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1704,8 +1993,14 @@ fn validsa049() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1737,8 +2032,14 @@ fn validsa050() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1770,8 +2071,14 @@ fn validsa051() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1804,8 +2111,14 @@ fn validsa052() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1838,8 +2151,14 @@ fn validsa053() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1872,8 +2191,14 @@ fn validsa054() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1906,8 +2231,14 @@ fn validsa055() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1940,8 +2271,14 @@ fn validsa056() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -1974,8 +2311,14 @@ fn validsa057() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2008,8 +2351,14 @@ fn validsa058() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2042,8 +2391,14 @@ fn validsa059() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2076,8 +2431,14 @@ fn validsa060() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2110,8 +2471,14 @@ fn validsa061() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2144,8 +2511,14 @@ fn validsa062() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2178,8 +2551,14 @@ fn validsa063() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2212,8 +2591,14 @@ fn validsa064() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2246,8 +2631,14 @@ fn validsa065() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2280,13 +2671,20 @@ fn validsa066() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validsa067() {
     /*
         Test ID:valid-sa-067
@@ -2314,13 +2712,20 @@ fn validsa067() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validsa068() {
     /*
         Test ID:valid-sa-068
@@ -2348,9 +2753,15 @@ fn validsa068() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
@@ -2382,13 +2793,20 @@ fn validsa069() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validsa070() {
     /*
         Test ID:valid-sa-070
@@ -2416,8 +2834,14 @@ fn validsa070() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2450,8 +2874,14 @@ fn validsa071() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2484,8 +2914,14 @@ fn validsa072() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2518,8 +2954,14 @@ fn validsa073() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2552,8 +2994,14 @@ fn validsa074() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2586,8 +3034,14 @@ fn validsa075() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2620,8 +3074,14 @@ fn validsa076() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2654,8 +3114,14 @@ fn validsa077() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2688,8 +3154,14 @@ fn validsa078() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2722,8 +3194,14 @@ fn validsa079() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2756,8 +3234,14 @@ fn validsa080() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2790,8 +3274,14 @@ fn validsa081() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2825,8 +3315,14 @@ fn validsa082() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2860,8 +3356,14 @@ fn validsa083() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2894,8 +3396,14 @@ fn validsa084() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2928,8 +3436,14 @@ fn validsa085() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2962,8 +3476,14 @@ fn validsa086() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -2996,13 +3516,20 @@ fn validsa087() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validsa088() {
     /*
         Test ID:valid-sa-088
@@ -3030,9 +3557,15 @@ fn validsa088() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
@@ -3064,8 +3597,14 @@ fn validsa089() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3098,8 +3637,14 @@ fn validsa090() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3133,8 +3678,14 @@ fn validsa091() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3167,8 +3718,14 @@ fn validsa092() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3201,8 +3758,14 @@ fn validsa093() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3235,8 +3798,14 @@ fn validsa094() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3270,8 +3839,14 @@ fn validsa095() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3304,8 +3879,14 @@ fn validsa096() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3343,8 +3924,14 @@ fn validsa097() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3378,8 +3965,14 @@ fn validsa098() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3412,8 +4005,14 @@ fn validsa099() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3451,8 +4050,14 @@ fn validsa100() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3485,8 +4090,14 @@ fn validsa101() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3519,13 +4130,20 @@ fn validsa102() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validsa103() {
     /*
         Test ID:valid-sa-103
@@ -3553,9 +4171,15 @@ fn validsa103() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
@@ -3587,8 +4211,14 @@ fn validsa104() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3621,8 +4251,14 @@ fn validsa105() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3655,8 +4291,14 @@ fn validsa106() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3689,8 +4331,14 @@ fn validsa107() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3723,8 +4371,14 @@ fn validsa108() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3757,8 +4411,14 @@ fn validsa109() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3792,8 +4452,14 @@ fn validsa110() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3826,8 +4492,14 @@ fn validsa111() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3860,8 +4532,14 @@ fn validsa112() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3894,13 +4572,20 @@ fn validsa113() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
 
 #[test]
+#[ignore]
 fn validsa114() {
     /*
         Test ID:valid-sa-114
@@ -3928,9 +4613,15 @@ fn validsa114() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
-        canonicalparseresult.unwrap().get_canonical().unwrap()
+        doc.get_canonical().unwrap(),
+        canonicalparseresult.unwrap()
     );
 }
 
@@ -3962,8 +4653,14 @@ fn validsa115() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -3996,8 +4693,14 @@ fn validsa116() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4030,8 +4733,14 @@ fn validsa117() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4064,8 +4773,14 @@ fn validsa118() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }
@@ -4098,8 +4813,14 @@ fn validsa119() {
 
     assert!(parseresult.is_ok());
     assert!(canonicalparseresult.is_ok());
+
+    let doc = parseresult.unwrap();
+
+    let validation = doc.validate(Schema::DTD);
+    assert!(validation.is_ok());
+
     assert_eq!(
-        parseresult.unwrap().get_canonical().unwrap(),
+        doc.get_canonical().unwrap(),
         canonicalparseresult.unwrap()
     );
 }


### PR DESCRIPTION
Hi Steve,

A first draft of support for DTD validation, based loosely on the algorithm described for RELAXNG validation [here.](https://relaxng.org/jclark/derivative.html)

Some notes: 

* Its in a very rough condition, and could definitely be sped up, but I wanted to show the POC.
* It is currently tripping up on parameter entities within the DTD, I hope to look at that over the christmas period
* It doesn't validate NMTOKENS and the like at the moment, everything is just text.
* Certain test (anything with lots of ANY element declarations) trap it in an infinite loop.
* A huge number of tests have been changed to validate as well as check a document is well formed.
* Currently does not support namespace declarations, any <!ATTLIST foo xmlns CDATA #IMPLIED> will fail. I will likely need some mechanism internal to xrust that pulls namespaces declared on that element.

I've made a few adjustments to Smite that aren't in the XDM standard. The document node now has an optional field where I store DTDs, and in addition to getters/setters for that field there is a validate method that accepts a Schema Enum as a parameter. Currently, that enum only has "DTD" as an option, but I expect that it'll eventually have RelaxNG(SchemaFile), Schematron(SchemaFile) and so on.

We could look at adjusting so that we don't have any of this on the node, that we have a function validate(doc, Schema::DTD(DTD)) or something like that, but we would need to adjust the output from the parser to also return the DTD information as a separate value to the document.

Let me know what changes you'd like made to this.